### PR TITLE
Add a Vagrantfile with a custom box to the project.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 2.x
 -----
 
+- #455: Add a Vagrantfile with a customized Arch Linux box for local testing
+
 - #454: Revert #407, empty commands is not treated as an error.
   Thanks Anthony Sottile (@asottile).
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -41,3 +41,4 @@ Igor Duarte Cardoso
 Allan Feldman
 Josh Smeaton
 Paweł Adamczak
+Oliver Bestwalter

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,34 @@
+<<-DOC
+Start a virtualbox image with
+    * all supported interpreters installed
+    * tox installed
+    * this folder mapped read/writable to /vagrant
+    * convenient way to ssh into the box
+
+This should work from Windows, macOS and Linux.
+
+To run tests in the box do:
+
+    $ cd </path/to/where/this/file/is>
+    $ vagrant up arch
+    $ vagrant ssh arch
+    $ tox
+
+Prerequisites: https://www.vagrantup.com/ and https://www.virtualbox.org/
+
+**NOTE** When sshing into vagrant all .pyc files in this folder will be removed
+automatically. This is necessary to avoid an ImportMismatchError in pytest.
+If you switch between Host and guests, running tests on both you have to
+remove all .pyc files in between runs.
+
+For now there is only an Arch Linux box provided. More to come.
+DOC
+
+Vagrant.configure("2") do |config|
+    config.vm.define :arch do |arch|
+        arch.vm.box = "obestwalter/bindlestiff-arch-linux"
+        arch.vm.provider "virtualbox" do |vb|
+            vb.memory = "2048"
+        end
+    end
+end


### PR DESCRIPTION
fixes #455

First implementation uses a [custom built Arch Linux box](https://github.com/obestwalter/packer-arch) hosted on [Atlas](https://atlas.hashicorp.com/obestwalter/boxes/bindlestiff-arch-linux/).

All relevant adjustments to the box creation are in [scripts/bindlestiff.sh](https://github.com/obestwalter/packer-arch/blob/master/scripts/bindlestiff.sh). Basically what is does is switch of the too small tmpfs, installs pyenv, compiles lots of Python versions and makes sure that the user can just type tox directly after logging in.

A first `vagrant up arch` looks for the box locally and downloads and imports it if necessary. This looks something like this:

    16:54:19 oliver@ob1 [0] < ~/work/tox/tox >  2972 %
    vagrant up arch
    
    Bringing machine 'arch' up with 'virtualbox' provider...
    ==> arch: Box 'obestwalter/bindlestiff-arch-linux' could not be found. Attempting to find and install...
        arch: Box Provider: virtualbox
        arch: Box Version: >= 0
    ==> arch: Loading metadata for box 'obestwalter/bindlestiff-arch-linux'
        arch: URL: https://atlas.hashicorp.com/obestwalter/bindlestiff-arch-linux
    ==> arch: Adding box 'obestwalter/bindlestiff-arch-linux' (v0.0.1) for provider: virtualbox
        arch: Downloading: https://atlas.hashicorp.com/obestwalter/boxes/bindlestiff-arch-linux/versions/0.0.1/providers/virtualbox.box
    ==> arch: Successfully added box 'obestwalter/bindlestiff-arch-linux' (v0.0.1) for 'virtualbox'!
    ==> arch: Importing base box 'obestwalter/bindlestiff-arch-linux'...
    ==> arch: Matching MAC address for NAT networking...
    ==> arch: Checking if box 'obestwalter/bindlestiff-arch-linux' is up to date...
    ==> arch: Setting the name of the VM: tox_arch_1489334164336_90778
    ==> arch: Clearing any previously set network interfaces...
    ==> arch: Preparing network interfaces based on configuration...
        arch: Adapter 1: nat
    ==> arch: Forwarding ports...
        arch: 22 (guest) => 2222 (host) (adapter 1)
    ==> arch: Running 'pre-boot' VM customizations...
    ==> arch: Booting VM...
    ==> arch: Waiting for machine to boot. This may take a few minutes...
        arch: SSH address: 127.0.0.1:2222
        arch: SSH username: vagrant
        arch: SSH auth method: private key
        arch: 
        arch: Vagrant insecure key detected. Vagrant will automatically replace
        arch: this with a newly generated keypair for better security.
        arch: 
        arch: Inserting generated public key within guest...
        arch: Removing insecure key from the guest if it's present...
        arch: Key inserted! Disconnecting and reconnecting using new SSH key...
    ==> arch: Machine booted and ready!
    ==> arch: Checking for guest additions in VM...
    ==> arch: Mounting shared folders...
        arch: /vagrant => /home/oliver/Dropbox/projects/tox/tox
    vagrant up arch  11.03s user 4.81s system 12% cpu 2:06.37 total

A `vagrant ssh arch` will propell the user into the machine and they can call `tox` right away:

    16:56:31 oliver@ob1 [0] < ~/work/tox/tox >  2973 %
    vagrant ssh arch
    
    Removing all *.pyc files in mapped project ...
    [vagrant@vagrant-arch vagrant]$ tox
    
    GLOB sdist-make: /vagrant/setup.py
    py27 inst-nodeps: /vagrant/.tox/dist/tox-2.6.1.dev1.zip
    [...]

Note the "Removing all *.pyc files in mapped project ..." this is something I added to the boxes `.bashrc` and I am not 100% sure if this is the right way to go about it. This prevents pytest from borking due to mismatches in the pyc files. It would be nice if pytest would be able to deal that directly. If anyone has an idea to handle that better, please let me know.

- [ ] Make sure to include one or more tests for your change;

I tested it manually from my Host (also Arch Linux). If macOS and Windows users have trouble, I will have to look into this, but from my experience, the whole vagrant workflow is pretty solid nowadays. 

The best way to test this is to start using it.

- [ ] if an enhancement PR please create docs and at best an example

Docs are in the Vagrantfile itself for now. If this turns out useful, I will provide "proper" docs as part of #475.

- [x] Add yourself to `CONTRIBUTORS`;

- [ ] make a descriptive Pull Request text (it will be used for changelog)

Added this to the changelog myself.
