### PR TITLE
Forward NUMBER_OF_PROCESSORS by default on Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ Not released yet
 
 - #474: Start using setuptools_scm for tag based versioning.
 - #506: With `-a`: do not show additional environments header if there are none
+- #517: Forward NUMBER_OF_PROCESSORS by default on Windows to fix
+        `multiprocessor.cpu_count()`.
 
 2.7.0
 -----

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -864,6 +864,7 @@ class TestConfigTestEnv:
             assert "COMSPEC" in envconfig.passenv
             assert "TEMP" in envconfig.passenv
             assert "TMP" in envconfig.passenv
+            assert "NUMBER_OF_PROCESSORS" in envconfig.passenv
         else:
             assert "TMPDIR" in envconfig.passenv
         assert "PATH" in envconfig.passenv

--- a/tox/config.py
+++ b/tox/config.py
@@ -489,6 +489,9 @@ def tox_addoption(parser):
             passenv.add("COMSPEC")      # needed for distutils cygwincompiler
             passenv.add("TEMP")
             passenv.add("TMP")
+            # for `multiprocessing.cpu_count()` on Windows
+            # (prior to Python 3.4).
+            passenv.add("NUMBER_OF_PROCESSORS")
         else:
             passenv.add("TMPDIR")
         for spec in value:


### PR DESCRIPTION
This fixes `multiprocessing.cpu_count()` on Windows for Python versions prior
to 3.4.

Fixes #517.