### PR TITLE
Stop after the first installdeps hook succeeds

### DIFF
--- a/tox/hookspecs.py
+++ b/tox/hookspecs.py
@@ -38,7 +38,7 @@ def tox_testenv_create(venv, action):
     """
 
 
-@hookspec
+@hookspec(firstresult=True)
 def tox_testenv_install_deps(venv, action):
     """ [experimental] perform install dependencies action for this venv.  """
 

--- a/tox/hookspecs.py
+++ b/tox/hookspecs.py
@@ -32,7 +32,7 @@ def tox_get_python_executable(envconfig):
     """
 
 
-@hookspec
+@hookspec(firstresult=True)
 def tox_testenv_create(venv, action):
     """ [experimental] perform creation action for this venv.
     """

--- a/tox/hookspecs.py
+++ b/tox/hookspecs.py
@@ -35,12 +35,49 @@ def tox_get_python_executable(envconfig):
 @hookspec(firstresult=True)
 def tox_testenv_create(venv, action):
     """ [experimental] perform creation action for this venv.
+
+    Some example usage:
+
+    - To *add* behavior but still use tox's implementation to set up a
+      virtualenv, implement this hook but do not return a value (or explicitly
+      return ``None``).
+    - To *override* tox's virtualenv creation, implement this hook and return
+      a non-``None`` value.
+
+    .. note:: This api is experimental due to the unstable api of
+        :class:`tox.venv.VirtualEnv`.
+
+    .. note:: This hook uses ``firstresult=True`` (see pluggy_) -- hooks
+        implementing this will be run until one returns non-``None``.
+
+    .. _pluggy: http://pluggy.readthedocs.io/en/latest/#first-result-only
     """
 
 
 @hookspec(firstresult=True)
 def tox_testenv_install_deps(venv, action):
-    """ [experimental] perform install dependencies action for this venv.  """
+    """ [experimental] perform install dependencies action for this venv.
+
+    Some example usage:
+
+    - To *add* behavior but still use tox's implementation to install
+      dependencies, implement this hook but do not return a value (or
+      explicitly return ``None``).  One use-case may be to install (or ensure)
+      non-python dependencies such as debian packages.
+    - To *override* tox's installation of dependencies, implement this hook
+      and return a non-``None`` value.  One use-case may be to install via
+      a different installation tool such as `pip-accel`_ or `pip-faster`_.
+
+    .. note:: This api is experimental due to the unstable api of
+        :class:`tox.venv.VirtualEnv`.
+
+    .. note:: This hook uses ``firstresult=True`` (see pluggy_) -- hooks
+        implementing this will be run until one returns non-``None``.
+
+    .. _pip-accel: https://github.com/paylogic/pip-accel
+    .. _pip-faster: https://github.com/Yelp/venv-update
+    .. _pluggy: http://pluggy.readthedocs.io/en/latest/#first-result-only
+    """
 
 
 @hookspec

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -441,6 +441,8 @@ def tox_testenv_create(venv, action):
     basepath.ensure(dir=1)
     args.append(venv.path.basename)
     venv._pcall(args, venv=False, action=action, cwd=basepath)
+    # Return non-None to indicate the plugin has completed
+    return True
 
 
 @hookimpl

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -450,3 +450,5 @@ def tox_testenv_install_deps(venv, action):
         depinfo = ", ".join(map(str, deps))
         action.setactivity("installdeps", "%s" % depinfo)
         venv._install(deps, action=action)
+    # Return non-None to indicate the plugin has completed
+    return True


### PR DESCRIPTION
By changing this hook to `firstresult=True`, a plugin may override this step and avoid running the base step

I'd like to write a plugin which overwrites the install_deps command, I've got it mostly working except when I run it it triggers dependency install twice (the second time is a noop, but a slow noop).  

## tox2.ini
```
[tox]
envlist = py27     
tox_pip_extensions_ext_venv_update = true

[testenv]
deps =
    pre-commit
    setuptools
commands =
    pip freeze --all
```

## Current behaviour

