### PR TITLE
[#614] add towncrier to manage changelog additions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,18 +1,22 @@
-Not released yet
-----------------
+..
+    You should *NOT* be adding new change log entries to this file, this
+    file is managed by towncrier. You *may* edit previous change logs to
+    fix problems like typo corrections or such.
+    To add a new change log entry, please see
+    https://pip.pypa.io/en/latest/development/#adding-a-news-entry
+    we named the news folder changelog
 
-- #571: skip_install should override usedevelop
-        Thanks Fernando P. (@ferdonline).
+.. towncrier release notes start
 
 2.8.1 (2017-09-04)
-------------------
+==================
 
 - :pull:`599`: fix problems with implementation of :issue:`515`.
   Substitutions from other sections were not made anymore if they were not in `envlist`.
   Thanks to Clark Boylan (:user:`cboylan`) for helping to get this fixed (:pull:`597`).
 
 2.8.0 (2017-09-01)
--------------------
+===================
 
 - :issue:`276`: Remove easy_install from docs (TL;DR: use pip). Thanks Martin Andrysík (:user:`sifuraz`).
 
@@ -62,7 +66,7 @@ Not released yet
 - :pull:`588`: Run pytest wit xfail_strict and adapt affected tests.
 
 2.7.0 (2017-04-02)
-------------------
+==================
 
 - :pull:`450`: Stop after the first installdeps and first testenv create hooks
   succeed. This changes the default behaviour of `tox_testenv_create`
@@ -100,7 +104,7 @@ Not released yet
   Thanks Jason R. Coombs (:user:`jaraco`).
 
 2.6.0 (2017-02-04)
-------------------
+==================
 
 - add "alwayscopy" config option to instruct virtualenv to always copy
   files instead of symlinking. Thanks Igor Duarte Cardoso (:user:`igordcard`).
@@ -122,7 +126,7 @@ Not released yet
   Thanks Allan Feldman (:user:`a-feld`).
 
 2.5.0 (2016-11-16)
-------------------
+==================
 
 - slightly backward incompatible: fix :issue:`310`: the {posargs} substitution
   now properly preserves the tox command line positional arguments. Positional
@@ -165,13 +169,13 @@ Not released yet
   succeeded', with relevant error message displayed. Thanks Lukasz Rogalski.
 
 2.4.1 (2016-10-12)
-------------------
+==================
 
 - fix :issue:`380`: properly perform substitution again. Thanks Ian
   Cordasco.
 
 2.4.0 (2016-10-12)
-------------------
+==================
 
 - remove PYTHONPATH from environment during the install phase because a
   tox-run should not have hidden dependencies and the test commands will also
@@ -224,7 +228,7 @@ Not released yet
   maintained, uses deprecated pytest API)
 
 2.3.2 (2016-02-11)
-------------------
+==================
 
 - fix :issue:`314`: fix command invocation with .py scripts on windows.
 
@@ -232,12 +236,12 @@ Not released yet
   posargs. Thanks Sachi King for the PR.
 
 2.3.1 (2015-12-14)
-------------------
+==================
 
 - fix :issue:`294`: re-allow cross-section substitution for setenv.
 
 2.3.0 (2015-12-09)
-------------------
+==================
 
 - DEPRECATE use of "indexservers" in tox.ini.  It complicates
   the internal code and it is recommended to rather use the
@@ -269,13 +273,13 @@ Not released yet
   tox core doesn't need it.
 
 2.2.1 (2015-12-09)
-------------------
+==================
 
 - fix bug where {envdir} substitution could not be used in setenv
   if that env value is then used in {basepython}. Thanks Florian Bruhin.
 
 2.2.0 (2015-11-11)
-------------------
+==================
 
 - fix :issue:`265` and add LD_LIBRARY_PATH to passenv on linux by default
   because otherwise the python interpreter might not start up in
@@ -300,14 +304,14 @@ Not released yet
 
 
 2.1.1 (2015-06-23)
-------------------
+==================
 
 - fix platform skipping for detox
 
 - report skipped platforms as skips in the summary
 
 2.1.0 (2015-06-19)
-------------------
+==================
 
 - fix :issue:`258`, fix :issue:`248`, fix :issue:`253`: for non-test commands
   (installation, venv creation) we pass in the full invocation environment.
