### PR TITLE
Add 'LANGUAGE' to default passed environment variables (#431)

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -212,10 +212,10 @@ Complete list of settings that you can put into ``testenv*`` sections:
    You can use ``*`` and ``?`` to match multiple environment variables with
    one name.
 
-   Note that the ``PATH``, ``LANG`` and ``PIP_INDEX_URL`` variables are
-   unconditionally passed down and on Windows ``SYSTEMROOT``, ``PATHEXT``,
-   ``TEMP`` and ``TMP`` will be passed down as well whereas on unix
-   ``TMPDIR`` will be passed down.  You can override these variables
+   Note that the ``PATH``, ``LANG``, ``LANGUAGE`` and ``PIP_INDEX_URL``
+   variables are unconditionally passed down and on Windows ``SYSTEMROOT``,
+   ``PATHEXT``, ``TEMP`` and ``TMP`` will be passed down as well whereas on
+   unix ``TMPDIR`` will be passed down.  You can override these variables
    with the ``setenv`` option.
 
    If defined the ``TOX_TESTENV_PASSENV`` environment variable (in the tox

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -869,6 +869,7 @@ class TestConfigTestEnv:
         assert "PATH" in envconfig.passenv
         assert "PIP_INDEX_URL" in envconfig.passenv
         assert "LANG" in envconfig.passenv
+        assert "LANGUAGE" in envconfig.passenv
         assert "LD_LIBRARY_PATH" in envconfig.passenv
         assert "A123A" in envconfig.passenv
         assert "A123B" in envconfig.passenv
@@ -898,6 +899,7 @@ class TestConfigTestEnv:
         assert "PATH" in envconfig.passenv
         assert "PIP_INDEX_URL" in envconfig.passenv
         assert "LANG" in envconfig.passenv
+        assert "LANGUAGE" in envconfig.passenv
         assert "A123A" in envconfig.passenv
         assert "A123B" in envconfig.passenv
 

--- a/tox/config.py
+++ b/tox/config.py
@@ -454,7 +454,9 @@ def tox_addoption(parser):
             itertools.chain.from_iterable(
                 [x.split(' ') for x in value]))
 
-        passenv = set(["PATH", "PIP_INDEX_URL", "LANG", "LD_LIBRARY_PATH"])
+        passenv = set([
+            "PATH", "PIP_INDEX_URL", "LANG", "LANGUAGE", "LD_LIBRARY_PATH"
+        ])
 
         # read in global passenv settings
         p = os.environ.get("TOX_TESTENV_PASSENV", None)


### PR DESCRIPTION
Adds `LANGUAGE` to default (and always) passed environment variables.

Fixes #431