### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+- 3.6-dev
+- nightly
 - pypy
 
 matrix:
+  fast_finish: true
   allow_failures:
+  - python: 3.6-dev
+  - python: nightly
   - python: pypy
 cache: python
 install: pip install tox

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1468,7 +1468,7 @@ class TestGlobalOptions:
         assert str(env.basepython) == sys.executable
 
     def test_default_environments(self, tmpdir, newconfig, monkeypatch):
-        envs = "py26,py27,py32,py33,py34,py35,py36,jython,pypy,pypy3"
+        envs = "py26,py27,py32,py33,py34,py35,py36,py37,jython,pypy,pypy3"
         inisource = """
             [tox]
             envlist = %s

--- a/tox/config.py
+++ b/tox/config.py
@@ -22,7 +22,7 @@ iswin32 = sys.platform == "win32"
 
 default_factors = {'jython': 'jython', 'pypy': 'pypy', 'pypy3': 'pypy3',
                    'py': sys.executable}
-for version in '26,27,32,33,34,35,36'.split(','):
+for version in '26,27,32,33,34,35,36,37'.split(','):
     default_factors['py' + version] = 'python%s.%s' % tuple(version)
 
 hookimpl = pluggy.HookimplMarker("tox")


### PR DESCRIPTION
This allows testing on Travis CI 'nightly'.
Also add Travis CI testing on '3.6-dev',
and enable Travis CI fast finishing as
problems with 3.6-dev are likely to also
occur with nightly (3.7-dev)