### PR TITLE
Set an envvar with the path to the sdist archive

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -222,6 +222,15 @@ Complete list of settings that you can put into ``testenv*`` sections:
    invocation environment) can define additional space-separated variable
    names that are to be passed down to the test command environment.
 
+   .. versionadded:: 2.7
+
+   Tox additionally defines the ``TOX_SDIST`` variable that holds the path to
+   the source distribution archive built by tox. This allows tox environments
+   to easily locate the sdist archive. It could be used for automatic uploading
+   to PyPI using twine_, for example.
+
+   .. _twine: https://pypi.python.org/pypi/twine
+
    .. versionchanged:: 2.7
 
    ``PYTHONPATH`` will be passed down if explicitly defined. If ``PYTHONPATH``

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -362,6 +362,36 @@ def test_venv_special_chars_issue252(cmd, initproj):
     ])
 
 
+def test_sdist_envvar(cmd, initproj):
+    initproj("example123-0.5", filedefs={
+        'tox.ini': '''
+            [testenv]
+            commands=python -c "import os;print(os.environ['TOX_SDIST'])"
+        '''
+    })
+    result = cmd.run("tox")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines([
+        "*example123-0.5.zip",
+    ])
+
+
+def test_no_sdist_envvar(cmd, initproj):
+    initproj("example123-0.5", filedefs={
+        'tox.ini': '''
+            [tox]
+            skipsdist=true
+            [testenv]
+            commands=python -c "import os; os.environ['TOX_SDIST']"
+        '''
+    })
+    result = cmd.run("tox")
+    assert result.ret
+    result.stderr.fnmatch_lines([
+        "*KeyError: 'TOX_SDIST'",
+    ])
+
+
 def test_unknown_environment(cmd, initproj):
     initproj("env123-0.7", filedefs={
         'tox.ini': ''

--- a/tox/_pytestplugin.py
+++ b/tox/_pytestplugin.py
@@ -143,6 +143,7 @@ def mocksession(request):
         def __init__(self):
             self._clearmocks()
             self.config = request.getfuncargvalue("newconfig")([], "")
+            self.sdist_path = None
             self.resultlog = ResultLog()
             self._actions = []
 

--- a/tox/session.py
+++ b/tox/session.py
@@ -330,6 +330,7 @@ class Session:
 
     def __init__(self, config, popen=subprocess.Popen, Report=Reporter):
         self.config = config
+        self.sdist_path = None
         self.popen = popen
         self.resultlog = ResultLog()
         self.report = Report(self)
@@ -532,10 +533,9 @@ class Session:
     def subcommand_test(self):
         if self.config.skipsdist:
             self.report.info("skipping sdist step")
-            path = None
         else:
-            path = self.get_installpkg_path()
-            if not path:
+            self.sdist_path = self.get_installpkg_path()
+            if not self.sdist_path:
                 return 2
         if self.config.option.sdistonly:
             return
@@ -546,7 +546,7 @@ class Session:
                 elif self.config.skipsdist or venv.envconfig.skip_install:
                     self.finishvenv(venv)
                 else:
-                    self.installpkg(venv, path)
+                    self.installpkg(venv, self.sdist_path)
 
                 # write out version dependency information
                 action = self.newaction(venv, "envreport")

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -348,6 +348,8 @@ class VirtualEnv(object):
         env.update(self.envconfig.setenv)
 
         env['VIRTUAL_ENV'] = str(self.path)
+        if self.session.sdist_path:
+            env['TOX_SDIST'] = str(self.session.sdist_path)
         return env
 
     def test(self, redirect=False):


### PR DESCRIPTION
This allows tox environments to easily find the sdist archive.

Example uses:
- upload the source archive to PyPI using twine
- create a windows installer using pynsist