@@ -327,7 +331,7 @@ Not released yet
   Thanks Marc Abramowitz for pushing in this direction.
 
 2.0.2 (2015-06-03)
-------------------
+==================
 
 - fix :issue:`247`: tox now passes the LANG variable from the tox invocation
   environment to the test environment by default.
@@ -336,12 +340,12 @@ Not released yet
   Thanks Michael Krause.
 
 2.0.1 (2015-05-13)
-------------------
+==================
 
 - fix wheel packaging to properly require argparse on py26.
 
 2.0.0 (2015-05-12)
-------------------
+==================
 
 - (new) introduce environment variable isolation:
   tox now only passes the PATH and PIP_INDEX_URL variable from the tox
@@ -400,7 +404,7 @@ Not released yet
 - DEPRECATE distshare in documentation
 
 1.9.2 (2015-03-23)
-------------------
+==================
 
 - backout ability that --force-dep substitutes name/versions in
   requirement files due to various issues.
@@ -408,7 +412,7 @@ Not released yet
   which popped up with 1.9.1.
 
 1.9.1 (2015-03-23)
-------------------
+==================
 
 - use a file instead of a pipe for command output in "--result-json".
   Fixes some termination issues with python2.6.
@@ -421,7 +425,7 @@ Not released yet
 
 
 1.9.0 (2015-02-24)
-------------------
+==================
 
 - fix :issue:`193`: Remove ``--pre`` from the default ``install_command``; by
   default tox will now only install final releases from PyPI for unpinned
@@ -446,7 +450,7 @@ Not released yet
 
 
 1.8.1 (2014-10-24)
-------------------
+==================
 
 - fix :issue:`190`: allow setenv to be empty.
 
@@ -459,7 +463,7 @@ Not released yet
   Gedminas.
 
 1.8.0 (2014-09-24)
-------------------
+==================
 
 - new multi-dimensional configuration support.  Many thanks to
   Alexander Schepanovski for the complete PR with docs.
@@ -476,7 +480,7 @@ Not released yet
 
 
 1.7.2 (2014-07-15)
-------------------
+==================
 
 - fix :issue:`150`: parse {posargs} more like we used to do it pre 1.7.0.
   The 1.7.0 behaviour broke a lot of OpenStack projects.
@@ -499,7 +503,7 @@ Not released yet
   memory errors.  Thanks March Schlaich for the PR90.
 
 1.7.1 (2014-03-28)
-------------------
+==================
 
 - fix :issue:`162`: don't list python 2.5 as compatibiliy/supported
 
@@ -508,7 +512,7 @@ Not released yet
   interpreter which invoked tox.  Thanks Chris Withers, Ionel Maries Cristian.
 
 1.7.0 (2014-01-29)
-------------------
+==================
 
 - don't lookup "pip-script" anymore but rather just "pip" on windows
   as this is a pip implementation detail and changed with pip-1.5.
@@ -569,7 +573,7 @@ Not released yet
 - fix :issue:`105` -- don't depend on an existing HOME directory from tox tests.
 
 1.6.1 (2013-09-04)
-------------------
+==================
 
 - fix :issue:`119`: {envsitepackagesdir} is now correctly computed and has
   a better test to prevent regression.
@@ -594,7 +598,7 @@ Not released yet
   this allows to use relative path like in "-rrequirements.txt".
 
 1.6.0 (2013-08-15)
-------------------
+==================
 
 - fix :issue:`35`: add new EXPERIMENTAL "install_command" testenv-option to
   configure the installation command with options for dep/pkg install.
@@ -636,7 +640,7 @@ Not released yet
   tox/interpreters.py file, tests in tests/test_interpreters.py.
 
 1.5.0 (2013-06-22)
-------------------
+==================
 
 - fix :issue:`104`: use setuptools by default, instead of distribute,
   now that setuptools has distribute merged.
@@ -663,7 +667,7 @@ Not released yet
 
 
 1.4.3 (2013-02-28)
-------------------
+==================
 
 - use pip-script.py instead of pip.exe on win32 to avoid the lock exe
   file on execution issue (thanks Philip Thiem)
