### PR TITLE
Feature/constraints

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -52,3 +52,4 @@ Laszlo Vasko
 Fernando L. Pereira
 Alexander Loechel
 Ville Skyttä
+Tony Breeds

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -89,6 +89,15 @@ Complete list of settings that you can put into ``testenv*`` sections:
     Similar to ``make`` recipe lines, any command with a leading ``-``
     will ignore the exit code.
 
+.. confval:: constraints=STRING
+
+    .. versionadded:: 2.10
+
+    Constraints are a new feature in pip 9.x, designed to enforce a specific
+    ''constrainted'' set of installed libraries.  This option when paired with
+    ''{constratints}'' in your install_command will instruct pip where to get
+    the constratints from.
+
 .. confval:: install_command=ARGV
 
     .. versionadded:: 1.6

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -643,10 +643,12 @@ def test_test_usedevelop(cmd, initproj, src_root):
 
 def _alwayscopy_not_supported():
     # This is due to virtualenv bugs with alwayscopy in some platforms
-    # see: https://github.com/pypa/virtualenv/issues/565
+    # See: https://github.com/pypa/virtualenv/issues/565
+    # See also: https://github.com/pypa/virtualenv/pull/1010 for the fix
     if hasattr(platform, 'linux_distribution'):
         _dist = platform.linux_distribution(full_distribution_name=False)
-        if _dist[0] == 'centos' and _dist[1][0] == '7':
+        if ((_dist[0] == 'centos' and _dist[1][0] == '7') or
+                (_dist[0] == 'fedora')):
             return True
     return False
 

--- a/tox/config.py
+++ b/tox/config.py
@@ -564,6 +564,14 @@ def tox_addoption(parser):
 
     parser.add_testenv_attribute_obj(InstallcmdOption())
 
+    def constraints(testenv_config, value):
+        return None if value == '' else value
+
+    parser.add_testenv_attribute(
+        name="constraints", type="string", postprocess=constraints,
+        default=None,
+        help="Location of the pip constraints file if needed")
+
     parser.add_testenv_attribute(
         name="list_dependencies_command",
         type="argv",
@@ -1109,7 +1117,7 @@ class Replacer:
         # special case: opts and packages. Leave {opts} and
         # {packages} intact, they are replaced manually in
         # _venv.VirtualEnv.run_install_command.
-        if sub_value in ('opts', 'packages'):
+        if sub_value in ('opts', 'packages', 'constraints'):
             return '{%s}' % sub_value
 
         try:

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -281,6 +281,7 @@ class VirtualEnv(object):
         return l
 
     def run_install_command(self, packages, action, options=()):
+        constraints = self.envconfig.constraints
         argv = self.envconfig.install_command[:]
         # use pip-script on win32 to avoid the executable locking
         i = argv.index('{packages}')
@@ -288,6 +289,14 @@ class VirtualEnv(object):
         if '{opts}' in argv:
             i = argv.index('{opts}')
             argv[i:i + 1] = list(options)
+
+        if '{constraints}' in argv:
+            i = argv.index('{constraints}')
+            if (constraints is not None and
+                    action.activity in ['installdeps']):
+                argv[i:i+1] = ['-c', constraints]
+            else:
+                del argv[i]
 
         for x in ('PIP_RESPECT_VIRTUALENV', 'PIP_REQUIRE_VIRTUALENV',
                   '__PYVENV_LAUNCHER__'):


### PR DESCRIPTION
Add native constraints support

Constraints are a new feature in pip 9.x, designed to enforce a specific ''constrainted'' set of installed libraries.  This option when paired with ''{constratints}'' in your install_command will instruct pip where to get the constratints from.

It's possible to use constraints without this change by manually adding:
    -c /path/to/constraints/file.txt
into install_coommand.  However this means that the constraints are used when doing the develop-inst.  This is fine *unless* the project you're trying to test is listed in your constraints file.  Then pip errors out saying that you can't satisfy the constraint from the dev install.

So we only use constraints in the installdeps phase

