### PR TITLE
Fix regression in env suupport in dependency list

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1177,13 +1177,14 @@ class TestConfigTestEnv:
             deps=
                 {{[testenv]deps}}
                 fun
+                frob{{env:ENV_VAR:>1.0,<2.0}}
         """.format(
             envlist=','.join(envlist),
             deps='\n' + '\n'.join([' ' * 17 + d for d in deps])
         )
         conf = newconfig([], inisource).envconfigs['py27']
         packages = [dep.name for dep in conf.deps]
-        assert packages == list(deps) + ['fun']
+        assert packages == list(deps) + ['fun', 'frob>1.0,<2.0']
 
     def test_take_dependencies_from_other_section(self, newconfig):
         inisource = """

--- a/tox/config.py
+++ b/tox/config.py
@@ -1023,7 +1023,8 @@ class Replacer:
         r'''
         (?<!\\)[{]
         (?:(?P<sub_type>[^[:{}]+):)?    # optional sub_type for special rules
-        (?P<substitution_value>[^,{}]*)  # substitution key
+        (?P<substitution_value>(?:\[[^,{}]*\])?[^:,{}]*)  # substitution key
+        (?::(?P<default_value>[^{}]*))?   # default value
         [}]
         ''', re.VERBOSE)
 
@@ -1064,18 +1065,12 @@ class Replacer:
         return self._replace_substitution(match)
 
     def _replace_env(self, match):
-        match_value = match.group('substitution_value')
-        if not match_value:
+        envkey = match.group('substitution_value')
+        if not envkey:
             raise tox.exception.ConfigError(
                 'env: requires an environment variable name')
 
-        default = None
-        envkey_split = match_value.split(':', 1)
-
-        if len(envkey_split) is 2:
-            envkey, default = envkey_split
-        else:
-            envkey = match_value
+        default = match.group('default_value')
 
         envvalue = self.reader.get_environ_value(envkey)
         if envvalue is None:


### PR DESCRIPTION
The fix for allowing parametrized dependencies in
174bf2da31a33deeb1985f3049b6884c21e3a9b4 broke the use case of having a
dependency whose version can be specified in an environment variable or
defaulted to a range, e.g.,

    deps =
       mydep{env:MYDEP_VERSION:>1.0,<2.0}

To fix this, we modify the regular expression to handle some
substitution value cases specifically while also handling the default
value of a env substitution explicitly.

Closes #380