### PR TITLE
Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: v0.9.3
+    sha: v1.1.1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/setup.py
+++ b/setup.py
@@ -82,17 +82,17 @@ def main():
         install_requires=install_requires,
         extras_require=extras_require,
         classifiers=[
-                        'Development Status :: 5 - Production/Stable',
-                        'Intended Audience :: Developers',
-                        'License :: OSI Approved :: MIT License',
-                        'Operating System :: POSIX',
-                        'Operating System :: Microsoft :: Windows',
-                        'Operating System :: MacOS :: MacOS X',
-                        'Topic :: Software Development :: Testing',
-                        'Topic :: Software Development :: Libraries',
-                        'Topic :: Utilities'] + [
-                        ('Programming Language :: Python :: %s' % x) for x in
-                        '2 2.6 2.7 3 3.3 3.4 3.5 3.6'.split()]
+            'Development Status :: 5 - Production/Stable',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: MIT License',
+            'Operating System :: POSIX',
+            'Operating System :: Microsoft :: Windows',
+            'Operating System :: MacOS :: MacOS X',
+            'Topic :: Software Development :: Testing',
+            'Topic :: Software Development :: Libraries',
+            'Topic :: Utilities'] + [
+                ('Programming Language :: Python :: %s' % x) for x in
+                '2 2.6 2.7 3 3.3 3.4 3.5 3.6'.split()]
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,8 @@ commands = python -m flake8 --show-source tox setup.py {posargs}
 [flake8]
 max-complexity = 22
 max-line-length = 99
+# TODO: fix E741
+ignore = E741
 
 [testenv:py26-bare]
 description = invoke the tox help message under Python 2.6

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands = sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out -
 basepython = python3.6
 deps = flake8 == 3.4.1
        flake8-bugbear == 17.4.0
-       pre-commit == 1.0.1
+       pre-commit == 1.3.0
 description = run static analysis and style check using flake8
 commands = python -m flake8 --show-source tox setup.py {posargs}
            python -m flake8 --show-source doc tests {posargs}


### PR DESCRIPTION
This should remove the symlink inside pre-commit-hooks.

piggybacking on https://github.com/pre-commit/pre-commit-hooks/commit/c5b7c35d81174fa8e69c50f6561fa9537f1334e5

Resolves #661