### PR TITLE
Exclude setuptools 34 & 35 from requirements

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -45,6 +45,7 @@ Paweł Adamczak
 Philip Thiem
 Ronald Evers
 Ronny Pfannschmidt
+Ryan P Kilby
 Selim Belhaouane
 Sridhar Ratnakumar
 Ville Skyttä

--- a/changelog/656.bugfix.rst
+++ b/changelog/656.bugfix.rst
@@ -1,0 +1,3 @@
+Exclude ``setuptools`` versions 34 & 35 from dependencies, and install before ``six``.
+This avoids a potential race condition when installing a package that ``setuptools``
+itself depends on - by @rpkilby.

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def main():
     version = sys.version_info[:2]
     virtualenv_open = ['virtualenv>=1.11.2']
     virtualenv_capped = ['virtualenv>=1.11.2,<14']
-    install_requires = ['py>=1.4.17', 'pluggy>=0.3.0,<1.0', 'six']
+    install_requires = ['setuptools!=34,!=35', 'py>=1.4.17', 'pluggy>=0.3.0,<1.0', 'six']
     extras_require = {}
     if has_environment_marker_support():
         extras_require[':python_version=="2.6"'] = ['argparse']


### PR DESCRIPTION
Travis's python 3.4 environment ships a broken version of setuptools (more details in the tox-travis issue). When upgrading dependencies that setuptools itself depends on (such as six in this case) a race condition may occur where the package temporarily does not exist, causing the installation to fail. 

By installing setuptools first, which re-vendors its dependencies, we can prevent the race condition. 

Fixes #656

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] ~~added/updated test(s)~~
- [x] ~~updated/extended the documentation~~
- [x] ~~added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) in message body~~
- [x] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
