### PR TITLE
Use venv module in python 3

### DIFF
--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -62,7 +62,7 @@ def test_create(monkeypatch, mocksession, newconfig):
     l = mocksession._pcalls
     assert len(l) >= 1
     args = l[0].args
-    assert "virtualenv" == str(args[2])
+    assert venv._module() == str(args[2])
     if sys.platform != "win32":
         # realpath is needed for stuff like the debian symlinks
         assert py.path.local(sys.executable).realpath() == py.path.local(args[0]).realpath()
@@ -486,7 +486,7 @@ class TestCreationConfig:
         assert venv.path_config.check()
         assert mocksession._pcalls
         args1 = map(str, mocksession._pcalls[0].args)
-        assert 'virtualenv' in " ".join(args1)
+        assert venv._module() in " ".join(args1)
         mocksession.report.expect("*", "*create*")
         # modify config and check that recreation happens
         mocksession._clearmocks()

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -708,6 +708,17 @@ def test_PYC(initproj, cmd, monkeypatch):
     ])
 
 
+def test_PYTHONWARNINGS(initproj, cmd, monkeypatch):
+    initproj("example123", filedefs={'tox.ini': """
+        [testenv]
+        setenv=
+            PYTHONWARNINGS=error
+        commands={envpython} --version
+    """})
+    result = cmd.run("tox", "-v")
+    assert not result.ret
+
+
 def test_env_VIRTUALENV_PYTHON(initproj, cmd, monkeypatch):
     initproj("example123", filedefs={'tox.ini': """
         [testenv]

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -640,25 +640,39 @@ def test_test_usedevelop(cmd, initproj):
     ])
 
 
-def test_alwayscopy(initproj, cmd):
+def test_alwayscopy(initproj, cmd, mocksession):
     initproj("example123", filedefs={'tox.ini': """
             [testenv]
             commands={envpython} --version
             alwayscopy=True
     """})
+    venv = mocksession.getenv('python')
     result = cmd.run("tox", "-vv")
     assert not result.ret
-    assert "virtualenv --always-copy" in result.stdout.str()
+
+    out = result.stdout.str()
+    assert venv._module() in out
+    if venv._ispython3():
+        assert "--copies" in out
+    else:
+        assert "--always-copy" in out
 
 
-def test_alwayscopy_default(initproj, cmd):
+def test_alwayscopy_default(initproj, cmd, mocksession):
     initproj("example123", filedefs={'tox.ini': """
             [testenv]
             commands={envpython} --version
     """})
+    venv = mocksession.getenv('python')
     result = cmd.run("tox", "-vv")
     assert not result.ret
-    assert "virtualenv --always-copy" not in result.stdout.str()
+
+    out = result.stdout.str()
+    assert venv._module() in out
+    if venv._ispython3():
+        assert "--copies" not in out
+    else:
+        assert "--always-copy" not in out
 
 
 def test_test_piphelp(initproj, cmd):


### PR DESCRIPTION
This is a proof of concept for issue #436. The fix is incoming after the failing test run is complete. I'm assuming this will probably fail on python 3.3, since the `--copies` option wasn't implemented yet. 
