### PR TITLE
Document constraints.txt usage.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Not released yet
 - #518: Forward `USERPROFILE` by default on Windows.
 - #515: Don't require environment variables in test environments
 	where they are not used.
+- : Add documentation for constrains.txt
 
 2.7.0
 -----

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@ Not released yet
 - #518: Forward `USERPROFILE` by default on Windows.
 - #515: Don't require environment variables in test environments
 	where they are not used.
-- : Add documentation for constrains.txt
+- : Add documentation for constraints.txt
 
 2.7.0
 -----

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -49,3 +49,4 @@ Nick Douma
 Cyril Roelandt
 Bartolome Sanchez Salado
 Laszlo Vasko
+Alexander Loechel

--- a/doc/example/basic.txt
+++ b/doc/example/basic.txt
@@ -82,32 +82,38 @@ configuration::
 
 .. _multiindex:
 
-depending on requirements.txt
+depending on requirements.txt or defining constraints
 -----------------------------------------------
 
 .. versionadded:: 1.6.1
 
-(experimental) If you have a ``requirements.txt`` file
-you can add it to your ``deps`` variable like this::
+(experimental) If you have a ``requirements.txt`` file or a ``constraints.txt`` file you can add it to your ``deps`` variable like this:
+
+.. code-block:: ini
 
     deps = -rrequirements.txt
 
-All installation commands are executed using ``{toxinidir}``
-(the directory where ``tox.ini`` resides) as the current
-working directory.  Therefore, the underlying ``pip`` installation
-will assume ``requirements.txt`` to exist at ``{toxinidir}/requirements.txt``.
+or
 
-defining constrains
------------------------------------------------
+.. code-block:: ini
 
-.. versionadded:: 1.6.1
+    deps = -cconstraints.txt
 
-(experimental) If you have a ``constrains.txt`` file you can add it to your ``deps``varaiable like this::
+or
 
-    deps = constrains.txt
+.. code-block:: ini
+
+    deps = -rrequirements.txt -cconstraints.txt
 
 All installation commands are executed using ``{toxinidir}`` (the directory where ``tox.ini`` resides) as the current working directory.
-Therefore, the underlying ``pip`` installation will assume ``contrains.txt`` to exist at ``{toxinidir}/contrains.txt``.
+Therefore, the underlying ``pip`` installation will assume ``requirements.txt`` or ``constraints.txt`` to exist at ``{toxinidir}/requirements.txt`` or ``{toxinidir}/contrains.txt``.
+
+This is actually a side effect that all elements of the dependency list is directly passed to ``pip``.
+
+For more details on ``requirements.txt`` files or ``constraints.txt`` files please see:
+
+* https://pip.pypa.io/en/stable/user_guide/#requirements-files
+* https://pip.pypa.io/en/stable/user_guide/#constraints-files
 
 using a different default PyPI url
 -----------------------------------------------

--- a/doc/example/basic.txt
+++ b/doc/example/basic.txt
@@ -97,6 +97,18 @@ All installation commands are executed using ``{toxinidir}``
 working directory.  Therefore, the underlying ``pip`` installation
 will assume ``requirements.txt`` to exist at ``{toxinidir}/requirements.txt``.
 
+defining constrains
+-----------------------------------------------
+
+.. versionadded:: 1.6.1
+
+(experimental) If you have a ``constrains.txt`` file you can add it to your ``deps``varaiable like this::
+
+    deps = constrains.txt
+
+All installation commands are executed using ``{toxinidir}`` (the directory where ``tox.ini`` resides) as the current working directory.
+Therefore, the underlying ``pip`` installation will assume ``contrains.txt`` to exist at ``{toxinidir}/contrains.txt``.
+
 using a different default PyPI url
 -----------------------------------------------
 


### PR DESCRIPTION
I have documented the corresponding constrains.txt usage with tox, as it work similar to requirements.txt but was not documented.


Here's a quick checklist of what we'd like you to think off:
- [x] Add yourself to `CONTRIBUTORS`;
- [x] make a descriptive Pull Request text (it will be used for changelog)

