### PR TITLE
#595 fix by updating implementation of #515

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -353,7 +353,7 @@ class TestIniParserAgainstCommandsKey:
             [testenv:bar]
             setenv = {[testenv]setenv}
             [testenv:baz]
-            setenv = 
+            setenv =
         """)
         assert config.envconfigs['foo'].setenv['VAR'] == 'x'
         assert config.envconfigs['bar'].setenv['VAR'] == 'x'

--- a/tox/__init__.py
+++ b/tox/__init__.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from pkg_resources import get_distribution, DistributionNotFound
 
 from .hookspecs import hookspec, hookimpl  # noqa
@@ -34,5 +36,14 @@ class exception:
         def __init__(self, message):
             self.message = message
             super(exception.MinVersionError, self).__init__(message)
+
+
+missing_env_substitution_map = defaultdict(list)  # FIXME - UGLY HACK
+"""Map section name to env variables that would be needed in that section but are not provided.
+
+Pre 2.8.1 missing substitutions crashed with a ConfigError although this would not be a problem
+if the env is not part of the current testrun. So we need to remember this and check later
+when the testenv is actually run and crash only then.
+"""
 
 from tox.session import main as cmdline  # noqa

--- a/tox/session.py
+++ b/tox/session.py
@@ -550,6 +550,12 @@ class Session:
             return
         for venv in self.venvlist:
             if self.setupenv(venv):
+                missing_vars = tox.missing_env_substitution_map.get(venv.name)
+                if missing_vars:
+                    raise tox.exception.ConfigError(
+                        "%s contains unresolvable substitution(s): %s. "
+                        "Environment variables are missing or defined recursively." %
+                        (venv.name, missing_vars))
                 if venv.envconfig.usedevelop:
                     self.developpkg(venv, self.config.setupdir)
                 elif self.config.skipsdist or venv.envconfig.skip_install:


### PR DESCRIPTION
fixes #595 

The way #515 was implemented did not play nicely with env var substitution. This might render the former additions completely or partially obsolete but I did not check this yet. First let's fix that bug.