@@ -711,20 +715,20 @@ Not released yet
   thanks to Barry Warsaw for both.
 
 1.4.2 (2012-07-20)
-------------------
+==================
 
 - fix some tests which fail if /tmp is a symlink to some other place
 - "python setup.py test" now runs tox tests via tox :)
   also added an example on how to do it for your project.
 
 1.4.1 (2012-07-03)
-------------------
+==================
 
 - fix :issue:`41` better quoting on windows - you can now use "<" and ">" in
   deps specifications, thanks Chris Withers for reporting
 
 1.4 (2012-06-13)
-----------------
+================
 
 - fix :issue:`26` - no warnings on absolute or relative specified paths for commands
 - fix :issue:`33` - commentchars are ignored in key-value settings allowing
@@ -745,7 +749,7 @@ Not released yet
   python-2.4, just tox itself requires 2.5 or higher.
 
 1.3 2011-12-21
---------------
+==============
 
 - fix: allow to specify wildcard filesystem paths when
   specifying dependencies such that tox searches for
@@ -759,7 +763,7 @@ Not released yet
 
 
 1.2 2011-11-10
---------------
+==============
 
 - remove the virtualenv.py that was distributed with tox and depend
   on >=virtualenv-1.6.4 (possible now since the latter fixes a few bugs
@@ -771,7 +775,7 @@ Not released yet
   (thanks Michael Foord for reporting)
 
 1.1 (2011-07-08)
-----------------
+================
 
 - fix :issue:`5` - don't require argparse for python versions that have it
 - fix :issue:`6` - recreate virtualenv if installing dependencies failed
@@ -788,7 +792,7 @@ Not released yet
 - rework and enhance docs for display on readthedocs.org
 
 1.0
----
+===
 
 - move repository and toxbootstrap links to https://bitbucket.org/hpk42/tox
 - fix :issue:`7`: introduce a "minversion" directive such that tox
@@ -814,7 +818,7 @@ Not released yet
 - added a CONTRIBUTORS file
 
 0.9
----
+===
 
 - fix pip-installation mixups by always unsetting PIP_RESPECT_VIRTUALENV
   (thanks Armin Ronacher)
@@ -828,7 +832,7 @@ Not released yet
   more readable)
 
 0.8
----
+===
 
 - work around a virtualenv limitation which crashes if
   PYTHONDONTWRITEBYTECODE is set.
@@ -842,7 +846,7 @@ Not released yet
 - change all internal source to strip trailing whitespaces
 
 0.7
----
+===
 
 - use virtualenv5 (my own fork of virtualenv3) for now to create python3
   environments, fixes a couple of issues and makes tox more likely to
@@ -865,7 +869,7 @@ Not released yet
 - recreate virtualenv on changed configurations
 
 0.6
----
+===
 
 - fix OSX related bugs that could cause the caller's environment to get
   screwed (sorry).  tox was using the same file as virtualenv for tracking
@@ -875,6 +879,6 @@ Not released yet
 - fix long description, thanks Michael Foord
 
 0.5
----
+===
 
 - initial release

--- a/README.rst
+++ b/README.rst
@@ -10,14 +10,14 @@
   :target: https://codecov.io/gh/tox-dev/tox
 
 tox automation project
-----------------------
+======================
 
 **vision: standardize testing in Python**
 
 tox aims to automate and standardize testing in Python. It is part of a larger vision of easing the packaging, testing and release process of Python software.
 
 What is tox?
-------------
+============
 
 tox is a generic virtualenv management and test command line tool you can use for:
 
@@ -36,7 +36,7 @@ For more information and the repository please see:
 - repository: https://github.com/tox-dev/tox
 
 Code coverage of latest master build
-------------------------------------
+====================================
 
 .. image:: https://codecov.io/gh/tox-dev/tox/branch/master/graphs/sunburst.svg
   :target: https://codecov.io/gh/tox-dev/tox/branch/master

--- a/doc/announce/changelog-only.rst
+++ b/doc/announce/changelog-only.rst
@@ -3,7 +3,7 @@ Less announcing, more change-logging
 
 With version 2.5.0 we dropped creating special announcement documents and rely on communicating
 all relevant changes through the
