### PR TITLE
Fixing #571. skip_install should override usedevelop

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Not released yet
 - #517: Forward NUMBER_OF_PROCESSORS by default on Windows to fix
         `multiprocessor.cpu_count()`.
 - #518: Forward `USERPROFILE` by default on Windows.
+- #571: skip_install should override usedevelop
 
 2.7.0
 -----

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -49,3 +49,4 @@ Nick Douma
 Cyril Roelandt
 Bartolome Sanchez Salado
 Laszlo Vasko
+Fernando L. Pereira

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -2,6 +2,7 @@ import tox
 import py
 import pytest
 from tox._pytestplugin import ReportExpectMock
+import platform
 try:
     import json
 except ImportError:
@@ -638,6 +639,17 @@ def test_test_usedevelop(cmd, initproj, src_root):
     assert "develop-inst-nodeps" in result.stdout.str()
 
 
+def _alwayscopy_not_supported():
+    # This is due to virtualenv bugs with alwayscopy in some platforms
+    # see: https://github.com/pypa/virtualenv/issues/565
+    if hasattr(platform, 'linux_distribution'):
+        _dist = platform.linux_distribution(full_distribution_name=False)
+        if _dist[0] == 'centos' and _dist[1][0] == '7':
+            return True
+    return False
+
+
+@pytest.mark.skipif(_alwayscopy_not_supported(), reason="Platform doesnt support alwayscopy")
 def test_alwayscopy(initproj, cmd):
     initproj("example123", filedefs={'tox.ini': """
             [testenv]

--- a/tox/session.py
+++ b/tox/session.py
@@ -16,6 +16,10 @@ from tox.venv import VirtualEnv
 from tox.config import parseconfig
 from tox.result import ResultLog
 from subprocess import STDOUT
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
 
 
 def now():
@@ -552,12 +556,15 @@ class Session:
             return
         for venv in self.venvlist:
             if self.setupenv(venv):
-                if venv.envconfig.usedevelop:
-                    self.developpkg(venv, self.config.setupdir)
-                elif self.config.skipsdist or venv.envconfig.skip_install:
+                if venv.envconfig.skip_install:
                     self.finishvenv(venv)
                 else:
-                    self.installpkg(venv, path)
+                    if venv.envconfig.usedevelop:
+                        self.developpkg(venv, self.config.setupdir)
+                    elif self.config.skipsdist:
+                        self.finishvenv(venv)
+                    else:
+                        self.installpkg(venv, path)
 
                 # write out version dependency information
                 action = self.newaction(venv, "envreport")


### PR DESCRIPTION
From the discussion in #270 one realises the need of supporting both skip_install and usedevelop together, with skip_install having priority (usedevelop being considered as an install option).
This PR implements such change.

For the tests to run also in py27 it was necessary to fix using FileNotFoundError
Also, in centos7 virtualenv alwayscopy is broken, so for the moment it detects the platform and skips the test. 
Fixes #571 