### PR TITLE
Fix substitution problems introduced in 2.8

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -353,7 +353,7 @@ class TestIniParserAgainstCommandsKey:
             [testenv:bar]
             setenv = {[testenv]setenv}
             [testenv:baz]
-            setenv = 
+            setenv =
         """)
         assert config.envconfigs['foo'].setenv['VAR'] == 'x'
         assert config.envconfigs['bar'].setenv['VAR'] == 'x'

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -871,3 +871,10 @@ def test_envtmpdir(initproj, cmd):
 
     result = cmd.run("tox")
     assert not result.ret
+
+
+def test_missing_env_fails(initproj, cmd):
+    initproj("foo", filedefs={'tox.ini': "[testenv:foo]\ncommands={env:VAR}"})
+    result = cmd.run("tox")
+    assert result.ret == 1
+    result.stdout.fnmatch_lines(["*foo: unresolvable substitution(s): 'VAR'*"])

--- a/tox/__init__.py
+++ b/tox/__init__.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from pkg_resources import get_distribution, DistributionNotFound
 
 from .hookspecs import hookspec, hookimpl  # noqa
@@ -34,5 +36,14 @@ class exception:
         def __init__(self, message):
             self.message = message
             super(exception.MinVersionError, self).__init__(message)
+
+
+missing_env_substitution_map = defaultdict(list)  # FIXME - UGLY HACK
+"""Map section name to env variables that would be needed in that section but are not provided.
+
+Pre 2.8.1 missing substitutions crashed with a ConfigError although this would not be a problem
+if the env is not part of the current testrun. So we need to remember this and check later
+when the testenv is actually run and crash only then.
+"""
 
 from tox.session import main as cmdline  # noqa

--- a/tox/__init__.py
+++ b/tox/__init__.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from pkg_resources import get_distribution, DistributionNotFound
 
 from .hookspecs import hookspec, hookimpl  # noqa
@@ -16,12 +14,18 @@ class exception:
         def __str__(self):
             return "%s: %s" % (self.__class__.__name__, self.args[0])
 
+    class MissingSubstitution(Exception):
+        FLAG = 'TOX_MISSING_SUBSTITUTION'
+        """placeholder for debugging configurations"""
+        def __init__(self, name):
+            self.name = name
+
     class ConfigError(Error):
         """ error in tox configuration. """
     class UnsupportedInterpreter(Error):
-        "signals an unsupported Interpreter"
+        """signals an unsupported Interpreter"""
     class InterpreterNotFound(Error):
-        "signals that an interpreter could not be found"
+        """signals that an interpreter could not be found"""
     class InvocationError(Error):
         """ an error while invoking a script. """
     class MissingFile(Error):
@@ -37,13 +41,5 @@ class exception:
             self.message = message
             super(exception.MinVersionError, self).__init__(message)
 
-
-missing_env_substitution_map = defaultdict(list)  # FIXME - UGLY HACK
-"""Map section name to env variables that would be needed in that section but are not provided.
-
-Pre 2.8.1 missing substitutions crashed with a ConfigError although this would not be a problem
-if the env is not part of the current testrun. So we need to remember this and check later
-when the testenv is actually run and crash only then.
-"""
 
 from tox.session import main as cmdline  # noqa

--- a/tox/config.py
+++ b/tox/config.py
@@ -612,8 +612,8 @@ class TestenvConfig:
         self.missing_subs = []
         """Holds substitutions that could not be resolved.
 
