### PR TITLE
display a short documentation with the -l/ show envlist (a concatenation of the environments description) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vagrant
 *.pyc
 *.pyo
 *.swp

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,7 @@
 
 contributions:
 
+Bernat Gabor
 Krisztian Fekete
 Marc Abramowitz
 Aleaxner Schepanovski

--- a/doc/config.txt
+++ b/doc/config.txt
@@ -337,6 +337,11 @@ Complete list of settings that you can put into ``testenv*`` sections:
     For example, ``extras = testing`` is equivalent to ``[testing]`` in a
     ``pip install`` command.
 
+.. confval:: description=SINGLE-LINE-TEXT
+
+    a short description of the environment, this will be used to explain
+    the environment to the user upon listing environments for the command
+    line. **default**: empty string
 
 Substitutions
 -------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1995,6 +1995,31 @@ class TestCmdInvocation:
             *docs*
         """)
 
+    def test_listenvs_description(self, cmd, initproj):
+        initproj('listenvs', filedefs={
+            'tox.ini': '''
+            [tox]
+            envlist={py27,py36}-{windows,linux}
+            [testenv]
+            description= py27: run py.test on Python 2.7
+                         py36: run py.test on Python 3.6
+                         windows: on Windows platform
+                         linux: on Linux platform
+                         docs: generate documentation
+            commands=py.test {posargs}
+
+            [testenv:docs]
+            changedir = docs
+            ''',
+        })
+        result = cmd.run("tox", "-l")
+        result.stdout.fnmatch_lines("""
+            py27-windows run py.test on Python 2.7 on Windows platform
+            py27-linux   run py.test on Python 2.7 on Linux platform
+            py36-windows run py.test on Python 3.6 on Windows platform
+            py36-linux   run py.test on Python 3.6 on Linux platform
+        """)
+
     def test_config_specific_ini(self, tmpdir, cmd):
         ini = tmpdir.ensure("hello.ini")
         result = cmd.run("tox", "-c", ini, "--showconfig")

--- a/tox/config.py
+++ b/tox/config.py
@@ -410,6 +410,15 @@ def tox_addoption(parser):
         help="executable name or path of interpreter used to create a "
              "virtual test environment.")
 
+    def merge_description(testenv_config, value):
+        """the reader by default joins generated description with new line,
+         replace new line with space"""
+        return value.replace('\n', ' ')
+
+    parser.add_testenv_attribute(
+        name="description", type="string", default='', postprocess=merge_description,
+        help="short description of this environment")
+
     parser.add_testenv_attribute(
         name="envtmpdir", type="path", default="{envdir}/tmp",
         help="venv temporary directory")

--- a/tox/session.py
+++ b/tox/session.py
@@ -627,8 +627,10 @@ class Session:
                                  % (attr.name, getattr(envconfig, attr.name)))
 
     def showenvs(self):
+        max_length = max(len(env) for env in self.config.envlist)
         for env in self.config.envlist:
-            self.report.line("%s" % env)
+            self.report.line("{0} {1}".format(env.ljust(max_length),
+                                              self.config.envconfigs[env].description).strip())
 
     def info_versions(self):
         versions = ['tox-%s' % tox.__version__]


### PR DESCRIPTION
This is the implementation for https://github.com/tox-dev/tox/issues/462. 

For example:
```ini
[tox]
envlist={py27,py36}-{windows,linux}
[testenv]
description= py27: run py.test on Python 2.7
             py36: run py.test on Python 3.6
             windows: on Windows platform
             linux: on Linux platform
             docs: generate documentation
commands=py.test {posargs}

[testenv:docs]
changedir = docs
```

```bash
tox -l 
py27-windows run py.test on Python 2.7 on Windows platform
py27-linux   run py.test on Python 2.7 on Linux platform
py36-windows run py.test on Python 3.6 on Windows platform
py36-linux   run py.test on Python 3.6 on Linux platform
```
