### PR TITLE
Replace references to bitbucket with github

### DIFF
--- a/doc/_templates/localtoc.html
+++ b/doc/_templates/localtoc.html
@@ -26,7 +26,7 @@
 </td></tr><tr><td>
         <a href="{{ pathto('config') }}">config</a>
 </td><td>
-        <a href="https://bitbucket.org/hpk42/tox/issues?status=new&status=open">issues[bb]</a>
+        <a href="https://github.com/tox-dev/tox/issues">issues[bb]</a>
 </td></tr><tr><td>
         <a href="{{ pathto('support') }}">support</a>
 </td><td>

--- a/doc/_templates/localtoc.html
+++ b/doc/_templates/localtoc.html
@@ -26,7 +26,7 @@
 </td></tr><tr><td>
         <a href="{{ pathto('config') }}">config</a>
 </td><td>
-        <a href="https://github.com/tox-dev/tox/issues">issues[bb]</a>
+        <a href="https://github.com/tox-dev/tox/issues">issues[gh]</a>
 </td></tr><tr><td>
         <a href="{{ pathto('support') }}">support</a>
 </td><td>

--- a/doc/config-v2.txt
+++ b/doc/config-v2.txt
@@ -6,9 +6,9 @@ V2: new tox multi-dimensional, platform-specific configuration
    This is a draft document sketching a to-be-done implementation.
    It does not fully specify each change yet but should give a good
    idea of where things are heading.  For feedback, mail the 
-   testing-in-python mailing list or open a pull request on 
-   https://bitbucket.org/hpk42/tox/src/84d8cf3c2a95fefd874f22c8b2d257e94365472f/doc/config-v2.txt?at=default
- 
+   testing-in-python mailing list or open a pull request on
+   https://github.com/tox-dev/tox/blob/master/doc/config-v2.txt
+
 **Abstract**: Adding multi-dimensional configuration, platform-specification
 and multiple installers to tox.ini.
  

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -12,7 +12,7 @@ Install info in a nutshell
 
 **License**: MIT license
 
-**hg repository**: https://bitbucket.org/hpk42/tox
+**git repository**: https://github.com/tox-dev/tox
 
 Installation with pip/easy_install
 --------------------------------------
@@ -29,7 +29,7 @@ Install from Checkout
 
 Consult the Bitbucket page to get a checkout of the mercurial repository:
 
-    https://bitbucket.org/hpk42/tox
+    https://github.com/tox-dev/tox
 
 and then install in your environment with something like::
 

--- a/doc/support.txt
+++ b/doc/support.txt
@@ -28,9 +28,9 @@ experienced well-known Python developers.
 .. _`Testing In Python (TIP) mailing list`: http://lists.idyll.org/listinfo/testing-in-python
 .. _`holger's twitter presence`: http://twitter.com/hpk42
 .. _`merlinux.eu`: http://merlinux.eu
-.. _`report on the issue tracker`: https://bitbucket.org/hpk42/tox/issues?status=new&status=open
+.. _`report on the issue tracker`: https://github.com/tox-dev/tox/issues
 .. _`tetamap blog`: http://holgerkrekel.net
 .. _`tox-dev`: http://codespeak.net/mailman/listinfo/tox-dev
 .. _`tox-commit`: http://codespeak.net/mailman/listinfo/tox-commit
-.. _`clone the mercurial repository`: https://bitbucket.org/hpk42/tox
+.. _`clone the mercurial repository`: https://github.com/tox-dev/tox
 


### PR DESCRIPTION
Since the code has now moved to github, this commit replaces links
in the documentation with references to the new home