### PR TITLE
Report more meaningful errors on why virtualenv creation failed

### DIFF
--- a/tox/session.py
+++ b/tox/session.py
@@ -449,8 +449,19 @@ class Session:
             envlog = self.resultlog.get_envlog(venv.name)
             try:
                 status = venv.update(action=action)
-            except tox.exception.InvocationError:
-                status = sys.exc_info()[1]
+            except FileNotFoundError as e:
+                status = (
+                    "Error creating virtualenv. "
+                    "Note that spaces in path are not supported by virtualenv. "
+                    "Error details: %r" % e
+                )
+            except tox.exception.InvocationError as e:
+                status = (
+                    "Error creating virtualenv. "
+                    "Note that some special characters (such as ':' and unicode symbols) "
+                    "in path are not supported by virtualenv. "
+                    "Error details: %r" % e
+                )
             if status:
                 commandlog = envlog.get_commandlog("setup")
                 commandlog.add_command(["setup virtualenv"], str(status), 1)


### PR DESCRIPTION
`virtualenv` fails if the destination directory contains unicode characters or spaces. A more descriptive error is printed if it's likely that that was the case.
As long as the upstream problem exists #121 cannot be fixed.

Open questions:

- [x] Should hard-fail even before executing `virtualenv` if the destination directory contains unsupported characters? -- I choosed not to in order to not block support of such paths if upstream is fixed
- [x] Should check for unsupported characters and only print error message about them if they are found? -- I decided not to, because testing this part of the code would be very hard and I don't like the idea to introduce logic without tests. I could abstract away the error reporting of venv.update() calls and test it in isolation if needed.

---

Thanks for contributing a PR!

Here's a quick checklist of what we'd like you to think off:

- [ ] Make sure to include one or more tests for your change;
- [ ] if an enhancement PR please create docs and at best an example
- [ ] Add yourself to `CONTRIBUTORS`;
- [ ] make a descriptive Pull Request text (it will be used for changelog)

