### PR TITLE
Use $XDG_CACHE_HOME by default for distshare

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Not released yet
 ----
 
+- #346: Use $XDG_CACHE_HOME by default for distshare
 - #474: Start using setuptools_scm for tag based versioning.
 - #506: With `-a`: do not show additional environments header if there are none
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -46,3 +46,4 @@ Paweł Adamczak
 Oliver Bestwalter
 Selim Belhaouane
 Nick Douma
+Jerome Leclanche

--- a/doc/config.txt
+++ b/doc/config.txt
@@ -19,7 +19,7 @@ List of optional global options::
     toxworkdir=path   # tox working directory, defaults to {toxinidir}/.tox
     setupdir=path     # defaults to {toxinidir}
     distdir=path      # defaults to {toxworkdir}/dist
-    distshare=path    # (DEPRECATED) defaults to {homedir}/.tox/distshare
+    distshare=path    # (DEPRECATED) defaults to $XDG_CACHE_HOME/tox/distshare
     envlist=ENVLIST   # defaults to the list of all environments
     skipsdist=BOOL    # defaults to false
 

--- a/doc/example/general.txt
+++ b/doc/example/general.txt
@@ -102,8 +102,10 @@ that another tox run can find the "latest" dependency.  This feature
 allows to test a package against an unreleased development version
 or even an uncommitted version on your own machine.
 
-By default, ``{homedir}/.tox/distshare`` will be used for
-copying in and copying out artifacts (i.e. Python packages).
+By default, the distshare directory is located in
+``$XDG_CACHE_HOME/tox/distshare``, where ``$XDG_CACHE_HOME`` defaults to
+``{homedir}`` if not set. This directory will be used for copying in and
+copying out artifacts (i.e. Python packages).
 
 For project ``two`` to depend on the ``one`` package you use
 the following entry::

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -178,7 +178,13 @@ class TestConfigPackage:
 
     def test_defaults_distshare(self, tmpdir, newconfig):
         config = newconfig([], "")
-        assert config.distshare == config.homedir.join(".tox", "distshare")
+        assert config.distshare == config.homedir.join(".cache", "tox", "distshare")
+
+    def test_defaults_distshare_xdg_set(self, tmpdir, newconfig):
+        xdg_cache = str(tmpdir.join("tox-xdg-cache-test"))
+        os.environ["XDG_CACHE_HOME"] = xdg_cache
+        config = newconfig([], "")
+        assert config.distshare == os.path.join(xdg_cache, "tox", "distshare")
 
     def test_defaults_changed_dir(self, tmpdir, newconfig):
         tmpdir.mkdir("abc").chdir()
@@ -1060,7 +1066,7 @@ class TestConfigTestEnv:
         assert argv[4][0] == conf.envtmpdir
         assert argv[5][0] == conf.envpython
         assert argv[6][0] == str(config.homedir)
-        assert argv[7][0] == config.homedir.join(".tox", "distshare")
+        assert argv[7][0] == config.distshare
         assert argv[8][0] == conf.envlogdir
 
     def test_substitution_notfound_issue246(tmpdir, newconfig):

--- a/tox/config.py
+++ b/tox/config.py
@@ -699,7 +699,8 @@ class parseini:
             distshare_default = "{toxworkdir}/distshare"
         elif not ctxname:
             reader = SectionReader("tox", self._cfg, prefix=prefix)
-            distshare_default = "{homedir}/.tox/distshare"
+            xdg_cache_home = os.getenv("XDG_CACHE_HOME", "{homedir}/.cache")
+            distshare_default = os.path.join(xdg_cache_home, "tox", "distshare")
         else:
             raise ValueError("invalid context")
 


### PR DESCRIPTION
Closes #346

https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html

This defaults distshare to $XDG_CACHE_HOME. Per the spec, if that variable is not defined, $HOME/cache is used (os.path.expanduser("~") is windows-compatible as well). All this removes extraneous clutter in $HOME.

----

- [x] Make sure to include one or more tests for your change;
- [x] if an enhancement PR please create docs and at best an example
- [x] Add yourself to `CONTRIBUTORS`;
- [x] make a descriptive Pull Request text (it will be used for changelog)

