### PR TITLE
Remove usage of py.builtin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def main():
     version = sys.version_info[:2]
     virtualenv_open = ['virtualenv>=1.11.2']
     virtualenv_capped = ['virtualenv>=1.11.2,<14']
-    install_requires = ['py>=1.4.17', 'pluggy>=0.3.0,<1.0']
+    install_requires = ['py>=1.4.17', 'pluggy>=0.3.0,<1.0', 'six']
     extras_require = {}
     if has_environment_marker_support():
         extras_require[':python_version=="2.6"'] = ['argparse']

--- a/tests/test_interpreters.py
+++ b/tests/test_interpreters.py
@@ -57,7 +57,7 @@ def test_tox_get_python_executable():
         popen = py.std.subprocess.Popen([str(p), '-V'],
                                         stderr=py.std.subprocess.PIPE)
         stdout, stderr = popen.communicate()
-        assert ver in py.builtin._totext(stderr, "ascii")
+        assert ver in stderr.decode('ascii')
 
 
 def test_find_executable_extra(monkeypatch):

--- a/tox/_pytestplugin.py
+++ b/tox/_pytestplugin.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+
 import py
 import pytest
 import tox
 import os
 import sys
-from py.builtin import _isbytes, _istext, print_
 from fnmatch import fnmatch
+import six
 import time
 from .config import parseconfig
 from .venv import VirtualEnv
@@ -222,7 +224,7 @@ class Cmd:
         def dump_lines(lines, fp):
             try:
                 for line in lines:
-                    py.builtin.print_(line, file=fp)
+                    print(line, file=fp)
             except UnicodeEncodeError:
                 print("couldn't print to %s because of encoding" % (fp,))
         dump_lines(out, sys.stdout)
@@ -271,17 +273,17 @@ class LineMatcher:
             while lines1:
                 nextline = lines1.pop(0)
                 if line == nextline:
-                    print_("exact match:", repr(line))
+                    print("exact match:", repr(line))
                     break
                 elif fnmatch(nextline, line):
-                    print_("fnmatch:", repr(line))
-                    print_("   with:", repr(nextline))
+                    print("fnmatch:", repr(line))
+                    print("   with:", repr(nextline))
                     break
                 else:
                     if not nomatchprinted:
-                        print_("nomatch:", repr(line))
+                        print("nomatch:", repr(line))
                         nomatchprinted = True
-                    print_("    and:", repr(nextline))
+                    print("    and:", repr(nextline))
                 extralines.append(nextline)
             else:
                 assert line == nextline
@@ -293,7 +295,10 @@ def initproj(request, tmpdir):
     def initproj(nameversion, filedefs=None, src_root="."):
         if filedefs is None:
             filedefs = {}
-        if _istext(nameversion) or _isbytes(nameversion):
+        if (
+                isinstance(nameversion, six.text_type) or
+                isinstance(nameversion, bytes)
+        ):
             parts = nameversion.split("-")
             if len(parts) == 1:
                 parts.append("0.1")

--- a/tox/config.py
+++ b/tox/config.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import argparse
 import os
 import random
@@ -243,7 +245,7 @@ def parseconfig(args=None, plugins=()):
     except tox.exception.InterpreterNotFound:
         exn = sys.exc_info()[1]
         # Use stdout to match test expectations
-        py.builtin.print_("ERROR: " + str(exn))
+        print("ERROR: " + str(exn))
 
     # post process config object
     pm.hook.tox_configure(config=config)
@@ -252,7 +254,7 @@ def parseconfig(args=None, plugins=()):
 
 
 def feedback(msg, sysexit=False):
-    py.builtin.print_("ERROR: " + msg, file=sys.stderr)
+    print("ERROR: " + msg, file=sys.stderr)
     if sysexit:
         raise SystemExit(1)
 
@@ -260,7 +262,7 @@ def feedback(msg, sysexit=False):
 class VersionAction(argparse.Action):
     def __call__(self, argparser, *args, **kwargs):
         version = tox.__version__
-        py.builtin.print_("%s imported from %s" % (version, tox.__file__))
+        print("%s imported from %s" % (version, tox.__file__))
         raise SystemExit(0)
 
 
@@ -1151,7 +1153,7 @@ class Replacer:
         val = self.reader._subs.get(sub_key, None)
         if val is None:
             val = self._substitute_from_other_section(sub_key)
-        if py.builtin.callable(val):
+        if callable(val):
             val = val()
         return str(val)
 

--- a/tox/session.py
+++ b/tox/session.py
@@ -4,6 +4,7 @@ Python2 and Python3 based virtual environments. Environments are
 setup by using virtualenv. Configuration is generally done through an
 INI-style "tox.ini" file.
 """
+from __future__ import print_function
 from __future__ import with_statement
 
 import tox
@@ -325,7 +326,7 @@ class Reporter(object):
             self.logline("%s" % msg, **opts)
 
     # def log(self, msg):
-    #    py.builtin.print_(msg, file=sys.stderr)
+    #    print(msg, file=sys.stderr)
 
 
 class Session:


### PR DESCRIPTION
Refs #610

- Adds dependency on `six` (for use of `six.text_type`)
- Replaces `py.builtin._totext` with explicit `.decode(...)`
- Replaces `_istext` and `_isbytes` with `isinstance` directly (`bytes` is available in python2.6)
- Replaces `py.builtin.print_` with `print` + `from __future__ import print_function`
- Replaces `py.builtin.callable` with just `callable` (available in python2.6)