### PR TITLE
Forward `USERPROFILE` by default on Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Not released yet
 
 - #474: Start using setuptools_scm for tag based versioning.
 - #506: With `-a`: do not show additional environments header if there are none
+- #518: Forward `USERPROFILE` by default on Windows.
 
 2.7.0
 -----

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -864,6 +864,7 @@ class TestConfigTestEnv:
             assert "COMSPEC" in envconfig.passenv
             assert "TEMP" in envconfig.passenv
             assert "TMP" in envconfig.passenv
+            assert "USERPROFILE" in envconfig.passenv
         else:
             assert "TMPDIR" in envconfig.passenv
         assert "PATH" in envconfig.passenv

--- a/tox/config.py
+++ b/tox/config.py
@@ -489,6 +489,7 @@ def tox_addoption(parser):
             passenv.add("COMSPEC")      # needed for distutils cygwincompiler
             passenv.add("TEMP")
             passenv.add("TMP")
+            passenv.add("USERPROFILE")  # needed for `os.path.expanduser()`.
         else:
             passenv.add("TMPDIR")
         for spec in value:


### PR DESCRIPTION
This ensures that `os.path.expanduser('~')` works by default inside a Tox
environment on Windows.

Fixes #518.