```
$ tox -v -r -e py27 -c tox2.ini
using tox.ini: /home/asottile/workspace/tox-pip-extensions/tox2.ini
using tox-2.6.0 from /home/asottile/workspace/tox-pip-extensions/venv/local/lib/python2.7/site-packages/tox/__init__.pyc
GLOB sdist-make: /home/asottile/workspace/tox-pip-extensions/setup.py
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/venv/bin/python /home/asottile/workspace/tox-pip-extensions/setup.py sdist --formats=zip --dist-dir /home/asottile/workspace/tox-pip-extensions/.tox/dist >/home/asottile/workspace/tox-pip-extensions/.tox/log/tox-0.log
py27 recreate: /home/asottile/workspace/tox-pip-extensions/.tox/py27
  /home/asottile/workspace/tox-pip-extensions/.tox$ /home/asottile/workspace/tox-pip-extensions/venv/bin/python -m virtualenv --python /home/asottile/workspace/tox-pip-extensions/venv/bin/python2.7 py27 >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-0.log
py27 bootstrap: venv-update>=2
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip install venv-update>=2 >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-1.log
py27 installdeps: pre-commit, setuptools
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip-faster install pre-commit setuptools --prune >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-2.log
py27 installdeps: pre-commit, setuptools
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip-faster install pre-commit setuptools >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-3.log
py27 inst: /home/asottile/workspace/tox-pip-extensions/.tox/dist/tox-pip-extensions-0.0.0.zip
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip-faster install /home/asottile/workspace/tox-pip-extensions/.tox/dist/tox-pip-extensions-0.0.0.zip >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-4.log
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip freeze >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-5.log
py27 installed: appdirs==1.4.0,aspy.yaml==0.2.2,cached-property==1.3.0,functools32==3.2.3.post2,jsonschema==2.5.1,nodeenv==1.1.2,packaging==16.8,pluggy==0.4.0,pre-commit==0.12.2,py==1.4.32,pyparsing==2.1.10,PyYAML==3.12,six==1.10.0,tox==2.6.0,tox-pip-extensions==0.0.0,venv-update==2.0.0,virtualenv==15.1.0
py27 runtests: PYTHONHASHSEED='1109614621'
py27 runtests: commands[0] | pip freeze --all
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip freeze --all 
appdirs==1.4.0
aspy.yaml==0.2.2
cached-property==1.3.0
functools32==3.2.3.post2
jsonschema==2.5.1
nodeenv==1.1.2
packaging==16.8
pip==9.0.1
pluggy==0.4.0
pre-commit==0.12.2
py==1.4.32
pyparsing==2.1.10
PyYAML==3.12
setuptools==34.1.1
six==1.10.0
tox==2.6.0
tox-pip-extensions==0.0.0
venv-update==2.0.0
virtualenv==15.1.0
wheel==0.29.0
______________________________________________________________________________________ summary ______________________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```

The important bit here being:

```
py27 installdeps: pre-commit, setuptools
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip-faster install pre-commit setuptools --prune >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-2.log
py27 installdeps: pre-commit, setuptools
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip-faster install pre-commit setuptools >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-3.log
```

