### PR TITLE
document environments for projects tox.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.orig
 *.rej
 *~
+__pycache__
 
 build
 dist
@@ -14,3 +15,7 @@ doc/_build/
 tox.egg-info
 .tox
 .cache
+
+.idea
+.eggs/
+py27/

--- a/tox.ini
+++ b/tox.ini
@@ -1,49 +1,50 @@
 [tox]
-envlist=py27,py26,py34,py33,py35,py36,pypy,flakes,py26-bare
+envlist = py27,py26,py34,py33,py35,py36,pypy,flakes,py26-bare
+minversion = 2.7.0
 
 [testenv:X]
-commands=echo {posargs}
+commands = echo {posargs}
+description = print the positional arguments passed in with echo
 
 [testenv]
-commands= pytest --timeout=180 {posargs:tests}
-
-deps=pytest>=3.0.0
-    pytest-timeout
+commands = pytest --timeout=180 {posargs:tests}
+description = run the unit tests with PyTest under the current Python env
+deps = pytest >= 3.0.0
+       pytest-timeout
 
 [testenv:py26-bare]
 deps =
 commands = tox -h
 install_command = pip install {opts} {packages}
 list_dependencies_command = pip freeze
+description = invoke the tox help message under Python 2.6
 
 [testenv:py26]
 install_command = pip install {opts} {packages}
 list_dependencies_command = pip freeze
 
-
 [testenv:docs]
-basepython=python
-changedir=doc
-deps=sphinx
-     {[testenv]deps}
-commands=
-    pytest -v check_sphinx.py {posargs}
+basepython = python
+changedir = doc
+deps = sphinx
+       {[testenv]deps}
+commands = pytest -v check_sphinx.py {posargs}
+description = invoke sphinx-build and try to build the HTML page (also check link validity)
 
 [testenv:flakes]
-deps = pytest-flakes>=0.2
+deps = pytest-flakes >= 0.2
        pytest-pep8
-
-commands =
-    pytest --flakes -m flakes tox tests
-    pytest --pep8 -m pep8 tox tests
+description = run static analysis and style check using flakes and pep-8
+commands = pytest --flakes -m flakes tox tests
+           pytest --pep8 -m pep8 tox tests
 
 [testenv:dev]
 # required to make looponfail reload on every source code change
 usedevelop = True
 
-deps =
-      pytest-xdist>=1.11
-commands = {posargs:pytest -s -x -f -v}
+deps = pytest-xdist >= 1.11
+commands = {posargs:py.test -s -x -f -v}
+description = DEV enviroment, if no posarg is specified run PyTest
 
 [pytest]
 rsyncdirs = tests tox
@@ -57,6 +58,5 @@ pep8maxlinelength = 99
 # W503 - line break before binary operator
 # E402 - module level import not at top of file
 # E731 - do not assign a lambda expression, use a def
-pep8ignore =
-           *.py W503 E402 E731
+pep8ignore = *.py W503 E402 E731
 flakes-ignore = ImportStarUsage

--- a/tox/config.py
+++ b/tox/config.py
@@ -834,7 +834,7 @@ class parseini:
                 res = env_attr.postprocess(testenv_config=vc, value=res)
             setattr(vc, env_attr.name, res)
 
-            if atype == "path":
+            if atype in ("path", "string"):
                 reader.addsubstitutions(**{env_attr.name: res})
 
         return vc


### PR DESCRIPTION
- also now all config values can be substituted (so e.g. basepython can be used inside the description)
- ignore IDEA project files