### PR TITLE
Add {:} -> os.pathsep substitute

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ unreleased
 
 - make "-h" and "--help-ini" options work even if there is no tox.ini
 
+- add {:} substitution, which is replaced with os-specific path separator
 
 2.4.1
 -----

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,3 +33,4 @@ Eugene Yunak
 Mark Hirota
 Itxaka Serrano
 Alex Grönholm
+Lukasz Rogalski

--- a/doc/config.txt
+++ b/doc/config.txt
@@ -362,6 +362,10 @@ Globally available substitutions
     (DEPRECATED) the directory where sdist-packages will be copied to so that
     they may be accessed by other processes or tox runs.
 
+``{:}``
+    OS-specific path separator (``:`` os *nix family, ``;`` on Windows). May be used in `setenv`,
+    when target variable is path variable (e.g. PATH or PYTHONPATH).
+
 substitutions for virtualenv-related sections
 +++++++++++++++++++++++++++++++++++++++++++++
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1887,25 +1887,18 @@ class TestIndexServer:
         assert config.indexserver['default'].url == expected
         assert config.indexserver['local1'].url == config.indexserver['default'].url
 
-    def test_replace_pathsep_unix(self, monkeypatch, newconfig):
-        monkeypatch.setattr('os.pathsep', ':')
-        config = newconfig("""
-        [testenv]
-        setenv =
-            PATH = dira{:}dirb{:}dirc
-        """)
-        envconfig = config.envconfigs["python"]
-        assert envconfig.setenv["PATH"] == "dira:dirb:dirc"
 
-    def test_replace_pathsep_win(self, monkeypatch, newconfig):
-        monkeypatch.setattr('os.pathsep', ';')
+class TestConfigConstSubstitutions:
+    @pytest.mark.parametrize('pathsep', [':', ';'])
+    def test_replace_pathsep_unix(self, monkeypatch, newconfig, pathsep):
+        monkeypatch.setattr('os.pathsep', pathsep)
         config = newconfig("""
         [testenv]
         setenv =
             PATH = dira{:}dirb{:}dirc
         """)
         envconfig = config.envconfigs["python"]
-        assert envconfig.setenv["PATH"] == "dira;dirb;dirc"
+        assert envconfig.setenv["PATH"] == pathsep.join(["dira", "dirb", "dirc"])
 
     def test_pathsep_regex(self):
         """Sanity check for regex behavior for empty colon."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1887,6 +1887,35 @@ class TestIndexServer:
         assert config.indexserver['default'].url == expected
         assert config.indexserver['local1'].url == config.indexserver['default'].url
 
+    def test_replace_pathsep_unix(self, monkeypatch, newconfig):
+        monkeypatch.setattr('os.pathsep', ':')
+        config = newconfig("""
+        [testenv]
+        setenv =
+            PATH = dira{:}dirb{:}dirc
+        """)
+        envconfig = config.envconfigs["python"]
+        assert envconfig.setenv["PATH"] == "dira:dirb:dirc"
+
+    def test_replace_pathsep_win(self, monkeypatch, newconfig):
+        monkeypatch.setattr('os.pathsep', ';')
+        config = newconfig("""
+        [testenv]
+        setenv =
+            PATH = dira{:}dirb{:}dirc
+        """)
+        envconfig = config.envconfigs["python"]
+        assert envconfig.setenv["PATH"] == "dira;dirb;dirc"
+
+    def test_pathsep_regex(self):
+        """Sanity check for regex behavior for empty colon."""
+        regex = tox.config.Replacer.RE_ITEM_REF
+        match = next(regex.finditer("{:}"))
+        mdict = match.groupdict()
+        assert mdict['sub_type'] is None
+        assert mdict['substitution_value'] == ""
+        assert mdict['default_value'] == ""
+
 
 class TestParseEnv:
 

--- a/tox/config.py
+++ b/tox/config.py
@@ -1051,6 +1051,10 @@ class Replacer:
             start, end = match.span()
             return match.string[start:end]
 
+        # special case: all empty values means ":" which is os.pathsep
+        if not any(g.values()):
+            return os.pathsep
+
         # special case: opts and packages. Leave {opts} and
         # {packages} intact, they are replaced manually in
         # _venv.VirtualEnv.run_install_command.


### PR DESCRIPTION
Alternative approach to PR #397