A `-vv` into that (you'll notice the second install is unnecessary).

```
py27 installdeps: pre-commit, setuptools
setting PATH=/home/asottile/workspace/tox-pip-extensions/.tox/py27/bin:/home/asottile/workspace/tox-pip-extensions/venv/bin:/home/asottile/bin:/home/asottile/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip-faster install pre-commit setuptools --prune 
Collecting pre-commit
  slow: full search for unpinned requirement pre-commit
  Using cached pre_commit-0.12.2-py2.py3-none-any.whl
Requirement already satisfied: setuptools in ./.tox/py27/lib/python2.7/site-packages
Collecting nodeenv>=0.11.1 (from pre-commit)
  slow: full search for unpinned requirement nodeenv>=0.11.1 (from pre-commit)
Collecting virtualenv (from pre-commit)
  slow: full search for unpinned requirement virtualenv (from pre-commit)
  Using cached virtualenv-15.1.0-py2.py3-none-any.whl
Collecting pyyaml (from pre-commit)
  slow: full search for unpinned requirement pyyaml (from pre-commit)
Collecting jsonschema (from pre-commit)
  slow: full search for unpinned requirement jsonschema (from pre-commit)
  Using cached jsonschema-2.5.1-py2.py3-none-any.whl
Collecting aspy.yaml (from pre-commit)
  slow: full search for unpinned requirement aspy.yaml (from pre-commit)
  Using cached aspy.yaml-0.2.2-py2.py3-none-any.whl
Collecting cached-property (from pre-commit)
  slow: full search for unpinned requirement cached-property (from pre-commit)
  Using cached cached_property-1.3.0-py2.py3-none-any.whl
Requirement already satisfied: six>=1.6.0 in ./.tox/py27/lib/python2.7/site-packages (from setuptools)
Requirement already satisfied: appdirs>=1.4.0 in ./.tox/py27/lib/python2.7/site-packages (from setuptools)
Requirement already satisfied: packaging>=16.8 in ./.tox/py27/lib/python2.7/site-packages (from setuptools)
Collecting functools32; python_version == "2.7" (from jsonschema->pre-commit)
  slow: full search for unpinned requirement functools32; python_version == "2.7" (from jsonschema->pre-commit)
Requirement already satisfied: pyparsing in ./.tox/py27/lib/python2.7/site-packages (from packaging>=16.8->setuptools)
Installing collected packages: nodeenv, virtualenv, pyyaml, functools32, jsonschema, aspy.yaml, cached-property, pre-commit
Successfully installed aspy.yaml-0.2.2 cached-property-1.3.0 functools32-3.2.3.post2 jsonschema-2.5.1 nodeenv-1.1.2 pre-commit-0.12.2 pyyaml-3.12 virtualenv-15.1.0
py27 installdeps: pre-commit, setuptools
setting PATH=/home/asottile/workspace/tox-pip-extensions/.tox/py27/bin:/home/asottile/workspace/tox-pip-extensions/venv/bin:/home/asottile/bin:/home/asottile/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip-faster install pre-commit setuptools 
Requirement already satisfied: pre-commit in ./.tox/py27/lib/python2.7/site-packages
Requirement already satisfied: setuptools in ./.tox/py27/lib/python2.7/site-packages
Requirement already satisfied: nodeenv>=0.11.1 in ./.tox/py27/lib/python2.7/site-packages (from pre-commit)
Requirement already satisfied: virtualenv in ./.tox/py27/lib/python2.7/site-packages (from pre-commit)
Requirement already satisfied: pyyaml in ./.tox/py27/lib/python2.7/site-packages (from pre-commit)
Requirement already satisfied: jsonschema in ./.tox/py27/lib/python2.7/site-packages (from pre-commit)
Requirement already satisfied: aspy.yaml in ./.tox/py27/lib/python2.7/site-packages (from pre-commit)
Requirement already satisfied: cached-property in ./.tox/py27/lib/python2.7/site-packages (from pre-commit)
Requirement already satisfied: six>=1.6.0 in ./.tox/py27/lib/python2.7/site-packages (from setuptools)
Requirement already satisfied: appdirs>=1.4.0 in ./.tox/py27/lib/python2.7/site-packages (from setuptools)
Requirement already satisfied: packaging>=16.8 in ./.tox/py27/lib/python2.7/site-packages (from setuptools)
Requirement already satisfied: functools32; python_version == "2.7" in ./.tox/py27/lib/python2.7/site-packages (from jsonschema->pre-commit)
Requirement already satisfied: pyparsing in ./.tox/py27/lib/python2.7/site-packages (from packaging>=16.8->setuptools)
```

## With my patch:

```
$ tox -v -r -e py27 -c tox2.ini
using tox.ini: /home/asottile/workspace/tox-pip-extensions/tox2.ini
using tox-2.6.1.dev1 from /home/asottile/workspace/tox/tox/__init__.pyc
GLOB sdist-make: /home/asottile/workspace/tox-pip-extensions/setup.py
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/venv/bin/python /home/asottile/workspace/tox-pip-extensions/setup.py sdist --formats=zip --dist-dir /home/asottile/workspace/tox-pip-extensions/.tox/dist >/home/asottile/workspace/tox-pip-extensions/.tox/log/tox-0.log
py27 recreate: /home/asottile/workspace/tox-pip-extensions/.tox/py27
  /home/asottile/workspace/tox-pip-extensions/.tox$ /home/asottile/workspace/tox-pip-extensions/venv/bin/python -m virtualenv --python /home/asottile/workspace/tox-pip-extensions/venv/bin/python2.7 py27 >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-0.log
py27 bootstrap: venv-update>=2
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip install venv-update>=2 >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-1.log
py27 installdeps: pre-commit, setuptools
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip-faster install pre-commit setuptools --prune >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-2.log
py27 inst: /home/asottile/workspace/tox-pip-extensions/.tox/dist/tox-pip-extensions-0.0.0.zip
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip-faster install /home/asottile/workspace/tox-pip-extensions/.tox/dist/tox-pip-extensions-0.0.0.zip >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-3.log
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip freeze >/home/asottile/workspace/tox-pip-extensions/.tox/py27/log/py27-4.log
py27 installed: appdirs==1.4.0,aspy.yaml==0.2.2,cached-property==1.3.0,functools32==3.2.3.post2,jsonschema==2.5.1,nodeenv==1.1.2,packaging==16.8,pluggy==0.4.0,pre-commit==0.12.2,py==1.4.32,pyparsing==2.1.10,PyYAML==3.12,six==1.10.0,tox==2.6.0,tox-pip-extensions==0.0.0,venv-update==2.0.0,virtualenv==15.1.0
py27 runtests: PYTHONHASHSEED='1881738361'
py27 runtests: commands[0] | pip freeze --all
  /home/asottile/workspace/tox-pip-extensions$ /home/asottile/workspace/tox-pip-extensions/.tox/py27/bin/pip freeze --all 
appdirs==1.4.0
aspy.yaml==0.2.2
cached-property==1.3.0
functools32==3.2.3.post2
jsonschema==2.5.1
nodeenv==1.1.2
packaging==16.8
pip==9.0.1
pluggy==0.4.0
pre-commit==0.12.2
py==1.4.32
pyparsing==2.1.10
PyYAML==3.12
setuptools==34.1.1
six==1.10.0
tox==2.6.0
tox-pip-extensions==0.0.0
venv-update==2.0.0
virtualenv==15.1.0
wheel==0.29.0
______________________________________________________________________________________ summary ______________________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```

## Hook implementation

A bit of a WIP but it mostly does what I want:

```python
@hookimpl
def tox_configure(config):
    cfg = six.moves.configparser.ConfigParser()
    cfg.read(config.option.configfile)
    configured = tuple(sorted(
        k[len(TOX_KEY):]
        for k, v in cfg.items('tox')
        if k.startswith(TOX_KEY) and _assert_true_value(k, v)
    ))
    config.pip_extensions = configured


@hookimpl(tryfirst=True)
def tox_testenv_install_deps(venv, action):
    config = venv.session.config
    extensions = config.pip_extensions

    # If there's nothing special for us to do, defer to other plugins
    if not extensions:
        return None

    def _install(step, deps):
        if deps:
            action.setactivity(step, ', '.join(map(str, deps)))
            venv._install(deps, action=action)

    # Install the bootstrap dependencies
    bootstrap = config.toxinidir.join('requirements-bootstrap.txt')
    if bootstrap.exists():
        bootstrap_deps = ['-r{}'.format(bootstrap)]
    else:
        bootstrap_deps = [INSTALL_DEPS[ext] for ext in extensions]
    _install('bootstrap', bootstrap_deps)

    # Run the deps install step with the custom deps install command
    venv.envconfig.install_command[:] = INSTALL_DEPS_CMD[extensions]
    _install('installdeps', venv._getresolvedeps())

    # Run the rest of the setup with the custom install command
    venv.envconfig.install_command[:] = INSTALL_CMD[extensions]

    # Indicate to the plugin framework that we have handled installation
    return True
```