### PR TITLE
[STYLE] Move to flake8, add bugbear, and also check doc and setup.py files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - TOXENV: flakes
+    - TOXENV: style
     - TOXENV: py26
     - TOXENV: py27
     - TOXENV: py33

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import setuptools
 from setuptools.command.test import test as TestCommand
 
 
-
 class Tox(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -14,9 +13,10 @@ class Tox(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
+        # import here, cause outside the eggs aren't loaded
         import tox
         tox.cmdline(self.test_args)
+
 
 def has_environment_marker_support():
     """
@@ -32,7 +32,8 @@ def has_environment_marker_support():
     """
     import pkg_resources
     try:
-        return pkg_resources.parse_version(setuptools.__version__) >= pkg_resources.parse_version('0.7.2')
+        v = pkg_resources.parse_version(setuptools.__version__)
+        return v >= pkg_resources.parse_version('0.7.2')
     except Exception as exc:
         sys.stderr.write("Could not test setuptool's version: %s\n" % exc)
         return False
@@ -109,8 +110,9 @@ def main():
             'Topic :: Software Development :: Libraries',
             'Topic :: Utilities'] + [
             ('Programming Language :: Python :: %s' % x) for x in
-                  '2 2.6 2.7 3 3.3 3.4 3.5 3.6'.split()]
+            '2 2.6 2.7 3 3.3 3.4 3.5 3.6'.split()]
     )
+
 
 if __name__ == '__main__':
     main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1380,7 +1380,10 @@ class TestConfigTestEnv:
                 {a,b}-y: dep-ab-and-y
         """
         configs = newconfig([], inisource).envconfigs
-        get_deps = lambda env: [dep.name for dep in configs[env].deps]
+
+        def get_deps(env):
+            return [dep.name for dep in configs[env].deps]
+
         assert get_deps("a-x") == ["dep-a-or-b", "dep-a-and-x"]
         assert get_deps("a-y") == ["dep-a-or-b", "dep-ab-and-y"]
         assert get_deps("b-x") == ["dep-a-or-b"]
@@ -1664,7 +1667,10 @@ class TestHashseedOption:
                 [testenv]
             """
         if make_hashseed is None:
-            make_hashseed = lambda: '123456789'
+
+            def make_hashseed():
+                return '123456789'
+
         original_make_hashseed = tox.config.make_hashseed
         tox.config.make_hashseed = make_hashseed
         try:

--- a/tests/test_interpreters.py
+++ b/tests/test_interpreters.py
@@ -1,9 +1,12 @@
 import sys
 import os
 
+import py
 import pytest
-from tox.interpreters import *  # noqa
+
 from tox.config import get_plugin_manager
+from tox.interpreters import Interpreters, locate_via_py, tox_get_python_executable,\
+    run_and_get_interpreter_info
 
 
 @pytest.fixture

--- a/tests/test_interpreters.py
+++ b/tests/test_interpreters.py
@@ -5,7 +5,7 @@ import py
 import pytest
 
 from tox.config import get_plugin_manager
-from tox.interpreters import Interpreters, locate_via_py, tox_get_python_executable,\
+from tox.interpreters import Interpreters, tox_get_python_executable, \
     run_and_get_interpreter_info
 
 
@@ -30,6 +30,7 @@ def test_locate_via_py(monkeypatch):
         return PseudoPy()
     # Monkeypatch py.path.local.sysfind to return PseudoPy
     monkeypatch.setattr(py.path.local, 'sysfind', ret_pseudopy)
+    from tox.interpreters import locate_via_py
     assert locate_via_py('3', '2') == sys.executable
 
 

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -20,7 +20,7 @@ class TestToxQuickstartMain(object):
             try:
                 return next(generator)
             except NameError:
-                return generator.next()
+                return generator.next()  # noqa
 
         return mock_term_input
 

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -4,10 +4,10 @@ import pytest
 import os
 import sys
 import tox.config
-from tox.venv import *  # noqa
 from tox.hookspecs import hookimpl
 from tox.interpreters import NoInterpreterInfo
-
+from tox.venv import VirtualEnv, tox_testenv_create, tox_testenv_install_deps, CreationConfig,\
+    getdigest
 
 # def test_global_virtualenv(capfd):
 #    v = VirtualEnv()
@@ -402,7 +402,7 @@ def test_install_python3(tmpdir, newmocksession):
     assert len(l) == 1
     args = l[0].args
     assert "pip" in args[0]
-    for x in args:
+    for _ in args:
         assert "--download-cache" not in args, args
 
 

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -10,8 +10,8 @@ except ImportError:
 
 pytest_plugins = "pytester"
 
-from tox.session import Session
-from tox.config import parseconfig
+from tox.session import Session  # noqa #E402 module level import not at top of file
+from tox.config import parseconfig  # noqa #E402 module level import not at top of file
 
 
 def test_report_protocol(newconfig):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py26,py34,py33,py35,py36,pypy,flakes,py26-bare,docs
+envlist = py27,py26,py34,py33,py35,py36,pypy,style,py26-bare,docs
 minversion = 2.7.0
 
 [testenv]
@@ -29,12 +29,16 @@ passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE
 commands = sphinx-build -d .tox/docs_doctree doc .tox/docs_out --color -W -bhtml
            sphinx-build -d .tox/docs_doctree doc .tox/docs_out --color -W -blinkcheck
 
