### PR TITLE
#466 stop env var leakage if popen failed with resultjson or redirect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2.8.2 (2017-10-09)
+------------------
+
+#466: stop env var leakage if popen failed with resultjson or redirect
+
 2.8.1 (2017-09-04)
 ------------------
 


### PR DESCRIPTION
There is a patch based on 2.8.1 that will be released today, because this has been hanging around for too long already and the quite active master has changes that needs more testing before we can release them into the wild