### PR TITLE
passenv HOMEPATH so pre-commit knows where to install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,9 @@ commands = sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out -
 
 [testenv:fix-lint]
 basepython = python3.6
+passenv =
+    {[testenv]passenv}
+    HOMEPATH
 deps = flake8 == 3.4.1
        flake8-bugbear == 17.4.0
        pre-commit == 1.3.0


### PR DESCRIPTION
This is necessary so `os.path.expanduser` works on windows -- stdlib used to error on this but I guess it was made more permissive 🤷‍♀️ 