-        Pre 2.8.1 missing substitutions crashed with a ConfigError although this would not be a 
-        problem if the env is not part of the current testrun. So we need to remember this and 
+        Pre 2.8.1 missing substitutions crashed with a ConfigError although this would not be a
+        problem if the env is not part of the current testrun. So we need to remember this and
         check later when the testenv is actually run and crash only then.
         """
 
@@ -824,27 +824,24 @@ class parseini:
             envpython=tc.get_envpython, **subs)
         for env_attr in config._testenv_attr:
             atype = env_attr.type
-            if atype in ("bool", "path", "string", "dict", "dict_setenv", "argv", "argvlist"):
-                meth = getattr(reader, "get" + atype)
-                try:
+            try:
+                if atype in ("bool", "path", "string", "dict", "dict_setenv", "argv", "argvlist"):
+                    meth = getattr(reader, "get" + atype)
                     res = meth(env_attr.name, env_attr.default, replace=replace)
-                except tox.exception.MissingSubstitution as e:
-                    tc.missing_subs.append(e.name)
-                    res = e.FLAG
-            elif atype == "space-separated-list":
-                res = reader.getlist(env_attr.name, sep=" ")
-            elif atype == "line-list":
-                res = reader.getlist(env_attr.name, sep="\n")
-            else:
-                raise ValueError("unknown type %r" % (atype,))
-
-            if env_attr.postprocess:
-                res = env_attr.postprocess(testenv_config=tc, value=res)
+                elif atype == "space-separated-list":
+                    res = reader.getlist(env_attr.name, sep=" ")
+                elif atype == "line-list":
+                    res = reader.getlist(env_attr.name, sep="\n")
+                else:
+                    raise ValueError("unknown type %r" % (atype,))
+                if env_attr.postprocess:
+                    res = env_attr.postprocess(testenv_config=tc, value=res)
+            except tox.exception.MissingSubstitution as e:
+                tc.missing_subs.append(e.name)
+                res = e.FLAG
             setattr(tc, env_attr.name, res)
-
             if atype in ("path", "string"):
                 reader.addsubstitutions(**{env_attr.name: res})
-
         return tc
 
     def _getenvdata(self, reader):

--- a/tox/session.py
+++ b/tox/session.py
@@ -364,6 +364,10 @@ class Session:
             self.report.error(
                 "venv %r in %s would delete project" % (name, envconfig.envdir))
             raise tox.exception.ConfigError('envdir must not equal toxinidir')
+        if envconfig.missing_subs:
+            raise tox.exception.ConfigError(
+                "venv %r envconfig contains unresolved substitution(s): %s",
+                envconfig.missing_subs)
         venv = VirtualEnv(envconfig=envconfig, session=self)
         self._name2venv[name] = venv
         return venv

--- a/tox/session.py
+++ b/tox/session.py
@@ -550,6 +550,12 @@ class Session:
             return
         for venv in self.venvlist:
             if self.setupenv(venv):
+                missing_vars = tox.missing_env_substitution_map.get(venv.name)
+                if missing_vars:
+                    raise tox.exception.ConfigError(
+                        "%s contains unresolvable substitution(s): %s. "
+                        "Environment variables are missing or defined recursively." %
+                        (venv.name, missing_vars))
                 if venv.envconfig.usedevelop:
                     self.developpkg(venv, self.config.setupdir)
                 elif self.config.skipsdist or venv.envconfig.skip_install:

--- a/tox/session.py
+++ b/tox/session.py
@@ -364,10 +364,6 @@ class Session:
             self.report.error(
                 "venv %r in %s would delete project" % (name, envconfig.envdir))
             raise tox.exception.ConfigError('envdir must not equal toxinidir')
-        if envconfig.missing_subs:
-            raise tox.exception.ConfigError(
-                "venv %r envconfig contains unresolved substitution(s): %s",
-                envconfig.missing_subs)
         venv = VirtualEnv(envconfig=envconfig, session=self)
         self._name2venv[name] = venv
         return venv
@@ -554,12 +550,11 @@ class Session:
             return
         for venv in self.venvlist:
             if self.setupenv(venv):
-                missing_vars = tox.missing_env_substitution_map.get(venv.name)
-                if missing_vars:
+                if venv.envconfig.missing_subs:
                     raise tox.exception.ConfigError(
                         "%s contains unresolvable substitution(s): %s. "
                         "Environment variables are missing or defined recursively." %
-                        (venv.name, missing_vars))
+                        (venv.name, venv.envconfig.missing_subs))
                 if venv.envconfig.usedevelop:
                     self.developpkg(venv, self.config.setupdir)
                 elif self.config.skipsdist or venv.envconfig.skip_install:

--- a/tox/session.py
+++ b/tox/session.py
@@ -440,6 +440,12 @@ class Session:
             path.ensure(dir=1)
 
     def setupenv(self, venv):
+        if venv.envconfig.missing_subs:
+            venv.status = (
+                "unresolvable substitution(s): %s. "
+                "Environment variables are missing or defined recursively." %
+                (','.join(["'%s'" % m for m in venv.envconfig.missing_subs])))
+            return
         if not venv.matching_platform():
             venv.status = "platform mismatch"
             return  # we simply omit non-matching platforms
@@ -550,12 +556,6 @@ class Session:
             return
         for venv in self.venvlist:
             if self.setupenv(venv):
-                if venv.envconfig.missing_subs:
-                    venv.status = (
-                        "unresolvable substitution(s): %s. "
-                        "Environment variables are missing or defined recursively." %
-                        (','.join(["'%s'" % m for m in venv.envconfig.missing_subs])))
-                    continue
                 if venv.envconfig.usedevelop:
                     self.developpkg(venv, self.config.setupdir)
                 elif self.config.skipsdist or venv.envconfig.skip_install:

--- a/tox/session.py
+++ b/tox/session.py
@@ -551,10 +551,11 @@ class Session:
         for venv in self.venvlist:
             if self.setupenv(venv):
                 if venv.envconfig.missing_subs:
-                    raise tox.exception.ConfigError(
-                        "%s contains unresolvable substitution(s): %s. "
+                    venv.status = (
+                        "unresolvable substitution(s): %s. "
                         "Environment variables are missing or defined recursively." %
-                        (venv.name, venv.envconfig.missing_subs))
+                        (','.join(["'%s'" % m for m in venv.envconfig.missing_subs])))
+                    continue
                 if venv.envconfig.usedevelop:
                     self.developpkg(venv, self.config.setupdir)
                 elif self.config.skipsdist or venv.envconfig.skip_install:


### PR DESCRIPTION
fixes #595 

The way #515 was implemented did not play nicely with env var substitution. This might render the former additions completely or partially obsolete but I did not check this yet. First let's fix that bug.

Instead of crashing early on testenv creation if substitution key is missing, the missing keys are added to a list attached to TestenvConfig. This way it is not necessary anymore to provide everything needed to resolve all testenvs but instead only what is needed to resolve all testenvs that are part of this restrun.

Implementation notes:

The first implementation used a module level mapping from envname to missing substitutions, which was ugly. Instead the information is bubbled up as an exception where it can be handled the way it is needed in the contexts where the information can be either translated into a crashing error or attached to the object which should carry the information (in this case TestenvConfig).

Atm a missing substitution in a testenv is not being left empty but filled with a special value 'TOX_MISSING_SUBSTITUTION', this is not exactly necessary, but I don't feel comfortable enough yet to leave it empty, this can help with debugging problems that might arise from this change.