### PR TITLE
remove easy_install from documentation (issue #276)

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -99,7 +99,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
     Must contain the substitution key
     ``{packages}`` which will be replaced by the packages to
     install.  You should also accept ``{opts}`` if you are using
-    pip or easy_install -- it will contain index server options
+    pip -- it will contain index server options
     such as ``--pre`` (configured as ``pip_pre``) and potentially
     index-options from the deprecated :confval:`indexserver`
     option.

--- a/doc/example/basic.txt
+++ b/doc/example/basic.txt
@@ -151,12 +151,7 @@ By default tox uses `pip`_ to install packages, both the
 package-under-test and any dependencies you specify in ``tox.ini``.
 You can fully customize tox's install-command through the
 testenv-specific :confval:`install_command=ARGV` setting.
-For instance, to use ``easy_install`` instead of `pip`_::
-
-    [testenv]
-    install_command = easy_install {opts} {packages}
-
-Or to use pip's ``--find-links`` and ``--no-index`` options to specify
+For instance, to use pip's ``--find-links`` and ``--no-index`` options to specify
 an alternative source for your dependencies::
 
     [testenv]

--- a/doc/index.txt
+++ b/doc/index.txt
@@ -25,7 +25,7 @@ Tox is a generic virtualenv_ management and test command line tool you can use f
 Basic example
 -----------------
 
-First, install ``tox`` with ``pip install tox`` or ``easy_install tox``.
+First, install ``tox`` with ``pip install tox``.
 Then put basic information about your project and the test environments you
 want your project to run in into a ``tox.ini`` file residing
 right next to your ``setup.py`` file::

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -14,13 +14,12 @@ Install info in a nutshell
 
 **git repository**: https://github.com/tox-dev/tox
 
-Installation with pip/easy_install
+Installation with pip
 --------------------------------------
 
-Use one of the following commands::
+Use the following command::
 
    pip install tox
-   easy_install tox
 
 It is fine to install ``tox`` itself into a virtualenv_ environment.
 

--- a/doc/install.txt
+++ b/doc/install.txt
@@ -4,7 +4,7 @@ tox installation
 Install info in a nutshell
 ----------------------------------
 
-**Pythons**: CPython 2.6-3.5, Jython-2.5.1, pypy-1.9ff
+**Pythons**: CPython 2.6-3.6, Jython-2.5.1, pypy-1.9ff
 
 **Operating systems**: Linux, Windows, OSX, Unix
 


### PR DESCRIPTION
Original issue text:

AFAIK easy_install is deprecated. It confuses new users.
Please remove it from this page:
http://tox.readthedocs.org/en/latest/install.html