### PR TITLE
Fix two docs warnings

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -374,7 +374,7 @@ Globally available substitutions
     they may be accessed by other processes or tox runs.
 
 ``{:}``
-    OS-specific path separator (``:`` os *nix family, ``;`` on Windows). May be used in `setenv`,
+    OS-specific path separator (``:`` os \*nix family, ``;`` on Windows). May be used in `setenv`,
     when target variable is path variable (e.g. PATH or PYTHONPATH).
 
 substitutions for virtualenv-related sections

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -85,9 +85,10 @@ class VirtualEnv(object):
 
     def getcommandpath(self, name, venv=True, cwd=None):
         """ Return absolute path (str or localpath) for specified command name.
-         - If it's a local path we will rewrite it as as a relative path.
-         - If venv is True we will check if the command is coming from the venv
-           or is whitelisted to come from external.
+
+        - If it's a local path we will rewrite it as as a relative path.
+        - If venv is True we will check if the command is coming from the venv
+          or is whitelisted to come from external.
         """
         name = str(name)
         if os.path.isabs(name):


### PR DESCRIPTION
Before this:

```
/home/asottile/workspace/tox/doc/config.txt:377: WARNING: Inline emphasis start-string without end-string.
/home/asottile/workspace/tox/.tox/docs/local/lib/python2.7/site-packages/tox/venv.py:docstring of tox.venv.VirtualEnv.getcommandpath:4: ERROR: Unexpected indentation.
```

I opened up the html and verified that escaping the `*` does not alter the output.  The other file doesn't appear to affect the output but sphinx produces a warning either way.