### PR TITLE
Differentiate pgid when popen

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -56,6 +56,7 @@ Pierre-Luc Tessier Gagné
 Ronald Evers
 Ronny Pfannschmidt
 Selim Belhaouane
+Seokju Hong
 Stephen Finucane
 Sridhar Ratnakumar
 Ville Skyttä

--- a/changelog/593.bugfix.rst
+++ b/changelog/593.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent tox from being killed by chiled process - by @Suckzoo

--- a/changelog/593.feature.rst
+++ b/changelog/593.feature.rst
@@ -1,0 +1,1 @@
+Stops child process immediately after waiting for 5 seconds - by @Suckzoo

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -919,3 +919,24 @@ def test_exit_code(initproj, cmd, exit_code, mocker):
     else:
         # need mocker.spy above
         assert tox.exception.exit_code_str.call_count == 0
+
+def test_new_session(initproj, cmd):
+    initproj("suckzoo", filedefs={
+        # This file first registers SIGINT handler and send SIGINT to itself.
+        'suicide.py': '''
+import os
+import signal
+
+
+signal.signal(signal.SIGINT, lambda *args: None)
+os.kill(0, signal.SIGINT)
+        ''',
+        'tox.ini': '''
+[testenv]
+commands =
+    python suicide.py
+        '''
+    })
+
+    result = cmd()
+    assert not result.ret

--- a/tox/session.py
+++ b/tox/session.py
@@ -194,7 +194,8 @@ class Action(object):
                     out, err = popen.communicate()
             except KeyboardInterrupt:
                 self.report.keyboard_interrupt()
-                kill = lambda popen: popen.kill()
+                def kill(_popen):
+                    _popen.kill()
                 timer_to_kill = threading.Timer(5, kill, [popen])
                 try:
                     timer_to_kill.start()

--- a/tox/session.py
+++ b/tox/session.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -199,6 +200,7 @@ class Action(object):
                 timer_to_kill = threading.Timer(5, kill, [popen])
                 try:
                     timer_to_kill.start()
+                    popen.send_signal(signal.SIGINT)
                     popen.wait()
                 finally:
                     timer_to_kill.cancel()

--- a/tox/session.py
+++ b/tox/session.py
@@ -195,6 +195,7 @@ class Action(object):
                     out, err = popen.communicate()
             except KeyboardInterrupt:
                 self.report.keyboard_interrupt()
+
                 def kill(_popen):
                     _popen.kill()
                 timer_to_kill = threading.Timer(5, kill, [popen])

--- a/tox/session.py
+++ b/tox/session.py
@@ -233,8 +233,14 @@ class Action(object):
     def _popen(self, args, cwd, stdout, stderr, env=None):
         if env is None:
             env = os.environ.copy()
+        new_session = {}
+        if sys.platform != 'win32':
+            new_session['preexec_fn'] = os.setsid
+        else:
+            new_session['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
         return self.session.popen(self._rewriteargs(cwd, args), shell=False, cwd=str(cwd),
-                                  universal_newlines=True, stdout=stdout, stderr=stderr, env=env)
+                                  universal_newlines=True, stdout=stdout, stderr=stderr, env=env,
+                                  **new_session)
 
 
 class Verbosity(object):

--- a/tox/session.py
+++ b/tox/session.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 import time
 
 import py
@@ -193,7 +194,13 @@ class Action(object):
                     out, err = popen.communicate()
             except KeyboardInterrupt:
                 self.report.keyboard_interrupt()
-                popen.wait()
+                kill = lambda popen: popen.kill()
+                timer_to_kill = threading.Timer(5, kill, [popen])
+                try:
+                    timer_to_kill.start()
+                    popen.wait()
+                finally:
+                    timer_to_kill.cancel()
                 raise
             ret = popen.wait()
         finally:


### PR DESCRIPTION
Thanks for contributing a PR!

Here's a quick checklist of what we'd like you to think off:

- [x] Make sure to include one or more tests for your change;
- [x] if an enhancement PR please create docs and at best an example
- [x] Add yourself to `CONTRIBUTORS`;
- [x] make a descriptive Pull Request text (it will be used for changelog)
---

Currently I'm applying tox to [aiotools](https://github.com/aiotools) project. And I noticed that tox is killed when I try to test signaling (i.e. SIGINT), and fails to test for every environment I defined (https://github.com/achimnol/aiotools/pull/7).

So I added `preexec_fn=os.setsid` to create new session and give child process a new process group id. With this modification, tox worked well with my use case without failing any existing test cases.

But I have no idea how to test this patch, so no test case is added for now. I want to get some advise about this.

Thanks.