### PR TITLE
recreate venv when -rrequire.txt changes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@ Itxaka Serrano
 Jannis Leidel
 Josh Smeaton
 Julian Krause
+Kapil Thangavelu
 Krisztian Fekete
 Laszlo Vasko
 Lukasz Balcerzak

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
+import hashlib
 import os
 import sys
+import tempfile
 from textwrap import dedent
 
 import py
@@ -9,6 +11,7 @@ from pluggy import PluginManager
 import tox
 import tox.config
 from tox.config import CommandParser
+from tox.config import DepConfig
 from tox.config import DepOption
 from tox.config import get_homedir
 from tox.config import get_version_info
@@ -128,6 +131,16 @@ class TestVenvConfig:
         assert DepOption._is_same_dep('pkg_hello-world3==1.0', 'pkg_hello-world3<2.0')
         assert DepOption._is_same_dep('pkg_hello-world3==1.0', 'pkg_hello-world3<=2.0')
         assert not DepOption._is_same_dep('pkg_hello-world3==1.0', 'otherpkg>=2.0')
+
+
+    def test_digest(self):
+        with tempfile.NamedTemporaryFile() as fh:
+            fh.write('hello_world==1.0')
+            fh.flush()
+            assert (DepConfig('-r%s' % fh.name).digest ==
+                    hashlib.md5('hello_world==1.0').hexdigest())
+        assert (DepConfig('pkg_helloworld3==1.0').digest ==
+                hashlib.md5('pkg_helloworld3==1.0').hexdigest())
 
 
 class TestConfigPlatform:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-import hashlib
 import os
 import sys
 from textwrap import dedent

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -136,7 +136,7 @@ class TestVenvConfig:
         reqs.write('hello_world==1.0')
         assert (DepConfig('-r%s' % (str(reqs))).digest == reqs.computehash())
         assert (DepConfig('pkg_helloworld3==1.0').digest ==
-                hashlib.md5('pkg_helloworld3==1.0').hexdigest())
+                hashlib.md5(b'pkg_helloworld3==1.0').hexdigest())
 
 
 class TestConfigPlatform:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,8 +135,7 @@ class TestVenvConfig:
         reqs = tmpdir.join('reqs.txt')
         reqs.write('hello_world==1.0')
         assert (DepConfig('-r%s' % (str(reqs))).digest == reqs.computehash())
-        assert (DepConfig('pkg_helloworld3==1.0').digest ==
-                hashlib.md5(b'pkg_helloworld3==1.0').hexdigest())
+        assert (DepConfig('pkg_helloworld3==1.0').digest == "0" * 32)
 
 
 class TestConfigPlatform:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 import sys
-import tempfile
 from textwrap import dedent
 
 import py
@@ -132,12 +131,10 @@ class TestVenvConfig:
         assert DepOption._is_same_dep('pkg_hello-world3==1.0', 'pkg_hello-world3<=2.0')
         assert not DepOption._is_same_dep('pkg_hello-world3==1.0', 'otherpkg>=2.0')
 
-    def test_digest(self):
-        with tempfile.NamedTemporaryFile() as fh:
-            fh.write('hello_world==1.0')
-            fh.flush()
-            assert (DepConfig('-r%s' % fh.name).digest ==
-                    hashlib.md5('hello_world==1.0').hexdigest())
+    def test_digest(self, tmpdir):
+        reqs = tmpdir.join('reqs.txt')
+        reqs.write('hello_world==1.0')
+        assert (DepConfig('-r%s' % (str(reqs))).digest == reqs.computehash())
         assert (DepConfig('pkg_helloworld3==1.0').digest ==
                 hashlib.md5('pkg_helloworld3==1.0').hexdigest())
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -132,7 +132,6 @@ class TestVenvConfig:
         assert DepOption._is_same_dep('pkg_hello-world3==1.0', 'pkg_hello-world3<=2.0')
         assert not DepOption._is_same_dep('pkg_hello-world3==1.0', 'otherpkg>=2.0')
 
-
     def test_digest(self):
         with tempfile.NamedTemporaryFile() as fh:
             fh.write('hello_world==1.0')

--- a/tox/config.py
+++ b/tox/config.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import argparse
 import itertools
+import hashlib
 import os
 import random
 import re
@@ -909,6 +910,18 @@ class DepConfig:
     def __init__(self, name, indexserver=None):
         self.name = name
         self.indexserver = indexserver
+
+    @property
+    def digest(self):
+        fname = None
+        if self.name.startswith('-r'):
+            fname = self.name[2:]
+        else:
+            fname = self.name
+        path = py.path.local(fname)
+        if not path.check(file=1):
+            return hashlib.md5(path).hexdigest()
+        return path.computehash()
 
     def __str__(self):
         if self.indexserver:

--- a/tox/config.py
+++ b/tox/config.py
@@ -920,7 +920,7 @@ class DepConfig:
             fname = self.name
         path = py.path.local(fname)
         if not path.check(file=1):
-            return hashlib.md5(path).hexdigest()
+            return hashlib.md5(self.name).hexdigest()
         return path.computehash()
 
     def __str__(self):

