### PR TITLE
Also catch ENOTDIR when initializing logdir

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -44,3 +44,4 @@ Josh Smeaton
 Paweł Adamczak
 Oliver Bestwalter
 Selim Belhaouane
+Nick Douma

--- a/tox/session.py
+++ b/tox/session.py
@@ -109,7 +109,7 @@ class Action(object):
             logdir = self.session.config.logdir
         try:
             l = logdir.listdir("%s-*" % actionid)
-        except py.error.ENOENT:
+        except (py.error.ENOENT, py.error.ENOTDIR):
             logdir.ensure(dir=1)
             l = []
         num = len(l)


### PR DESCRIPTION
There is an implementation difference between CPython and Jython. On
CPython, only ENOENT is raised when the directory does not exist
(see posixmodule.c for instance). On Jython, ENOTDIR is raised when
the directory does not exist, and EACCESS is raised when there is
no read access.

This patch also catches ENOTDIR, but not EACCESS. The code flow
ensures that the logdir is created when it does not exist.

Ref #326 .

Thanks for contributing a PR!

Here's a quick checklist of what we'd like you to think off:

- [ ] Make sure to include one or more tests for your change;
- [X] Add yourself to `CONTRIBUTORS`;
- [X] make a descriptive Pull Request text (it will be used for changelog)

