### PR TITLE
Isolate environment variable substitutions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ Not released yet
 ----
 
 - #474: Start using setuptools_scm for tag based versioning.
+- #515: Don't require environment variables in test environments
+	where they are not used.
 
 2.7.0
 -----

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1075,6 +1075,26 @@ class TestConfigTestEnv:
         assert 'FOO' in env
         assert 'BAR' in env
 
+    def test_substitution_notfound_issue515(tmpdir, newconfig):
+        config = newconfig("""
+            [tox]
+            envlist = standard-greeting
+
+            [testenv:standard-greeting]
+            commands =
+                python -c 'print("Hello, world!")'
+
+            [testenv:custom-greeting]
+            passenv =
+                NAME
+            commands =
+                python -c 'print("Hello, {env:NAME}!")'
+        """)
+        conf = config.envconfigs['standard-greeting']
+        assert conf.commands == [
+            ['python', '-c', 'print("Hello, world!")'],
+        ]
+
     @pytest.mark.xfail(raises=AssertionError, reason="issue #301")
     def test_substitution_env_defaults_issue301(tmpdir, newconfig, monkeypatch):
         monkeypatch.setenv("IGNORE_STATIC_DEFAULT", "env")


### PR DESCRIPTION
Perform `{env:X}` replacement only in environments where `X` is used.  This
enables different environments to use different subsets of the environment
(e.g. don't require union of all passenv sections in all environments).

Fixes #515.

**Note to reviewers**: this is a tentative fix.  I'm definitely not sure how to best proceed with this fix.  Feel free to recommend an alternate approach!