### PR TITLE
config: expand nested substitutions (fixes #301)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,3 +48,4 @@ Selim Belhaouane
 Nick Douma
 Cyril Roelandt
 Bartolome Sanchez Salado
+Laszlo Vasko

--- a/doc/config.txt
+++ b/doc/config.txt
@@ -435,6 +435,14 @@ then the value will be retrieved as ``os.environ['KEY']``
 and replace with and empty string if the environment variable does not
 exist.
 
+Substitutions can also be nested. In that case they are expanded starting
+from the innermost expression::
+
+    {env:KEY:{env:DEFAULT_OF_KEY}}
+
+the above example is roughly equivalent to
+``os.environ.get('KEY', os.environ['DEFAULT_OF_KEY'])``
+
 .. _`command positional substitution`:
 .. _`positional substitution`:
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1088,8 +1088,7 @@ class TestConfigTestEnv:
         assert 'FOO' in env
         assert 'BAR' in env
 
-    @pytest.mark.xfail(raises=AssertionError, reason="issue #301")
-    def test_substitution_env_defaults_issue301(tmpdir, newconfig, monkeypatch):
+    def test_substitution_nested_env_defaults_issue301(tmpdir, newconfig, monkeypatch):
         monkeypatch.setenv("IGNORE_STATIC_DEFAULT", "env")
         monkeypatch.setenv("IGNORE_DYNAMIC_DEFAULT", "env")
         config = newconfig("""

--- a/tox/config.py
+++ b/tox/config.py
@@ -1059,8 +1059,20 @@ class Replacer:
         self.reader = reader
         self.crossonly = crossonly
 
-    def do_replace(self, x):
-        return self.RE_ITEM_REF.sub(self._replace_match, x)
+    def do_replace(self, value):
+        '''
+        Recursively expand substitutions starting from the innermost expression
+        '''
+        def substitute_once(x):
+            return self.RE_ITEM_REF.sub(self._replace_match, x)
+
+        expanded = substitute_once(value)
+
+        while expanded != value:  # substitution found
+            value = expanded
+            expanded = substitute_once(value)
+
+        return expanded
 
     def _replace_match(self, match):
         g = match.groupdict()


### PR DESCRIPTION
In case of a nested substitution values are expanded starting from the
innermost expression and continued until no successful substitutions
could be found.

Thanks for contributing a PR!

Here's a quick checklist of what we'd like you to think off:

- [x] Make sure to include one or more tests for your change;
- [x] if an enhancement PR please create docs and at best an example
- [x] Add yourself to `CONTRIBUTORS`;
- [x] make a descriptive Pull Request text (it will be used for changelog)

