### PR TITLE
Exclude PYTHONPATH when invoking install, as it won't be present when invoking tests.

### DIFF
--- a/tox/venv.py
+++ b/tox/venv.py
@@ -264,7 +264,7 @@ class VirtualEnv(object):
             argv[i:i + 1] = list(options)
 
         for x in ('PIP_RESPECT_VIRTUALENV', 'PIP_REQUIRE_VIRTUALENV',
-                  '__PYVENV_LAUNCHER__'):
+                  '__PYVENV_LAUNCHER__', 'PYTHONPATH'):
             os.environ.pop(x, None)
 
         old_stdout = sys.stdout


### PR DESCRIPTION
Fixes #330.