### PR TITLE
Revert "Warn about commands key missing in tox.ini"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 2.x
 -----
 
+- #454: Revert #407, empty commands is not treated as an error.
+  Thanks Anthony Sottile (@asottile).
+
 - #446: (infrastructure) Travis CI tests for tox now also run on OS X now.
   Thanks Jason R. Coombs (@jaraco).
 

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -644,7 +644,6 @@ def test_run_install_command(newmocksession):
 def test_run_custom_install_command(newmocksession):
     mocksession = newmocksession([], """
         [testenv]
-        commands={envpython} --version
         install_command=easy_install {opts} {packages}
     """)
     venv = mocksession.getenv('python')
@@ -661,7 +660,6 @@ def test_run_custom_install_command(newmocksession):
 def test_command_relative_issue26(newmocksession, tmpdir, monkeypatch):
     mocksession = newmocksession([], """
         [testenv]
-        commands={envpython} --version
     """)
     x = tmpdir.ensure("x")
     venv = mocksession.getenv("python")
@@ -736,14 +734,3 @@ def test_tox_testenv_pre_post(newmocksession):
     assert l == []
     mocksession.runtestenv(venv)
     assert l == ['started', 'finished']
-
-
-def test_error_when_commands_missing(newmocksession):
-    mocksession = newmocksession([], """
-        [testenv]
-    """)
-
-    venv = mocksession.getenv('python')
-    venv.status = None
-    mocksession.runtestenv(venv)
-    assert venv.status == 'nothing to do'

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -351,8 +351,6 @@ def test_venv_special_chars_issue252(cmd, initproj):
         'tox.ini': '''
             [tox]
             envlist = special&&1
-            [testenv]
-            commands={envpython} --version
             [testenv:special&&1]
             changedir=tests
         '''
@@ -470,10 +468,7 @@ def test_package_install_fails(cmd, initproj):
                 install_requires=['qweqwe123'],
                 )
             """,
-        'tox.ini': """
-        [testenv]
-        commands={envpython} --version
-        """,
+        'tox.ini': '',
     })
     result = cmd.run("tox", )
     assert result.ret
@@ -546,8 +541,6 @@ class TestToxRun:
 
 def test_develop(initproj, cmd):
     initproj("example123", filedefs={'tox.ini': """
-        [testenv]
-        commands={envpython} --version
     """})
     result = cmd.run("tox", "-vv", "--develop")
     assert not result.ret
@@ -557,7 +550,6 @@ def test_develop(initproj, cmd):
 def test_usedevelop(initproj, cmd):
     initproj("example123", filedefs={'tox.ini': """
             [testenv]
-            commands={envpython} --version
             usedevelop=True
     """})
     result = cmd.run("tox", "-vv")
@@ -567,8 +559,6 @@ def test_usedevelop(initproj, cmd):
 
 def test_usedevelop_mixed(initproj, cmd):
     initproj("example123", filedefs={'tox.ini': """
-            [testenv]
-            commands={envpython} --version
             [testenv:devenv]
             usedevelop=True
             [testenv:nondev]
@@ -679,7 +669,6 @@ def test_notest(initproj, cmd):
     initproj("example123", filedefs={'tox.ini': """
         # content of: tox.ini
         [testenv:py26]
-        commands={envpython} --version
         basepython=python
     """})
     result = cmd.run("tox", "-v", "--notest")
@@ -696,10 +685,7 @@ def test_notest(initproj, cmd):
 
 
 def test_PYC(initproj, cmd, monkeypatch):
-    initproj("example123", filedefs={'tox.ini': """
-        [testenv]
-        commands={envpython} --version
-    """})
+    initproj("example123", filedefs={'tox.ini': ''})
     monkeypatch.setenv("PYTHONDOWNWRITEBYTECODE", 1)
     result = cmd.run("tox", "-v", "--notest")
     assert not result.ret
@@ -709,10 +695,7 @@ def test_PYC(initproj, cmd, monkeypatch):
 
 
 def test_env_VIRTUALENV_PYTHON(initproj, cmd, monkeypatch):
-    initproj("example123", filedefs={'tox.ini': """
-        [testenv]
-        commands={envpython} --version
-    """})
+    initproj("example123", filedefs={'tox.ini': ''})
     monkeypatch.setenv("VIRTUALENV_PYTHON", '/FOO')
     result = cmd.run("tox", "-v", "--notest")
     assert not result.ret, result.stdout.lines
@@ -738,8 +721,6 @@ def test_separate_sdist_no_sdistfile(cmd, initproj):
         'tox.ini': """
             [tox]
             distshare=%s
-            [testenv]
-            commands={envpython} --version
         """ % distshare
     })
     result = cmd.run("tox", "--sdistonly")
@@ -757,8 +738,6 @@ def test_separate_sdist(cmd, initproj):
             [tox]
             distshare=%s
             sdistsrc={distshare}/pkg123-0.7.zip
-            [testenv]
-            commands={envpython} --version
         """ % distshare
     })
     result = cmd.run("tox", "--sdistonly")
@@ -779,8 +758,6 @@ def test_sdist_latest(tmpdir, newconfig):
             [tox]
             distshare=%s
             sdistsrc={distshare}/pkg123-*
-            [testenv]
-            commands={envpython} --version
     """ % distshare)
     p = distshare.ensure("pkg123-1.4.5.zip")
     distshare.ensure("pkg123-1.4.5a1.zip")
@@ -833,7 +810,6 @@ def test_verbosity(cmd, initproj, verbosity):
     initproj("pkgX-0.0.5", filedefs={
         'tox.ini': """
         [testenv]
-        commands={envpython} --version
     """})
     result = cmd.run("tox", verbosity)
     assert result.ret == 0

--- a/tox/session.py
+++ b/tox/session.py
@@ -565,11 +565,7 @@ class Session:
         return retcode
 
     def runtestenv(self, venv, redirect=False):
-        if not venv.envconfig.commands:
-            self.report.error(("Commands not specified. Please update "
-                               "relevant section of {0}").format(self.config.toxinipath))
-            venv.status = "nothing to do"
-        elif not self.config.option.notest:
+        if not self.config.option.notest:
             if venv.status:
                 return
             self.hook.tox_runtest_pre(venv=venv)


### PR DESCRIPTION
Reverts tox-dev/tox#407

See #454 and #316

I'd rather fix this to have the following behaviour but at a glance it doesn't seem easy / possible with the current `argvlist` parser (which doesn't differentiate between missing and present-but-empy):
- If there are no `commands`: warning (or error)
- If `commands` is present but empty: successfully do nothing (no warning).