### PR TITLE
Create an empty envtmpdir before running the commands, instead of just clearing it if it already existed.

### DIFF
--- a/tox/venv.py
+++ b/tox/venv.py
@@ -327,6 +327,7 @@ class VirtualEnv(object):
         with action:
             self.status = 0
             self.session.make_emptydir(self.envconfig.envtmpdir)
+            self.envconfig.envtmpdir.ensure(dir=1)
             cwd = self.envconfig.changedir
             env = self._getenv(testcommand=True)
             # Display PYTHONHASHSEED to assist with reproducibility.


### PR DESCRIPTION
Fixes issue #399.

One possible refactoring is to modify `make_emptydir()` to always create the directory. This would simplify the function and its users a bit, but change behavior (insignificantly) in the functions `tox_testenv_create()` in tox/venv.py and `_makesdist()` in tox/session.py. Should this go in a separate pull request?