### PR TITLE
tox no longer uses `python setup.py test`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,6 @@ import os
 import sys
 
 import setuptools
-from setuptools.command.test import test as TestCommand
-
-
-class Tox(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = ["-v", "-epy"]
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import tox
-        tox.cmdline(self.test_args)
 
 
 def has_environment_marker_support():
@@ -75,10 +62,6 @@ def main():
         packages=['tox'],
         entry_points={'console_scripts': 'tox=tox:cmdline\ntox-quickstart=tox._quickstart:main'},
         setup_requires=['setuptools_scm'],
-        # we use a public tox version to test, see tox.ini's testenv
-        # "deps" definition for the required dependencies
-        tests_require=['tox'],
-        cmdclass={"test": Tox},
         install_requires=install_requires,
         extras_require=extras_require,
         classifiers=[


### PR DESCRIPTION
Refs #651 