--- a/tox/config.py
+++ b/tox/config.py
@@ -913,14 +913,14 @@ class DepConfig:
 
     @property
     def digest(self):
-        fname = None
-        if self.name.startswith('-r'):
-            fname = self.name[2:]
+        fname = str(self.name)
+        if fname.startswith('-r'):
+            fname = fname[2:]
         else:
-            fname = self.name
+            fname = fname
         path = py.path.local(fname)
         if not path.check(file=1):
-            return hashlib.md5(self.name + (self.indexserver or '')).hexdigest()
+            return hashlib.md5(fname + (self.indexserver or '')).hexdigest()
         return path.computehash()
 
     def __str__(self):

--- a/tox/config.py
+++ b/tox/config.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import argparse
-import hashlib
 import itertools
 import os
 import random

--- a/tox/config.py
+++ b/tox/config.py
@@ -916,11 +916,9 @@ class DepConfig:
         fname = str(self.name)
         if fname.startswith('-r'):
             fname = fname[2:]
-        else:
-            fname = fname
         path = py.path.local(fname)
         if not path.check(file=1):
-            return hashlib.md5(fname + (self.indexserver or '')).hexdigest()
+            return "0" * 32
         return path.computehash()
 
     def __str__(self):

--- a/tox/config.py
+++ b/tox/config.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
 
 import argparse
-import itertools
 import hashlib
+import itertools
 import os
 import random
 import re
@@ -920,7 +920,7 @@ class DepConfig:
             fname = self.name
         path = py.path.local(fname)
         if not path.check(file=1):
-            return hashlib.md5(self.name).hexdigest()
+            return hashlib.md5(self.name + self.indexserver or '').hexdigest()
         return path.computehash()
 
     def __str__(self):

--- a/tox/config.py
+++ b/tox/config.py
@@ -920,7 +920,7 @@ class DepConfig:
             fname = self.name
         path = py.path.local(fname)
         if not path.check(file=1):
-            return hashlib.md5(self.name + self.indexserver or '').hexdigest()
+            return hashlib.md5(self.name + (self.indexserver or '')).hexdigest()
         return path.computehash()
 
     def __str__(self):

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -1,5 +1,6 @@
 import ast
 import codecs
+import hashlib
 import os
 import re
 import sys
@@ -156,6 +157,7 @@ class VirtualEnv(object):
         """ return status string for updating actual venv to match configuration.
             if status string is empty, all is ok.
         """
+
         rconfig = CreationConfig.readconfig(self.path_config)
         if not self.envconfig.recreate and rconfig and \
            rconfig.matches(self._getliveconfig()):
@@ -417,7 +419,7 @@ class VirtualEnv(object):
 def getdigest(path):
     path = py.path.local(path)
     if not path.check(file=1):
-        return "0" * 32
+        return hashlib.md5(path).hexdigest()
     return path.computehash()
 
 

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -1,6 +1,5 @@
 import ast
 import codecs
-import hashlib
 import os
 import re
 import sys
@@ -157,7 +156,6 @@ class VirtualEnv(object):
         """ return status string for updating actual venv to match configuration.
             if status string is empty, all is ok.
         """
-
         rconfig = CreationConfig.readconfig(self.path_config)
         if not self.envconfig.recreate and rconfig and \
            rconfig.matches(self._getliveconfig()):
@@ -415,10 +413,10 @@ class VirtualEnv(object):
 
 
 def getdigest(path):
-    fpath = py.path.local(path)
-    if not fpath.check(file=1):
-        return hashlib.md5(path).hexdigest()
-    return fpath.computehash()
+    path = py.path.local(path)
+    if not path.check(file=1):
+        return "0" * 32
+    return path.computehash()
 
 
 @hookimpl

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -190,9 +190,7 @@ class VirtualEnv(object):
         alwayscopy = self.envconfig.alwayscopy
         deps = []
         for dep in self._getresolvedeps():
-            raw_dep = dep.name
-            md5 = getdigest(raw_dep)
-            deps.append((md5, raw_dep))
+            deps.append((dep.digest, dep.name))
         return CreationConfig(md5, python, version,
                               sitepackages, develop, deps, alwayscopy)
 
@@ -417,10 +415,10 @@ class VirtualEnv(object):
 
 
 def getdigest(path):
-    path = py.path.local(path)
-    if not path.check(file=1):
+    fpath = py.path.local(path)
+    if not fpath.check(file=1):
         return hashlib.md5(path).hexdigest()
-    return path.computehash()
+    return fpath.computehash()
 
 
 @hookimpl


### PR DESCRIPTION
This seems to be a long standing fundamental issue with tox, thats been long sidelined by calling -r in deps spec experimental, but given its common usage,  one worth correcting given its a common pitfall, and reported numerous times per discussion and refs in #149. i took a look at the suggestions in there of various other tools, but they all had various pitfalls, and also took a look at what some other real world projects are doing with tox (like botocore which does a separate installer script in commands to avoid this pitfall) before deciding the simplest thing was just fixing tox, via checksum on requirements files.

