### PR TITLE
[#271] show all defined enviroments for listenv, not just what's in envlist

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -341,7 +341,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
 
     a short description of the environment, this will be used to explain
     the environment to the user upon listing environments for the command
-    line. **default**: empty string
+    line with any level of verbosity higher than zero. **default**: empty string
 
 Substitutions
 -------------

--- a/tox/config.py
+++ b/tox/config.py
@@ -321,7 +321,12 @@ def tox_addoption(parser):
     parser.add_argument("--showconfig", action="store_true",
                         help="show configuration information for all environments. ")
     parser.add_argument("-l", "--listenvs", action="store_true",
-                        dest="listenvs", help="show list of test environments")
+                        dest="listenvs", help="show list of test environments "
+                                              "(with description if verbose)")
+    parser.add_argument("-a", "--listenvs-all", action="store_true",
+                        dest="listenvs_all",
+                        help="show list of all defined environments"
+                             "(with description if verbose)")
     parser.add_argument("-c", action="store", default="tox.ini",
                         dest="configfile",
                         help="config file name or directory with 'tox.ini' file.")


### PR DESCRIPTION
first list the automatically running environments, all other environments are printed in alphabetical order (attached to the end)

If we want to differentiate between them I would recommend having some kind of separator, e.g:

```
py27-windows run py.test on Python 2.7 on Windows platform
py27-linux   run py.test on Python 2.7 on Linux platform
py36-windows run py.test on Python 3.6 on Windows platform
py36-linux   run py.test on Python 3.6 on Linux platform
------------------------- other env ----------------------
notincluded  something else
```