### PR TITLE
Fix glob resolution from TOX_TESTENV_PASSENV env variable.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,3 +38,4 @@ Manuel Jacob
 Eli Collins
 Andrii Soldatenko
 Igor Duarte Cardoso
+Allan Feldman

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -935,6 +935,17 @@ class TestConfigTestEnv:
         assert "A1" in env.passenv
         assert "A2" in env.passenv
 
+    def test_passenv_glob_from_global_env(self, tmpdir, newconfig, monkeypatch):
+        monkeypatch.setenv("A1", "a1")
+        monkeypatch.setenv("A2", "a2")
+        monkeypatch.setenv("TOX_TESTENV_PASSENV", "A*")
+        config = newconfig("""
+            [testenv]
+        """)
+        env = config.envconfigs["python"]
+        assert "A1" in env.passenv
+        assert "A2" in env.passenv
+
     def test_changedir_override(self, tmpdir, newconfig):
         config = newconfig("""
             [testenv]

--- a/tox/config.py
+++ b/tox/config.py
@@ -456,7 +456,8 @@ def tox_addoption(parser):
         # read in global passenv settings
         p = os.environ.get("TOX_TESTENV_PASSENV", None)
         if p is not None:
-            passenv.update(x for x in p.split() if x)
+            env_values = [x for x in p.split() if x]
+            value.extend(env_values)
 
         # we ensure that tmp directory settings are passed on
         # we could also set it to the per-venv "envtmpdir"


### PR DESCRIPTION
https://github.com/tox-dev/tox/issues/263#issuecomment-247790754
Glob resolution from the TOX_TESTENV_PASSENV env variable should be
supported.

This update allows for globs to be resolved from the TOX_TESTENV_PASSENV
variable.

Thanks for contributing a PR!

Here's a quick checklist of what we'd like you to think off:

- [x] Make sure to include one or more tests for your change;
- [x] ~~if an enhacement PR please create docs and at best an example~~
- [x] Add yourself to `CONTRIBUTORS`;
- [x] make a descriptive Pull Request text (it will be used for changelog)

