### PR TITLE
Pass setenv variables to setup.py during usedevelop's reinstall check

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,3 +35,4 @@ Itxaka Serrano
 Alex Grönholm
 Lukasz Rogalski
 Manuel Jacob
+Eli Collins

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -292,6 +292,7 @@ def test_env_variables_added_to_needs_reinstall(tmpdir, mocksession, newconfig, 
     assert 'TEMP_NOPASS_VAR' in env
     assert env["TEMP_NOPASS_VAR"] == "456"
 
+
 def test_test_hashseed_is_in_output(newmocksession):
     original_make_hashseed = tox.config.make_hashseed
     tox.config.make_hashseed = lambda: '123456789'

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -285,15 +285,15 @@ def test_env_variables_added_to_needs_reinstall(tmpdir, mocksession, newconfig, 
     l = mocksession._pcalls
     assert len(l) == 1
     env = l[0].env
-    
+
     # should have access to setenv vars
     assert 'CUSTOM_VAR' in env
     assert env['CUSTOM_VAR'] == '789'
-    
-    # should have access to passenv vars 
+
+    # should have access to passenv vars
     assert 'TEMP_PASS_VAR' in env
     assert env['TEMP_PASS_VAR'] == "123"
-    
+
     # should also have access to full invocation environment,
     # for backward compatibility, and to match behavior of venv.run_install_command()
     assert 'TEMP_NOPASS_VAR' in env

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -285,10 +285,17 @@ def test_env_variables_added_to_needs_reinstall(tmpdir, mocksession, newconfig, 
     l = mocksession._pcalls
     assert len(l) == 1
     env = l[0].env
+    
+    # should have access to setenv vars
     assert 'CUSTOM_VAR' in env
     assert env['CUSTOM_VAR'] == '789'
+    
+    # should have access to passenv vars 
     assert 'TEMP_PASS_VAR' in env
     assert env['TEMP_PASS_VAR'] == "123"
+    
+    # should also have access to full invocation environment,
+    # for backward compatibility, and to match behavior of venv.run_install_command()
     assert 'TEMP_NOPASS_VAR' in env
     assert env["TEMP_NOPASS_VAR"] == "456"
 

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -265,6 +265,7 @@ def test_develop_extras(newmocksession, tmpdir):
     expected = "%s[testing,development]" % tmpdir.strpath
     assert expected in l[-1].args
 
+
 def test_env_variables_added_to_needs_reinstall(tmpdir, mocksession, newconfig, monkeypatch):
     tmpdir.ensure("setup.py")
     monkeypatch.setenv("TEMP_PASS_VAR", "123")

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -208,8 +208,9 @@ class VirtualEnv(object):
         setup_py = setupdir.join('setup.py')
         setup_cfg = setupdir.join('setup.cfg')
         args = [self.envconfig.envpython, str(setup_py), '--name']
+        env = self._getenv()
         output = action.popen(args, cwd=setupdir, redirect=False,
-                              returnout=True)
+                              returnout=True, env=env)
         name = output.strip()
         egg_info = setupdir.join('.'.join((name, 'egg-info')))
         for conf_file in (setup_py, setup_cfg):


### PR DESCRIPTION
This fixes venv._needs_reinstall() so that setenv variables are passed along to the setup.py call.