### PR TITLE
Provide friendlier error for missing setup.py.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,6 +23,7 @@ Ionel Maries Cristian
 Ionel Maries Cristian
 Itxaka Serrano
 Jannis Leidel
+Johannes Christ
 Josh Smeaton
 Julian Krause
 Krisztian Fekete

--- a/changelog/331.misc.rst
+++ b/changelog/331.misc.rst
@@ -1,0 +1,1 @@
+Running ``tox`` without a ``setup.py`` now has a more friendly error message and gives troubleshooting suggestions - by @Volcyy.

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -1,3 +1,4 @@
+import os
 import platform
 
 import py
@@ -451,6 +452,21 @@ def test_sdist_fails(cmd, initproj):
     assert result.ret
     result.stdout.fnmatch_lines([
         "*FAIL*could not package project*",
+    ])
+
+
+def test_no_setup_py_exits(cmd, initproj):
+    initproj("pkg123-0.7", filedefs={
+        'tox.ini': """
+            [testenv]
+            commands=python -c "2 + 2"
+        """
+    })
+    os.remove("setup.py")
+    result = cmd.run("tox", )
+    assert result.ret
+    result.stdout.fnmatch_lines([
+        "*ERROR*No setup.py file found*"
     ])
 
 

--- a/tox/session.py
+++ b/tox/session.py
@@ -404,7 +404,17 @@ class Session:
     def _makesdist(self):
         setup = self.config.setupdir.join("setup.py")
         if not setup.check():
-            raise tox.exception.MissingFile(setup)
+            self.report.error(
+                "No setup.py file found. The expected location is:\n"
+                "  %s\n"
+                "You can\n"
+                "  1. Create one:\n"
+                "     https://packaging.python.org/tutorials/distributing-packages/#setup-py\n"
+                "  2. Configure tox to avoid running sdist:\n"
+                "     http://tox.readthedocs.io/en/latest/example/general.html"
+                "#avoiding-expensive-sdist" % setup
+            )
+            raise SystemExit(1)
         action = self.newaction(None, "packaging")
         with action:
             action.setactivity("sdist-make", setup)


### PR DESCRIPTION
As suggested in #331, this PR makes `tox` output a friendlier exception when `setup.py` could not be found. When this is the case, the following is outputted instead of throwing a `MissingFile` exception:

![tox output missing setup.py](https://user-images.githubusercontent.com/22679924/31583698-598a2570-b1a0-11e7-952e-4880e7153458.png)

**Checklist**:
- [X] wrote descriptive pull request text
- [X] added/updated test(s)
 - [ ] updated/extended the documentation
Should this be documented and if yes, where?
- [X] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [X] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog), see [this](https://github.com/Volcyy/tox/blob/nicer-missing-setup-output/changelog/331.misc.rst)
- [X] added yourself to `CONTRIBUTORS` (preserving alphabetical order)