### PR TITLE
Groundwork for supporting PEP-518/`pyproject.toml`

### DIFF
--- a/tox/config.py
+++ b/tox/config.py
@@ -595,9 +595,25 @@ def tox_addoption(parser):
     parser.add_testenv_attribute_obj(InstallcmdOption())
 
     parser.add_testenv_attribute(
+        name="install_setuptools", type="bool", default=True,
+        help="If true the ``setuptools`` and ``wheel`` packages will "
+             "automatically be installed into the virtual environment.")
+
+    def list_dependencies_command(testenv_config, value):
+        using_setuptools = testenv_config.install_setuptools
+
+        # Display setuptools and wheel when listing dependencies of an
+        # environment where they are not present by default
+        if value == ["pip", "freeze"] and not using_setuptools:
+            value.append("--all")
+
+        return value
+
+    parser.add_testenv_attribute(
         name="list_dependencies_command",
         type="argv",
         default="pip freeze",
+        postprocess=list_dependencies_command,
         help="list dependencies for a virtual environment")
 
     parser.add_testenv_attribute_obj(DepOption())

--- a/tox/config.py
+++ b/tox/config.py
@@ -673,6 +673,14 @@ class TestenvConfig:
         check later when the testenv is actually run and crash only then.
         """
 
+    def __str__(self):
+        return "<{0}: config={2!r}, envname={3!r}, factors={4!r} at 0x{1:x}>".format(
+            self.__class__.__name__, id(self),
+            self.config,
+            self.envname,
+            self.factors
+        )
+
     def get_envbindir(self):
         """ path to directory where scripts/binaries reside. """
         if sys.platform == "win32" and "jython" not in self.basepython and \

--- a/tox/config.py
+++ b/tox/config.py
@@ -856,6 +856,12 @@ class parseini:
             for env in _split_env(stated_envlist):
                 known_factors.update(env.split('-'))
 
+        # sdist creation environment
+        config.sdist_envconfig = self.make_envconfig(
+            "sdist", "toxenv:sdist", reader._subs, config, replace=True,
+            fallbacksections=[]
+        )
+
         # configure testenvs
         for name in all_envs:
             section = testenvprefix + name
@@ -867,6 +873,7 @@ class parseini:
                           config.envconfigs[name].usedevelop for name in config.envlist)
 
         config.skipsdist = reader.getbool("skipsdist", all_develop)
+        config.venvsdist = reader.getbool("venvsdist", False)
 
     def _list_section_factors(self, section):
         factors = set()
@@ -876,10 +883,14 @@ class parseini:
                 factors.update(*mapcat(_split_factor_expr_all, exprs))
         return factors
 
-    def make_envconfig(self, name, section, subs, config, replace=True):
+    def make_envconfig(self, name, section, subs, config, replace=True,
+                       fallbacksections=None):
+        if fallbacksections is None:
+            fallbacksections = ["testenv"]
+
         factors = set(name.split('-'))
-        reader = SectionReader(section, self._cfg, fallbacksections=["testenv"],
-                               factors=factors)
+        reader = SectionReader(section, self._cfg, factors=factors,
+                               fallbacksections=fallbacksections)
         tc = TestenvConfig(name, config, factors, reader)
         reader.addsubstitutions(
             envname=name, envbindir=tc.get_envbindir, envsitepackagesdir=tc.get_envsitepackagesdir,

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -430,6 +430,8 @@ def tox_testenv_create(venv, action):
         args.append('--system-site-packages')
     if venv.envconfig.alwayscopy:
         args.append('--always-copy')
+    if not venv.envconfig.install_setuptools:
+        args.extend(['--no-setuptools', '--no-wheel'])
     # add interpreter explicitly, to prevent using
     # default (virtualenv.ini)
     args.extend(['--python', str(config_interpreter)])

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -22,6 +22,14 @@ class CreationConfig:
         self.alwayscopy = alwayscopy
         self.deps = deps
 
+    def __str__(self):
+        return ("<{0}: alwayscopy={2!r}, deps={3!r}, md5={4!r}, python={5!r}, "
+                "sitepackages={6!r}, version={7!r}, usedevelop={8!r}"
+                " at 0x{1:x}>").format(
+            self.__class__.__name__, id(self),
+            self.alwayscopy, self.deps, self.md5, self.python,
+            self.sitepackages, self.version, self.usedevelop)
+
     def writeconfig(self, path):
         lines = ["%s %s" % (self.md5, self.python)]
         lines.append("%s %d %d %d" % (self.version, self.sitepackages,


### PR DESCRIPTION
This PR currently adds two new options:

  * `install_setuptools` (defaulting to `True`) to the per-testenv settings
  * `venvsdist` (defaulting to `False`) to the global `tox` settings

When `venvsdist` is `True` and a sdist is to be created then tox will provision a new virtual environment and run `./setup.py sdist` in there. All settings for that environment (except `changedir`, `commands` & `list_dependencies_command`) can be tweaked using the new `toxenv:sdist` configuration section.

(All new introduced names are ofc subject to change at your leisure.)

.

Here's a quick checklist of things that will be done once the current set of changes has been ACK'ed:

- [ ] Make sure to include one or more tests for your change;
- [ ] if an enhancement PR please create docs and at best an example
- [ ] Add yourself to `CONTRIBUTORS`;
- [ ] make a descriptive Pull Request text (it will be used for changelog)

