### PR TITLE
Fix incorrect egg-info location for modified package_dir in setup.py

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,3 +42,4 @@ Allan Feldman
 Josh Smeaton
 Paweł Adamczak
 Oliver Bestwalter
+Selim Belhaouane

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -283,7 +283,7 @@ def test_env_variables_added_to_needs_reinstall(tmpdir, mocksession, newconfig, 
     venv._needs_reinstall(tmpdir, action)
 
     l = mocksession._pcalls
-    assert len(l) == 1
+    assert len(l) == 2
     env = l[0].env
 
     # should have access to setenv vars

--- a/tox/_pytestplugin.py
+++ b/tox/_pytestplugin.py
@@ -290,7 +290,7 @@ class LineMatcher:
 @pytest.fixture
 def initproj(request, tmpdir):
     """ create a factory function for creating example projects. """
-    def initproj(nameversion, filedefs=None):
+    def initproj(nameversion, filedefs=None, src_root="."):
         if filedefs is None:
             filedefs = {}
         if _istext(nameversion) or _isbytes(nameversion):
@@ -304,18 +304,20 @@ def initproj(request, tmpdir):
         create_files(base, filedefs)
         if 'setup.py' not in filedefs:
             create_files(base, {'setup.py': '''
-                from setuptools import setup
+                from setuptools import setup, find_packages
                 setup(
                     name='%(name)s',
                     description='%(name)s project',
                     version='%(version)s',
                     license='MIT',
                     platforms=['unix', 'win32'],
-                    packages=['%(name)s', ],
+                    packages=find_packages('%(src_root)s'),
+                    package_dir={'':'%(src_root)s'},
                 )
             ''' % locals()})
         if name not in filedefs:
-            create_files(base, {
+            src_dir = base.ensure(src_root, dir=1)
+            create_files(src_dir, {
                 name: {'__init__.py': '__version__ = %r' % version}
             })
         manifestlines = []

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -1,4 +1,5 @@
 from __future__ import with_statement
+import ast
 import os
 import sys
 import re
@@ -220,7 +221,7 @@ class VirtualEnv(object):
         args = [self.envconfig.envpython, '-c', 'import sys; print(sys.path)']
         out = action.popen(args, redirect=False, returnout=True, env=env)
         try:
-            sys_path = eval(out.strip())
+            sys_path = ast.literal_eval(out.strip())
         except SyntaxError:
             sys_path = []
         egg_info_fname = '.'.join((name, 'egg-info'))

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -217,10 +217,18 @@ class VirtualEnv(object):
         output = action.popen(args, cwd=setupdir, redirect=False,
                               returnout=True, env=env)
         name = output.strip()
-        egg_info = setupdir.join('.'.join((name, 'egg-info')))
+        args = [self.envconfig.envpython, '-c', 'import sys; print(sys.path)']
+        out = action.popen(args, redirect=False, returnout=True, env=env)
+        sys_path = eval(out.strip())
+        egg_info_fname = '.'.join((name, 'egg-info'))
+        for d in reversed(sys_path):
+            egg_info = py.path.local(d).join(egg_info_fname)
+            if egg_info.check():
+                break
+        else:
+            return True
         for conf_file in (setup_py, setup_cfg):
-            if (not egg_info.check()
-                    or (conf_file.check() and conf_file.mtime() > egg_info.mtime())):
+            if conf_file.check() and conf_file.mtime() > egg_info.mtime():
                 return True
         return False
 

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -219,7 +219,10 @@ class VirtualEnv(object):
         name = output.strip()
         args = [self.envconfig.envpython, '-c', 'import sys; print(sys.path)']
         out = action.popen(args, redirect=False, returnout=True, env=env)
-        sys_path = eval(out.strip())
+        try:
+            sys_path = eval(out.strip())
+        except SyntaxError:
+            sys_path = []
         egg_info_fname = '.'.join((name, 'egg-info'))
         for d in reversed(sys_path):
             egg_info = py.path.local(d).join(egg_info_fname)


### PR DESCRIPTION
fixes #464 

Check for `egg-info` in `sys.path` instead of directory containing `setup.py`. Thanks to @RonnyPfannschmidt for the hint. 

Commits have been split TDD-style to show that the tests fail initially and then a fix is applied. Left some comments on the commits as well. 

If the PR is to be accepted, I certainly could squash them all together. 

