### PR TITLE
allow -h and --help-ini to work without a tox.ini file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,8 @@ unreleased
   updating the list of default envs in the tox basic example.
   Thanks Tobias McNulty.
 
+- make "-h" and "--help-ini" options work even if there is no tox.ini
+
 
 2.4.1
 -----

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -199,6 +199,34 @@ def test_minversion(cmd, initproj):
     assert result.ret
 
 
+def test_notoxini_help_still_works(initproj, cmd):
+    initproj("example123-0.5", filedefs={
+        'tests': {'test_hello.py': "def test_hello(): pass"},
+    })
+    result = cmd.run("tox", "-h")
+    result.stderr.fnmatch_lines([
+        "*ERROR*tox.ini*"
+    ])
+    result.stdout.fnmatch_lines([
+        "*--help*"
+    ])
+    assert not result.ret
+
+
+def test_notoxini_help_ini_still_works(initproj, cmd):
+    initproj("example123-0.5", filedefs={
+        'tests': {'test_hello.py': "def test_hello(): pass"},
+    })
+    result = cmd.run("tox", "--help-ini")
+    result.stderr.fnmatch_lines([
+        "*ERROR*tox.ini*"
+    ])
+    result.stdout.fnmatch_lines([
+        "*setenv*"
+    ])
+    assert not result.ret
+
+
 def test_envdir_equals_toxini_errors_out(cmd, initproj):
     initproj("interp123-0.7", filedefs={
         'tox.ini': '''

--- a/tox/config.py
+++ b/tox/config.py
@@ -229,7 +229,11 @@ def parseconfig(args=None, plugins=()):
         else:
             inipath = py.path.local().join('setup.cfg')
             if not inipath.check():
-                feedback("toxini file %r not found" % (basename), sysexit=True)
+                helpoptions = option.help or option.helpini
+                feedback("toxini file %r not found" % (basename),
+                         sysexit=not helpoptions)
+                if helpoptions:
+                    return config
 
     try:
         parseini(config, inipath)


### PR DESCRIPTION
previously you could not get help until you had a tox.ini.  