### PR TITLE
Use builtin venv module for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ sudo: false
 language: python
 cache: python
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -50,3 +50,4 @@ Selim Belhaouane
 Sridhar Ratnakumar
 Ville Skyttä
 anatoly techtonik
+Ryan P. Kilby

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,7 @@
 environment:
   matrix:
     - TOXENV: fix-lint
-    - TOXENV: py26
     - TOXENV: py27
-    - TOXENV: py33
     - TOXENV: py34
     - TOXENV: py35
     - TOXENV: py36

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def main():
             'Topic :: Software Development :: Libraries',
             'Topic :: Utilities'] + [
                 ('Programming Language :: Python :: %s' % x) for x in
-                '2 2.6 2.7 3 3.3 3.4 3.5 3.6'.split()]
+                '2 2.7 3 3.4 3.5 3.6'.split()]
     )
 
 

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -51,6 +51,20 @@ def test_getsupportedinterpreter(monkeypatch, newconfig, mocksession):
     pytest.raises(tox.exception.InvocationError, venv.getsupportedinterpreter)
 
 
+def test_module(mocksession, newconfig):
+    config = newconfig([], """
+        [testenv:py2]
+        basepython=python2.7
+
+        [testenv:py3]
+        basepython=python3.6
+    """)
+    venv = VirtualEnv(config.envconfigs['py2'], session=mocksession)
+    assert venv._module() == 'virtualenv'
+    venv = VirtualEnv(config.envconfigs['py3'], session=mocksession)
+    assert venv._module() == 'venv'
+
+
 def test_create(monkeypatch, mocksession, newconfig):
     config = newconfig([], """
         [testenv:py123]
@@ -64,7 +78,8 @@ def test_create(monkeypatch, mocksession, newconfig):
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
     args = pcalls[0].args
-    assert "virtualenv" == str(args[2])
+    module = 'venv' if venv._ispython3() else 'virtualenv'
+    assert module == str(args[2])
     if sys.platform != "win32":
         # realpath is needed for stuff like the debian symlinks
         assert py.path.local(sys.executable).realpath() == py.path.local(args[0]).realpath()
@@ -488,7 +503,8 @@ class TestCreationConfig:
         assert venv.path_config.check()
         assert mocksession._pcalls
         args1 = map(str, mocksession._pcalls[0].args)
-        assert 'virtualenv' in " ".join(args1)
+        module = 'venv' if venv._ispython3() else 'virtualenv'
+        assert module in " ".join(args1)
         mocksession.report.expect("*", "*create*")
         # modify config and check that recreation happens
         mocksession._clearmocks()

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -81,8 +81,13 @@ def test_create(monkeypatch, mocksession, newconfig):
     module = 'venv' if venv._ispython3() else 'virtualenv'
     assert module == str(args[2])
     if sys.platform != "win32":
+        executable = sys.executable
+        if venv._ispython3() and hasattr(sys, 'real_prefix'):
+            # workaround virtualenv prefixing issue w/ venv on python3
+            _, executable = executable.rsplit('bin/', 1)
+            executable = os.path.join(sys.real_prefix, 'bin/', executable)
         # realpath is needed for stuff like the debian symlinks
-        assert py.path.local(sys.executable).realpath() == py.path.local(args[0]).realpath()
+        assert py.path.local(executable).realpath() == py.path.local(args[0]).realpath()
         # assert Envconfig.toxworkdir in args
         assert venv.getcommandpath("easy_install", cwd=py.path.local())
     interp = venv._getliveconfig().python

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -399,11 +399,11 @@ def test_install_command_not_installed_bash(newmocksession):
 
 
 def test_install_python3(tmpdir, newmocksession):
-    if not py.path.local.sysfind('python3.3'):
-        pytest.skip("needs python3.3")
+    if not py.path.local.sysfind('python3.6'):
+        pytest.skip("needs python3.6")
     mocksession = newmocksession([], """
         [testenv:py123]
-        basepython=python3.3
+        basepython=python3.6
         deps=
             dep1
             dep2
@@ -414,7 +414,7 @@ def test_install_python3(tmpdir, newmocksession):
     pcalls = mocksession._pcalls
     assert len(pcalls) == 1
     args = pcalls[0].args
-    assert str(args[2]) == 'virtualenv'
+    assert str(args[2]) == 'venv'
     pcalls[:] = []
     action = mocksession.newaction(venv, "hello")
     venv._install(["hello"], action=action)

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -668,25 +668,37 @@ def _alwayscopy_not_supported():
 
 
 @pytest.mark.skipif(_alwayscopy_not_supported(), reason="Platform doesnt support alwayscopy")
-def test_alwayscopy(initproj, cmd):
+def test_alwayscopy(initproj, cmd, mocksession):
     initproj("example123", filedefs={'tox.ini': """
             [testenv]
             commands={envpython} --version
             alwayscopy=True
     """})
+    venv = mocksession.getenv('python')
     result = cmd.run("tox", "-vv")
     assert not result.ret
-    assert "virtualenv --always-copy" in result.stdout.str()
+
+    out = result.stdout.str()
+    if venv._ispython3():
+        assert "venv --copies" in out
+    else:
+        assert "virtualenv --always-copy" in out
 
 
-def test_alwayscopy_default(initproj, cmd):
+def test_alwayscopy_default(initproj, cmd, mocksession):
     initproj("example123", filedefs={'tox.ini': """
             [testenv]
             commands={envpython} --version
     """})
+    venv = mocksession.getenv('python')
     result = cmd.run("tox", "-vv")
     assert not result.ret
-    assert "virtualenv --always-copy" not in result.stdout.str()
+
+    out = result.stdout.str()
+    if venv._ispython3():
+        assert "venv --copies" not in out
+    else:
+        assert "virtualenv --always-copy" not in out
 
 
 def test_empty_activity_ignored(initproj, cmd):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py26,py34,py33,py35,py36,pypy,style,py26-bare,docs
+envlist = py27,py34,py35,py36,pypy,style,docs
 minversion = 2.7.0
 
 [testenv]
@@ -47,17 +47,6 @@ commands = python -m flake8 --show-source tox setup.py {posargs}
 [flake8]
 max-complexity = 22
 max-line-length = 99
-
-[testenv:py26-bare]
-description = invoke the tox help message under Python 2.6
-install_command = pip install {opts} {packages}
-list_dependencies_command = pip freeze
-deps =
-commands = tox -h
-
-[testenv:py26]
-install_command = pip install {opts} {packages}
-list_dependencies_command = pip freeze
 
 [testenv:X]
 description = print the positional arguments passed in with echo

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -157,7 +157,7 @@ class VirtualEnv(object):
         """
         args = [str(python), '-c', 'import sys; print(sys.real_prefix)']
 
-        process = subprocess.Popen(args, stdout=subprocess.PIPE)
+        process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output, _ = process.communicate()
         output = output.decode('UTF-8').strip()
         path = os.path.join(output, 'bin/python3')

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -152,6 +152,9 @@ class VirtualEnv(object):
     def _ispython3(self):
         return "python3" in str(self.envconfig.basepython)
 
+    def _module(self):
+        return "venv" if self._ispython3() else "virtualenv"
+
     def update(self, action):
         """ return status string for updating actual venv to match configuration.
             if status string is empty, all is ok.
@@ -426,14 +429,22 @@ def tox_testenv_create(venv, action):
     # if self.getcommandpath("activate").dirpath().check():
     #    return
     config_interpreter = venv.getsupportedinterpreter()
-    args = [sys.executable, '-m', 'virtualenv']
+    is_python3 = venv._ispython3()
+
+    if is_python3:
+        args = [config_interpreter, '-m', venv._module()]
+    else:
+        args = [sys.executable, '-m', venv._module()]
+
     if venv.envconfig.sitepackages:
         args.append('--system-site-packages')
     if venv.envconfig.alwayscopy:
-        args.append('--always-copy')
+        args.append('--copies' if is_python3 else '--always-copy')
+
     # add interpreter explicitly, to prevent using
     # default (virtualenv.ini)
-    args.extend(['--python', str(config_interpreter)])
+    if not is_python3:
+        args.extend(['--python', config_interpreter])
     # if sys.platform == "win32":
     #    f, path, _ = imp.find_module("virtualenv")
     #    f.close()


### PR DESCRIPTION
I'd like to propose that the builtin `venv` module be used for python 3 virtual environments instead of `virtualenv` (resolves #436), and this is now possible given python 3.3's [impending EOL](https://www.python.org/dev/peps/pep-0398/#x-end-of-life). 

There is more discussion in #436, but the short version is that  `virtualenv` is not fully compatible with newer versions of python. Currently, deprecation warnings are raised, but eventually these will become exceptions. There was a [rewrite](https://github.com/pypa/virtualenv/pull/697) a while back, but the PR was closed due to bit rot. Additionally, development/maintenance of `virtualenv` seems to have largely ended (a total of three non-merge commits this year), so it's unlikely that the issue will be fixed by `virtualenv`.

It's worth noting that this PR is dependent on dropping python 3.3 support, as the `--copies` option was not supported by `venv` yet. I've also gone ahead and dropped python 2.6 support, but this isn't strictly necessary.

## Changelog

Start using the builtin venv module for python 3 virtual environments, and drop python 2.6 & 3.3 support.

## Checklist

- [x] Make sure to include one or more tests for your change;
- [x] ~~if an enhancement PR please create docs and at best an example~~
- [x] Add yourself to `CONTRIBUTORS`;
- [x] make a descriptive Pull Request text (it will be used for changelog)

