### PR TITLE
tox --version now shows version info of registered plugins

### DIFF
--- a/newsfragments/544.feature
+++ b/newsfragments/544.feature
@@ -1,0 +1,1 @@
+``tox --version`` now shows information about all registered plugins - by :user:`obestwalter`

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,10 +4,11 @@ from textwrap import dedent
 
 import py
 import pytest
+from pluggy import PluginManager
 
 import tox
 import tox.config
-from tox.config import CommandParser
+from tox.config import CommandParser, get_version_info
 from tox.config import DepOption
 from tox.config import get_homedir
 from tox.config import getcontextname
@@ -2024,12 +2025,57 @@ class TestCmdInvocation:
             "*help*",
         ])
 
-    def test_version(self, cmd):
+    def test_version_simple(self, cmd):
         result = cmd.run("tox", "--version")
         assert not result.ret
         stdout = result.stdout.str()
         assert tox.__version__ in stdout
         assert "imported from" in stdout
+
+    def test_version_no_plugins(self):
+        pm = PluginManager('fakeprject')
+        version_info = get_version_info(pm)
+        assert "imported from" in version_info
+        assert "registered plugins:" not in version_info
+
+    def test_version_with_normal_plugin(self, monkeypatch):
+        def fake_normal_plugin_distinfo():
+            class MockModule:
+                __file__ = 'some-file'
+
+            class MockEggInfo:
+                project_name = 'some-project'
+                version = '1.0'
+            return [(MockModule, MockEggInfo)]
+
+        pm = PluginManager('fakeproject')
+        monkeypatch.setattr(
+            pm, 'list_plugin_distinfo', fake_normal_plugin_distinfo)
+        version_info = get_version_info(pm)
+        assert "registered plugins:" in version_info
+        assert "some-file" in version_info
+        assert "some-project" in version_info
+        assert "1.0" in version_info
+
+    def test_version_with_fileless_module(self, monkeypatch):
+        def fake_no_file_plugin_distinfo():
+            class MockModule:
+                def __repr__(self):
+                    return "some-repr"
+
+            class MockEggInfo:
+                project_name = 'some-project'
+                version = '1.0'
+            return [(MockModule(), MockEggInfo)]
+
+        pm = PluginManager('fakeproject')
+        monkeypatch.setattr(
+            pm, 'list_plugin_distinfo', fake_no_file_plugin_distinfo)
+        version_info = get_version_info(pm)
+        assert "registered plugins:" in version_info
+        assert "some-project" in version_info
+        assert "some-repr" in version_info
+        assert "1.0" in version_info
 
     def test_listenvs(self, cmd, initproj):
         initproj('listenvs', filedefs={

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,9 +8,10 @@ from pluggy import PluginManager
 
 import tox
 import tox.config
-from tox.config import CommandParser, get_version_info
+from tox.config import CommandParser
 from tox.config import DepOption
 from tox.config import get_homedir
+from tox.config import get_version_info
 from tox.config import getcontextname
 from tox.config import is_section_substitution
 from tox.config import parseconfig

--- a/tox/config.py
+++ b/tox/config.py
@@ -218,7 +218,7 @@ def parseconfig(args=None, plugins=()):
     config._parser = parser
     config._testenv_attr = parser._testenv_attr
     if config.option.version:
-        print_version_info(pm)
+        print(get_version_info(pm))
         raise SystemExit(0)
     # parse ini file
     basename = config.option.configfile
@@ -260,16 +260,16 @@ def feedback(msg, sysexit=False):
         raise SystemExit(1)
 
 
-def print_version_info(pm):
-    print("%s imported from %s" % (tox.__version__, tox.__file__))
+def get_version_info(pm):
+    out = ["%s imported from %s" % (tox.__version__, tox.__file__)]
     plugin_dist_info = pm.list_plugin_distinfo()
-    if not plugin_dist_info:
-        return
-    print('registered plugins:')
-    for mod, egg_info in plugin_dist_info:
-        source = getattr(mod, '__file__', repr(mod))
-        info = "%s-%s at %s" % (egg_info.project_name, egg_info.version, source)
-        print("    " + info)
+    if plugin_dist_info:
+        out.append('registered plugins:')
+        for mod, egg_info in plugin_dist_info:
+            source = getattr(mod, '__file__', repr(mod))
+            out.append("    %s-%s at %s" % (
+                egg_info.project_name, egg_info.version, source))
+    return '\n'.join(out)
 
 
 class SetenvDict(object):


### PR DESCRIPTION
Closes #544 

output from my box, with installed plugins:

    tox --version
    2.8.2.dev27 imported from /home/oliver/work/tox/tox/tox/__init__.py
    registered plugins:
        tox-virtualenv-no-download-1.0.0 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/tox_virtualenv_no_download.py
        tox-travis-0.8 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/tox_travis/hooks.py
        tox-run-command-0.4 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/tox_run_command.py
        tox-pyenv-1.1.0 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/tox_pyenv.py
        tox-py-backwards-0.1 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/tox_py_backwards.py
        tox-pip-extensions-1.1.0 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/tox_pip_extensions.py
        tox-globinterpreter-0.3 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/tox_globinterpreter.py
        tox-docker-1.0.0 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/tox_docker.py
        tox-bitbucket-status-1.0 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/tox_bitbucket_status.py
        tox-battery-0.5 at /home/oliver/.virtualenvs/tmp/lib/python3.6/site-packages/toxbat/requirements.py
