### PR TITLE
Adding --help and --version command-line arguments to tox-quickstart

### DIFF
--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -379,6 +379,106 @@ deps =
         result = read_tox('tox-generated.ini')
         assert(result == expected_tox_ini)
 
+    def test_quickstart_main_tox_ini_location_can_be_overridden(
+            self,
+            tmpdir,
+            monkeypatch):
+        monkeypatch.setattr(
+            tox._quickstart, 'term_input',
+            self.get_mock_term_input(
+                [
+                    '1',          # py27 and py33
+                    'py.test',    # command to run tests
+                    '',            # test dependencies
+                ]
+            )
+        )
+
+        root_dir = tmpdir.mkdir('alt-root')
+        tox_ini_path = root_dir.join('tox.ini')
+
+        tox._quickstart.main(argv=['tox-quickstart', root_dir.basename])
+
+        assert tox_ini_path.isfile()
+
+        expected_tox_ini = """
+# Tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27
+
+[testenv]
+commands = py.test
+deps =
+    pytest
+""".lstrip()
+        result = read_tox(fname=tox_ini_path.strpath)
+        assert(result == expected_tox_ini)
+
+    def test_quickstart_main_custom_tox_ini_location_with_existing_tox_ini(
+            self,
+            tmpdir,
+            monkeypatch):
+        monkeypatch.setattr(
+            tox._quickstart, 'term_input',
+            self.get_mock_term_input(
+                [
+                    '1',          # py27 and py33
+                    'py.test',    # command to run tests
+                    '',            # test dependencies
+                    '',           # tox.ini already exists; overwrite?
+                ]
+            )
+        )
+
+        root_dir = tmpdir.mkdir('alt-root')
+        tox_ini_path = root_dir.join('tox.ini')
+        tox_ini_path.write('foo\nbar\n')
+
+        tox._quickstart.main(argv=['tox-quickstart', root_dir.basename])
+        tox_ini_path = root_dir.join('tox-generated.ini')
+
+        assert tox_ini_path.isfile()
+
+        expected_tox_ini = """
+# Tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27
+
+[testenv]
+commands = py.test
+deps =
+    pytest
+""".lstrip()
+        result = read_tox(fname=tox_ini_path.strpath)
+        assert(result == expected_tox_ini)
+
+    def test_quickstart_main_custom_nonexistent_tox_ini_location(
+            self,
+            tmpdir,
+            monkeypatch):
+        monkeypatch.setattr(
+            tox._quickstart, 'term_input',
+            self.get_mock_term_input(
+                [
+                    '1',          # py27 and py33
+                    'py.test',    # command to run tests
+                    '',           # test dependencies
+                ]
+            )
+        )
+
+        root_dir = tmpdir.join('nonexistent-root')
+
+        assert tox._quickstart.main(argv=['tox-quickstart', root_dir.basename]) == 2
+
 
 class TestToxQuickstart(object):
     def test_pytest(self):

--- a/tox/_quickstart.py
+++ b/tox/_quickstart.py
@@ -40,6 +40,7 @@
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
+import argparse
 import sys
 from os import path
 from codecs import open
@@ -256,14 +257,25 @@ Execute `tox` to test your project.
 ''')
 
 
-def main(argv=sys.argv):
-    d = {}
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description='Command-line script to quickly setup tox.ini for a Python project.'
+    )
+    parser.add_argument(
+        'root', type=str, nargs='?', default='.',
+        help='Custom root directory to write tox.ini to. Defaults to current directory.'
+    )
+    parser.add_argument('--version', action='version', version='%(prog)s ' + __version__)
 
-    if len(argv) > 3:
-        print('Usage: tox-quickstart [root]')
-        return 1
-    elif len(argv) == 2:
-        d['path'] = argv[1]
+    args = argv[1:]
+    return parser.parse_args(args)
+
+
+def main(argv=sys.argv):
+    args = parse_args(argv)
+
+    d = {}
+    d['path'] = args.root
 
     try:
         ask_user(d)

--- a/tox/_quickstart.py
+++ b/tox/_quickstart.py
@@ -224,19 +224,24 @@ def generate(d, overwrite=True, silent=False):
 
     def write_file(fpath, mode, content):
         print('Creating file %s.' % fpath)
-        f = open(fpath, mode, encoding='utf-8')
         try:
-            f.write(content)
-        finally:
-            f.close()
+            with open(fpath, mode, encoding='utf-8') as f:
+                f.write(content)
+        except IOError:
+            print('Error writing file.')
+            raise
 
     sys.stdout.write('\n')
 
-    fpath = 'tox.ini'
+    fpath = path.join(d.get('path', ''), 'tox.ini')
 
     if path.isfile(fpath) and not overwrite:
         print('File %s already exists.' % fpath)
-        do_prompt(d, 'fpath', 'Alternative path to write tox.ini contents to', 'tox-generated.ini')
+        do_prompt(
+            d,
+            'fpath',
+            'Alternative path to write tox.ini contents to',
+            path.join(d.get('path', ''), 'tox-generated.ini'))
         fpath = d['fpath']
 
     write_file(fpath, 'w', conf_text)
@@ -268,7 +273,10 @@ def main(argv=sys.argv):
         return
 
     d = process_input(d)
-    generate(d, overwrite=False)
+    try:
+        generate(d, overwrite=False)
+    except Exception:
+        return 2
 
     return 0
 

--- a/tox/_quickstart.py
+++ b/tox/_quickstart.py
@@ -256,7 +256,7 @@ def main(argv=sys.argv):
 
     if len(argv) > 3:
         print('Usage: tox-quickstart [root]')
-        sys.exit(1)
+        return 1
     elif len(argv) == 2:
         d['path'] = argv[1]
 
@@ -270,6 +270,8 @@ def main(argv=sys.argv):
     d = process_input(d)
     generate(d, overwrite=False)
 
+    return 0
+
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Fixes #315 . There was only one command line argument parsed before but it was unused. I've fixed and tested its usage too.

Additional notes:
- argparse is used to parse command line arguments instead of the previous hand-made logic
- The positional argument for custom root directory is still optional, however defaulted to `.` to simplify logic. 

---

Thanks for contributing a PR!

Here's a quick checklist of what we'd like you to think off:

- [x] Make sure to include one or more tests for your change;
- [ ] if an enhancement PR please create docs and at best an example
- [ ] Add yourself to `CONTRIBUTORS`;
- [ ] make a descriptive Pull Request text (it will be used for changelog)
