### PR TITLE
Removed PYTHONDONTWRITEBYTECODE from being unset from venv

### DIFF
--- a/tox/venv.py
+++ b/tox/venv.py
@@ -364,7 +364,7 @@ class VirtualEnv(object):
 
     def _pcall(self, args, cwd, venv=True, testcommand=False,
                action=None, redirect=True, ignore_ret=False):
-        for name in ("VIRTUALENV_PYTHON", "PYTHONDONTWRITEBYTECODE"):
+        for name in ("VIRTUALENV_PYTHON",):
             os.environ.pop(name, None)
 
         cwd.ensure(dir=1)


### PR DESCRIPTION
Hi Guys.

I was wondering if the unset of PYTHONDONTWRITEBYTECODE it's still needed.

The insertion was in 700c8777c651809f72bd8fd2fbc495097c98c676, more that three years ago, because of some setuptools incompatibility.

I'm available for any discussion.

Best regards.