### PR TITLE
WIP Add --show-envdir argument

### DIFF
--- a/tox/config.py
+++ b/tox/config.py
@@ -320,6 +320,8 @@ def tox_addoption(parser):
                         help="increase verbosity of reporting output.")
     parser.add_argument("--showconfig", action="store_true",
                         help="show configuration information for all environments. ")
+    parser.add_argument("--show-envdir", action="store_true", dest="showenvdir",
+                        help="show virtualenv directory for specified environments")
     parser.add_argument("-l", "--listenvs", action="store_true",
                         dest="listenvs", help="show list of test environments")
     parser.add_argument("-c", action="store", default="tox.ini",

--- a/tox/session.py
+++ b/tox/session.py
@@ -385,6 +385,8 @@ class Session:
             self.showconfig()
         elif self.config.option.listenvs:
             self.showenvs()
+        elif self.config.option.showenvdir:
+            self.showenvdirs()
         else:
             return self.subcommand_test()
 
@@ -624,6 +626,20 @@ class Session:
             for attr in self.config._parser._testenv_attr:
                 self.report.line("  %-15s = %s"
                                  % (attr.name, getattr(envconfig, attr.name)))
+
+    def showenvdirs(self):
+        should_use_evalable_output = len(self.config.envconfigs.keys()) == 1
+        if should_use_evalable_output:
+            env = list(self.config.envconfigs.values())[0]
+            envname = env.name
+            envdir = env.envdir
+            self.report.line("# [testenv:%s]" % envname)
+            self.report.line("# To activate this virtualenv, run: eval `tox -e {} --show-envdir`".format(envname))
+            self.report.line("source {envdir}/bin/activate".format(envdir=envdir))
+        else:
+            for envconfig in self.config.envconfigs.values():
+                self.report.line("[testenv:%s]" % envconfig.envname, bold=True)
+                self.report.line("  envdir = {}".format(envconfig.envdir))
 
     def showenvs(self):
         for env in self.config.envlist:


### PR DESCRIPTION
This is incomplete. Currently `--show-envdir` works for all environments:

```
$ python -m tox --show-envdir
[testenv:py27]
  envdir = /Users/daenyth/Curata/tox/.tox/py27
[testenv:docs]
  envdir = /Users/daenyth/Curata/tox/.tox/docs
[testenv:py26-bare]
  envdir = /Users/daenyth/Curata/tox/.tox/py26-bare
[testenv:dev]
  envdir = /Users/daenyth/Curata/tox/.tox/dev
[testenv:py33]
  envdir = /Users/daenyth/Curata/tox/.tox/py33
[testenv:py34]
  envdir = /Users/daenyth/Curata/tox/.tox/py34
[testenv:flakes]
  envdir = /Users/daenyth/Curata/tox/.tox/flakes
[testenv:X]
  envdir = /Users/daenyth/Curata/tox/.tox/X
[testenv:py26]
  envdir = /Users/daenyth/Curata/tox/.tox/py26
[testenv:py35]
  envdir = /Users/daenyth/Curata/tox/.tox/py35
[testenv:pypy]
  envdir = /Users/daenyth/Curata/tox/.tox/pypy
```

But it doesn't work with `-e`; it just prints all environments again. I know my check is wrong, just not sure how to fix it yet.

I also could use some guidance on how to structure a test case for this, it's not clear to me how you'd like to have it set up. Probably we want to have cases for all envs, specific single env, and specific multiple envs.

We should probably also make sure that the single-env mode ensures that a current version of the env is built, so that it doesn't fail with a "no such file" error

Closes #379