### PR TITLE
Allow tests to be run through a user-defined hook.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -46,3 +46,4 @@ Paweł Adamczak
 Oliver Bestwalter
 Selim Belhaouane
 Nick Douma
+Cyril Roelandt

--- a/tox/hookspecs.py
+++ b/tox/hookspecs.py
@@ -88,6 +88,15 @@ def tox_runtest_pre(venv):
     """
 
 
+@hookspec(firstresult=True)
+def tox_runtest(venv, redirect):
+    """ [experimental] run the tests for this venv.
+
+    .. note:: This hook uses ``firstresult=True`` (see pluggy_) -- hooks
+        implementing this will be run until one returns non-``None``.
+    """
+
+
 @hookspec
 def tox_runtest_post(venv):
     """ [experimental] perform arbitrary action after running tests for this venv.

--- a/tox/session.py
+++ b/tox/session.py
@@ -571,7 +571,7 @@ class Session:
             if venv.status:
                 return
             self.hook.tox_runtest_pre(venv=venv)
-            venv.test(redirect=redirect)
+            self.hook.tox_runtest(venv=venv, redirect=redirect)
             self.hook.tox_runtest_post(venv=venv)
         else:
             venv.status = "skipped tests"

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -455,3 +455,10 @@ def tox_testenv_install_deps(venv, action):
         venv._install(deps, action=action)
     # Return non-None to indicate the plugin has completed
     return True
+
+
+@hookimpl
+def tox_runtest(venv, redirect):
+    venv.test(redirect=redirect)
+    # Return non-None to indicate the plugin has completed
+    return True


### PR DESCRIPTION
Currently, users can only extend/overwrite the pre/post phases. They should be able to change the way the tests are run. This would be useful to implement a GNU Guix backend, for instance.