### PR TITLE
Add "alwayscopy" config option

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -37,3 +37,4 @@ Lukasz Rogalski
 Manuel Jacob
 Eli Collins
 Andrii Soldatenko
+Igor Duarte Cardoso

--- a/doc/config.txt
+++ b/doc/config.txt
@@ -237,6 +237,14 @@ Complete list of settings that you can put into ``testenv*`` sections:
     **default:** False, meaning that virtualenvs will be
     created without inheriting the global site packages.
 
+.. confval:: alwayscopy=True|False
+
+    Set to ``True`` if you want virtualenv to always copy files rather
+    than symlinking.
+
+    **default:** False, meaning that virtualenvs will
+    make use of symbolic links.
+
 .. confval:: args_are_paths=BOOL
 
     treat positional arguments passed to ``tox`` as file system paths

--- a/doc/example/basic.txt
+++ b/doc/example/basic.txt
@@ -282,3 +282,13 @@ use :ref:`generative-envlist` and :ref:`conditional settings <factors>` to expre
         py33-mysql: PyMySQL     ; use if both py33 and mysql are in an env name
         py26,py27: urllib3      ; use if any of py26 or py27 are in an env name
         py{26,27}-sqlite: mock  ; mocking sqlite in python 2.x
+
+Prevent symbolic links in virtualenv
+------------------------------------
+By default virtualenv will use symlinks to point to the system's python files, modules, etc.
+If you want the files to be copied instead, possibly because your filesystem is not capable
+of handling symbolic links, you can instruct virtualenv to use the "--always-copy" argument
+meant exactly for that purpose, by setting the ``alwayscopy`` directive in your environment:
+
+    [testenv]
+    alwayscopy = True

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -640,6 +640,27 @@ def test_test_usedevelop(cmd, initproj):
     ])
 
 
+def test_alwayscopy(initproj, cmd):
+    initproj("example123", filedefs={'tox.ini': """
+            [testenv]
+            commands={envpython} --version
+            alwayscopy=True
+    """})
+    result = cmd.run("tox", "-vv")
+    assert not result.ret
+    assert "virtualenv --always-copy" in result.stdout.str()
+
+
+def test_alwayscopy_default(initproj, cmd):
+    initproj("example123", filedefs={'tox.ini': """
+            [testenv]
+            commands={envpython} --version
+    """})
+    result = cmd.run("tox", "-vv")
+    assert not result.ret
+    assert "virtualenv --always-copy" not in result.stdout.str()
+
+
 def test_test_piphelp(initproj, cmd):
     initproj("example123", filedefs={'tox.ini': """
         # content of: tox.ini

--- a/tox/config.py
+++ b/tox/config.py
@@ -366,6 +366,8 @@ def tox_addoption(parser):
                              "'pytest<2.7' or 'django>=1.6'.")
     parser.add_argument("--sitepackages", action="store_true",
                         help="override sitepackages setting to True in all envs")
+    parser.add_argument("--alwayscopy", action="store_true",
+                        help="override alwayscopy setting to True in all envs")
     parser.add_argument("--skip-missing-interpreters", action="store_true",
                         help="don't fail tests for missing interpreters")
     parser.add_argument("--workdir", action="store",
@@ -496,10 +498,18 @@ def tox_addoption(parser):
     def sitepackages(testenv_config, value):
         return testenv_config.config.option.sitepackages or value
 
+    def alwayscopy(testenv_config, value):
+        return testenv_config.config.option.alwayscopy or value
+
     parser.add_testenv_attribute(
         name="sitepackages", type="bool", default=False, postprocess=sitepackages,
         help="Set to ``True`` if you want to create virtual environments that also "
              "have access to globally installed packages.")
+
+    parser.add_testenv_attribute(
+        name="alwayscopy", type="bool", default=False, postprocess=alwayscopy,
+        help="Set to ``True`` if you want virtualenv to always copy files rather "
+             "than symlinking.")
 
     def pip_pre(testenv_config, value):
         return testenv_config.config.option.pre or value


### PR DESCRIPTION
This config option will translate into virtualenv's --always-copy,
which is described as:
"Always copy files rather than symlinking."

This is useful when symlinks are inconvenient or impossible. A
use case is when running tox inside a mountpoint whose filesystem
doesn't support symlinks.

Suggested changelog line:
- add "alwayscopy" config option to instruct virtualenv to always copy files instead of symlinking.

This PR is related to issue #218.