### PR TITLE
#466 stop env var leakage if popen failed with resultjson or redirect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2.8.2 (2017-10-09)
+------------------
+
+#466: stop env var leakage if popen failed with resultjson or redirect
+
 2.8.1 (2017-09-04)
 ------------------
 

--- a/tox/session.py
+++ b/tox/session.py
@@ -123,8 +123,7 @@ class Action(object):
         resultjson = self.session.config.option.resultjson
         if resultjson or redirect:
             fout = self._initlogpath(self.id)
-            fout.write("actionid: %s\nmsg: %s\ncmdargs: %r\nenv: %s\n\n" % (
-                self.id, self.msg, args, env))
+            fout.write("actionid: %s\nmsg: %s\ncmdargs: %r\n\n" % (self.id, self.msg, args))
             fout.flush()
             self.popen_outpath = outpath = py.path.local(fout.name)
             fin = outpath.open()


### PR DESCRIPTION
hotfix vor 2.8.x will integrate that into master as well. Master had too many changes to just put them out quickly, but I think this should be fixed now.