-`CHANGELOG <https://github.com/tox-dev/tox/blob/master/CHANGELOG>`_. See at
+`CHANGELOG <https://github.com/tox-dev/tox/blob/master/CHANGELOG.rst>`_. See at
 `pypi <https://pypi.org/project/tox/>`_ for a rendered version of the last changes containing
 links to the important issues and pull requests that were integrated into the release.
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,7 +1,9 @@
-
 .. _changelog:
 
 Changelog history
-=================================
+=================
+
+.. include:: ../.tox/docs/fragments.rst
 
 .. include:: ../CHANGELOG.rst
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,6 @@
-from datetime import datetime
+from datetime import date
 import os
+import subprocess
 import sys
 
 from pkg_resources import get_distribution
@@ -16,7 +17,7 @@ release = _full_version.split('+', 1)[0]
 version = '.'.join(release.split('.')[:2])
 
 author = 'holger krekel and others'
-year = datetime.today().year
+year = date.today().year
 copyright = u'2010-{}, {}'.format(year, author)
 
 master_doc = 'index'
@@ -57,3 +58,20 @@ linkcheck_ignore = [r'http://holgerkrekel.net']
 extlinks = {'issue': ('https://github.com/tox-dev/tox/issues/%s', '#'),
             'pull': ('https://github.com/tox-dev/tox/pull/%s', 'p'),
             'user': ('https://github.com/%s', '@')}
+
+
+def generate_newsfragments():
+    """
+    generate and include into the changelog news fragments so they are also subject to the CI,
+    whenever a new release is done there should be no news fragment and as such this will have
+    no effect
+    """
+    from os import path as p
+    with open('../.tox/docs/fragments.rst', 'w') as file_handle:
+        project_base = p.abspath(p.join(p.dirname(__file__), p.pardir))
+        cmd = ['towncrier', '--draft', '--dir', project_base]
+        out = subprocess.check_output(cmd).decode('utf-8').strip()
+        file_handle.write(out)
+
+
+generate_newsfragments()

--- a/newsfragments/571.bugfix
+++ b/newsfragments/571.bugfix
@@ -1,0 +1,2 @@
+``skip_install`` overrides ``usedevelop`` (``usedevelop`` is an option to choose the installation type if the package
+is installed and `skip_install` determines if it should be installed at all) - by :user:`ferdonline`

--- a/newsfragments/614.doc
+++ b/newsfragments/614.doc
@@ -1,0 +1,3 @@
+add `towncrier <https://github.com/hawkowl/towncrier>`_ to allow adding changelog entries with the pull requests without
+generating merge conflicts; with this release notes are now grouped into four distinct collections: `Features`,
+`Bugfixes`, `Improved Documentation` and `Deprecations and Removals`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.towncrier]
+    package = "tox"
+    package_dir = ".."
+    filename = "CHANGELOG.rst"
+    issue_format = "`#{issue} <https://github.com/tox-dev/tox/issues/{issue}>`_"
+
+    [[tool.towncrier.section]]
+        path = ""
+
+    [[tool.towncrier.type]]
+        directory = "feature"
+        name = "Features"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "bugfix"
+        name = "Bugfixes"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "doc"
+        name = "Improved Documentation"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "removal"
+        name = "Deprecations and Removals"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "misc"
+        name = "Misc"
+        showcontent = false

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import io
 import os
 import re
 import sys
+
 import setuptools
 from setuptools.command.test import test as TestCommand
 
@@ -45,7 +46,7 @@ def get_linked_changelog(here, n=5):
     changelog_url = '%s/blob/master/CHANGELOG.rst' % repo_url
     with io.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as f:
         changelog = f.read()
-    header_matches = list(re.finditer('^-+$', changelog, re.MULTILINE))
+    header_matches = list(re.finditer('^=+$', changelog, re.MULTILINE))
     lines = changelog[:header_matches[n].start()].splitlines()[:-1]
     title = "Changelog (last %s releases - `full changelog <%s>`_)" % (
         n, changelog_url)
@@ -100,17 +101,17 @@ def main():
         install_requires=install_requires,
         extras_require=extras_require,
         classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'Intended Audience :: Developers',