-[testenv:flakes]
-deps = pytest-flakes >= 0.2
-       pytest-pep8
-description = run static analysis and style check using flakes and pep-8
-commands = pytest --flakes -m flakes tox tests
-           pytest --pep8 -m pep8 tox tests
+[testenv:style]
+basepython = python3.6
+deps = flake8 == 3.4.1
+       flake8-bugbear == 17.4.0
+description = run static analysis and style check using flake8
+commands = python -m flake8 --show-source tox setup.py {posargs}
+           python -m flake8 --show-source doc tests {posargs}
+[flake8]
+max-complexity = 22
+max-line-length = 99
 
 [testenv:py26-bare]
 description = invoke the tox help message under Python 2.6
@@ -87,10 +91,4 @@ addopts = -rsxX
 rsyncdirs = tests tox
 looponfailroots = tox tests
 norecursedirs = .hg .tox
-pep8maxlinelength = 99
-# W503 - line break before binary operator
-# E402 - module level import not at top of file
-# E731 - do not assign a lambda expression, use a def
-pep8ignore = *.py W503 E402 E731
-flakes-ignore = ImportStarUsage
 xfail_strict = True

--- a/tox/__init__.py
+++ b/tox/__init__.py
@@ -1,6 +1,6 @@
 from pkg_resources import get_distribution, DistributionNotFound
 
-from .hookspecs import hookspec, hookimpl  # noqa
+from .hookspecs import hookspec, hookimpl
 
 try:
     _full_version = get_distribution(__name__).version
@@ -43,3 +43,5 @@ class exception:
 
 
 from tox.session import main as cmdline  # noqa
+
+__all__ = ('hookspec', 'hookimpl', 'cmdline', 'exception', '__version__')

--- a/tox/_quickstart.py
+++ b/tox/_quickstart.py
@@ -47,7 +47,7 @@ from codecs import open
 
 TERM_ENCODING = getattr(sys.stdin, 'encoding', None)
 
-from tox import __version__
+from tox import __version__  # noqa #E402 module level import not at top of file
 
 # function to get input from terminal -- overridden by the test suite
 try:

--- a/tox/_verlib.py
+++ b/tox/_verlib.py
@@ -25,6 +25,7 @@ class HugeMajorVersionNumError(IrrationalVersionError):
     """
     pass
 
+
 # A marker used in the second and third parts of the `parts` tuple, for
 # versions that don't have those segments, to sort properly. An example
 # of versions in sort order ('highest' last):

--- a/tox/config.py
+++ b/tox/config.py
@@ -622,9 +622,8 @@ class TestenvConfig:
 
     def get_envbindir(self):
         """ path to directory where scripts/binaries reside. """
-        if (sys.platform == "win32"
-                and "jython" not in self.basepython
-                and "pypy" not in self.basepython):
+        if sys.platform == "win32" and "jython" not in self.basepython and \
+           "pypy" not in self.basepython:
             return self.envdir.join("Scripts")
         else:
             return self.envdir.join("bin")
@@ -803,9 +802,8 @@ class parseini:
             if section in self._cfg or factors <= known_factors:
                 config.envconfigs[name] = self.make_envconfig(name, section, reader._subs, config)
 
-        all_develop = all(name in config.envconfigs
-                          and config.envconfigs[name].usedevelop
-                          for name in config.envlist)
+        all_develop = all(name in config.envconfigs and
+                          config.envconfigs[name].usedevelop for name in config.envlist)
 
         config.skipsdist = reader.getbool("skipsdist", all_develop)
 

--- a/tox/interpreters.py
+++ b/tox/interpreters.py
@@ -123,6 +123,7 @@ class NoInterpreterInfo:
         else:
             return "<executable not found for: %s>" % self.name
 
+
 if sys.platform != "win32":
     @hookimpl
     def tox_get_python_executable(envconfig):

--- a/tox/session.py
+++ b/tox/session.py
@@ -46,7 +46,7 @@ def main(args=None):
         raise SystemExit(2)
     except tox.exception.MinVersionError as e:
         r = Reporter(None)
-        r.error(e.args)
+        r.error(str(e))
         raise SystemExit(1)
 
 

--- a/tox/session.py
+++ b/tox/session.py
@@ -46,7 +46,7 @@ def main(args=None):
         raise SystemExit(2)
     except tox.exception.MinVersionError as e:
         r = Reporter(None)
-        r.error(e.message)
+        r.error(e.args)
         raise SystemExit(1)
 
 

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -48,13 +48,13 @@ class CreationConfig:
             return None
 
     def matches(self, other):
-        return (other and self.md5 == other.md5
-                and self.python == other.python
-                and self.version == other.version
-                and self.sitepackages == other.sitepackages
-                and self.usedevelop == other.usedevelop
-                and self.alwayscopy == other.alwayscopy
-                and self.deps == other.deps)
+        return (other and self.md5 == other.md5 and
+                self.python == other.python and
+                self.version == other.version and
+                self.sitepackages == other.sitepackages and
+                self.usedevelop == other.usedevelop and
+                self.alwayscopy == other.alwayscopy and
+                self.deps == other.deps)
 
 
 class VirtualEnv(object):


### PR DESCRIPTION
- removed some errors from global list and made it locally ignored
- pin point versions for linters so that release of new versions do
  not break CI tests that were successful previously

start tackling #558, as agreed there small chunks :+1:  this is the first; 

next I would make probably the doc/conf.py pass the style checks