### PR TITLE
Made custom config file path parameter more flexible (#460)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,3 +40,4 @@ Andrii Soldatenko
 Igor Duarte Cardoso
 Allan Feldman
 Josh Smeaton
+Paweł Adamczak

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,6 +205,21 @@ class TestParseconfig:
             old.chdir()
         assert config.toxinipath == toxinipath
 
+    def test_explicit_config_path(self, tmpdir):
+        """
+        Test explicitly setting config path, both with and without the filename
+        """
+        path = tmpdir.mkdir('tox_tmp_directory')
+        config_file_path = path.ensure('tox.ini')
+
+        config = parseconfig(['-c', str(config_file_path)])
+        assert config.toxinipath == config_file_path
+
+        # Passing directory of the config file should also be possible
+        # ('tox.ini' filename is assumed)
+        config = parseconfig(['-c', str(path)])
+        assert config.toxinipath == config_file_path
+
 
 def test_get_homedir(monkeypatch):
     monkeypatch.setattr(py.path.local, "_gethomedir",

--- a/tox/config.py
+++ b/tox/config.py
@@ -324,7 +324,7 @@ def tox_addoption(parser):
                         dest="listenvs", help="show list of test environments")
     parser.add_argument("-c", action="store", default="tox.ini",
                         dest="configfile",
-                        help="use the specified config file name.")
+                        help="config file name or directory with 'tox.ini' file.")
     parser.add_argument("-e", action="append", dest="env",
                         metavar="envlist",
                         help="work against specified environments (ALL selects all).")

--- a/tox/config.py
+++ b/tox/config.py
@@ -219,8 +219,11 @@ def parseconfig(args=None, plugins=()):
 
     # parse ini file
     basename = config.option.configfile
-    if os.path.isabs(basename):
+    if os.path.isfile(basename):
         inipath = py.path.local(basename)
+    elif os.path.isdir(basename):
+        # Assume 'tox.ini' filename if directory was passed
+        inipath = py.path.local(os.path.join(basename, 'tox.ini'))
     else:
         for path in py.path.local().parts(reverse=True):
             inipath = path.join(basename)


### PR DESCRIPTION
Made custom config file path parameter (`-c`) more flexible. It now allows both a path to the `tox.ini` file and a path to the directory where `tox.ini` is located.
Tests added.
I also tried to add some info to docs but couldn't really find a good place for it - any suggestions welcome

Resolves issue #460