-            'License :: OSI Approved :: MIT License',
-            'Operating System :: POSIX',
-            'Operating System :: Microsoft :: Windows',
-            'Operating System :: MacOS :: MacOS X',
-            'Topic :: Software Development :: Testing',
-            'Topic :: Software Development :: Libraries',
-            'Topic :: Utilities'] + [
-            ('Programming Language :: Python :: %s' % x) for x in
-            '2 2.6 2.7 3 3.3 3.4 3.5 3.6'.split()]
+                        'Development Status :: 5 - Production/Stable',
+                        'Intended Audience :: Developers',
+                        'License :: OSI Approved :: MIT License',
+                        'Operating System :: POSIX',
+                        'Operating System :: Microsoft :: Windows',
+                        'Operating System :: MacOS :: MacOS X',
+                        'Topic :: Software Development :: Testing',
+                        'Topic :: Software Development :: Libraries',
+                        'Topic :: Utilities'] + [
+                        ('Programming Language :: Python :: %s' % x) for x in
+                        '2 2.6 2.7 3 3.3 3.4 3.5 3.6'.split()]
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import io
 import os
-import re
 import sys
 
 import setuptools
@@ -40,11 +39,12 @@ def has_environment_marker_support():
         return False
 
 
-def get_long_description(): 
-    here = os.path.abspath('.') 
-    with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f: 
-        with io.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as g: 
-            return "%s\n\n%s" % (f.read(), g.read()) 
+def get_long_description():
+    here = os.path.abspath('.')
+    with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
+        with io.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as g:
+            return "%s\n\n%s" % (f.read(), g.read())
+
 
 def main():
     version = sys.version_info[:2]

--- a/setup.py
+++ b/setup.py
@@ -40,30 +40,11 @@ def has_environment_marker_support():
         return False
 
 
-def get_linked_changelog(here, n=5):
-    """changelog containing last n releases with links to issues"""
-    repo_url = 'https://github.com/tox-dev/tox'
-    changelog_url = '%s/blob/master/CHANGELOG.rst' % repo_url
-    with io.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as f:
-        changelog = f.read()
-    header_matches = list(re.finditer('^=+$', changelog, re.MULTILINE))
-    lines = changelog[:header_matches[n].start()].splitlines()[:-1]
-    title = "Changelog (last %s releases - `full changelog <%s>`_)" % (
-        n, changelog_url)
-    changelog = '\n'.join([title, '=' * len(title), "\n", "\n".join(lines)])
-    issue_replacement = r'`#\1 <%s/issues/\1>`_' % repo_url
-    for pattern in [r'#(\d+)', r'issue(\d+)']:
-        changelog = re.sub(pattern, issue_replacement, changelog)
-    pull_replacement = r'`#p\1 <%s/pull/\1>`_' % repo_url
-    changelog = re.sub(r'#p(\d+)', pull_replacement, changelog)
-    return changelog
-
-
-def get_long_description():
-    here = os.path.abspath('.')
-    with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
-        return "%s\n\n%s" % (f.read(), get_linked_changelog(here))
-
+def get_long_description(): 
+    here = os.path.abspath('.') 
+    with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f: 
+        with io.open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8') as g: 
+            return "%s\n\n%s" % (f.read(), g.read()) 
 
 def main():
     version = sys.version_info[:2]

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands = {posargs:py.test -s -x -f -v}
 description = invoke sphinx-build and try to build the HTML page, and check that URIs are valid
 basepython = python
 deps = sphinx >= 1.6.3, < 2
-       towncrier >= 17.8.0, < 18
+       towncrier >= 17.8.0  
        {[testenv]deps}
 passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE
 commands = sphinx-build -d .tox/docs_doctree doc .tox/docs_out --color -W -bhtml

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands = {posargs:py.test -s -x -f -v}
 description = invoke sphinx-build and try to build the HTML page, and check that URIs are valid
 basepython = python
 deps = sphinx >= 1.6.3, < 2
+       towncrier >= 17.8.0, < 18
        {[testenv]deps}
 passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE
 commands = sphinx-build -d .tox/docs_doctree doc .tox/docs_out --color -W -bhtml


### PR DESCRIPTION
- also moved #571 documentation to news fragment as demonstration
- extended the documentation build to automatically prepend the current new fragments to the changelog, this way news fragments are also subject to the CI operations, but otherwise when we do a release (and there are no news staged don't get in the way)