### PR TITLE
cmd simplify, use pytest stderr/stdout management, and use regex instead of fnmatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     language: generic
 
 before_install: if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis-osx; fi
-install: pip install six && pip install --pre -U tox
+install: pip install --pre -U tox --ignore-installed six
 script: tox -e py
 after_success:
   - tox -e coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py26,py34,py33,py35,py36,pypy,style,py26-bare,docs
+envlist = py27,py26,py34,py33,py35,py36,pypy,py26-bare,docs
 minversion = 2.7.0
 
 [testenv]

--- a/tox/session.py
+++ b/tox/session.py
@@ -38,6 +38,8 @@ def main(args=None):
     try:
         config = prepare(args)
         retcode = Session(config).runcommand()
+        if retcode is None:
+            retcode = 0
         raise SystemExit(retcode)
     except KeyboardInterrupt:
         raise SystemExit(2)


### PR DESCRIPTION
this is part of trying to speed up the unit tests with three changes that make the test less tox specific (use what the builtin stdlib/pytest offers/uses) and remove some indirection:

- the Cmd class is needlessly a class - it has just an init and one call - make it instead just a simple fixture (which returns a callable that can  be invoked with the command)
- remove calling subprocess  from Cmd, call instead directly to remove a sub-process indirection 
-  instead of hacking the stdin/stdout away during hacking, use the pytest provided capfd
- the fnmatch is kinda hard to read, and allows non precise test outcome specification - migrate to regex instead