### PR TITLE
With `-a`: do not show additional environments header if there are none

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Not released yet
 ----
 
 - #474: Start using setuptools_scm for tag based versioning.
+- #506: With `-a`: do not show additional environments header if there are none
 
 2.7.0
 -----

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,6 +23,7 @@ Carl Meyer
 Anthon van der Neuth
 Matt Good
 Mattieu Agopian
+Mikhail Kyshtymov
 Asmund Grammeltwedt
 Ionel Maries Cristian
 Julian Krause

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2085,6 +2085,21 @@ class TestCmdInvocation:
             docs         -> generate documentation
         """)
 
+    def test_listenvs_all_verbose_description_no_additional_environments(self, cmd, initproj):
+        initproj('listenvs_all_verbose_description', filedefs={
+            'tox.ini': '''
+            [tox]
+            envlist=py27,py36
+            ''',
+        })
+        result = cmd.run("tox", "-av")
+        result.stdout.fnmatch_lines("""
+            default environments:
+            py27 -> [no description]
+            py36 -> [no description]
+        """)
+        assert 'additional environments' not in result.stdout.str()
+
     def test_config_specific_ini(self, tmpdir, cmd):
         ini = tmpdir.ensure("hello.ini")
         result = cmd.run("tox", "-c", ini, "--showconfig")

--- a/tox/session.py
+++ b/tox/session.py
@@ -645,7 +645,7 @@ class Session:
             self.report.line(msg)
         for e in default:
             report_env(e)
-        if all_envs:
+        if all_envs and extra:
             if description:
                 self.report.line('')
                 self.report.line('additional environments:')


### PR DESCRIPTION
Closes #504