### PR TITLE
Support space in long and short options with spaces in deps

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,7 +20,6 @@ Eugene Yunak
 Fernando L. Pereira
 Igor Duarte Cardoso
 Ionel Maries Cristian
-Ionel Maries Cristian
 Itxaka Serrano
 Jannis Leidel
 Josh Smeaton

--- a/changelog/668.feature.rst
+++ b/changelog/668.feature.rst
@@ -1,0 +1,1 @@
+Allow spaces in command line options to pip in deps. Where previously only ``deps=-rreq.txt`` and ``deps=--requirement=req.txt`` worked, now also ``deps=-r req.txt`` and ``deps=--requirement req.txt`` work - by @cryvate

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -118,6 +118,24 @@ class TestVenvConfig:
             'dep1==1.5', 'https://pypi.python.org/xyz/pkg1.tar.gz'
         ]
 
+    def test_process_deps(self, newconfig):
+        config = newconfig([], """
+            [testenv]
+            deps =
+                -r requirements.txt
+                --index-url https://pypi.org/simple
+                -fhttps://pypi.org/packages
+                --global-option=foo
+                -v dep1
+                --help dep2
+        """)  # note that those last two are invalid
+        envconfig = config.envconfigs['python']
+        assert [str(x) for x in config.envconfigs['python'].deps] == [
+            '-rrequirements.txt', '--index-url=https://pypi.org/simple',
+            '-fhttps://pypi.org/packages', '--global-option=foo',
+            '-v dep1', '--help dep2'
+        ]
+
     def test_is_same_dep(self):
         """
         Ensure correct parseini._is_same_dep is working with a few samples.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,7 +129,6 @@ class TestVenvConfig:
                 -v dep1
                 --help dep2
         """)  # note that those last two are invalid
-        envconfig = config.envconfigs['python']
         assert [str(x) for x in config.envconfigs['python'].deps] == [
             '-rrequirements.txt', '--index-url=https://pypi.org/simple',
             '-fhttps://pypi.org/packages', '--global-option=foo',

--- a/tox/config.py
+++ b/tox/config.py
@@ -31,11 +31,11 @@ hookimpl = pluggy.HookimplMarker("tox")
 
 _dummy = object()
 
-PIP_INSTALL_SHORT_OPTIONS_ARGUMENT = ['-{}'.format(option) for option in [
+PIP_INSTALL_SHORT_OPTIONS_ARGUMENT = ['-{0}'.format(option) for option in [
     'c', 'e', 'r', 'b', 't', 'd',
 ]]
 
-PIP_INSTALL_LONG_OPTIONS_ARGUMENT = ['--{}'.format(option) for option in [
+PIP_INSTALL_LONG_OPTIONS_ARGUMENT = ['--{0}'.format(option) for option in [
     'constraint', 'editable', 'requirement', 'build', 'target', 'download',
     'src', 'upgrade-strategy', 'install-options', 'global-option',
     'root', 'prefix', 'no-binary', 'only-binary', 'index-url',

--- a/tox/config.py
+++ b/tox/config.py
@@ -143,12 +143,16 @@ class DepOption:
                 # in case of a short option, we remove the space
                 for option in PIP_INSTALL_SHORT_OPTIONS_ARGUMENT:
                     if name.startswith(option):
-                        name = option + name[len(option):].strip()
+                        name = '{0}{1}'.format(
+                            option, name[len(option):].strip()
+                        )
 
                 # in case of a long option, we add an equal sign
                 for option in PIP_INSTALL_LONG_OPTIONS_ARGUMENT:
                     if name.startswith(option + ' '):
-                        name = option + '=' + name[len(option):].strip()
+                        name = '{0}={1}'.format(
+                            option, name[len(option):].strip()
+                        )
 
             name = self._replace_forced_dep(name, config)
             deps.append(DepConfig(name, ixserver))

--- a/tox/config.py
+++ b/tox/config.py
@@ -147,7 +147,7 @@ class DepOption:
 
                 # in case of a long option, we add an equal sign
                 for option in PIP_INSTALL_LONG_OPTIONS_ARGUMENT:
-                    if name.startswith(option):
+                    if name.startswith(option + ' '):
                         name = option + '=' + name[len(option):].strip()
 
             name = self._replace_forced_dep(name, config)

--- a/tox/config.py
+++ b/tox/config.py
@@ -31,6 +31,18 @@ hookimpl = pluggy.HookimplMarker("tox")
 
 _dummy = object()
 
+PIP_INSTALL_SHORT_OPTIONS_ARGUMENT = ['-{}'.format(option) for option in [
+    'c', 'e', 'r', 'b', 't', 'd',
+]]
+
+PIP_INSTALL_LONG_OPTIONS_ARGUMENT = ['--{}'.format(option) for option in [
+    'constraint', 'editable', 'requirement', 'build', 'target', 'download',
+    'src', 'upgrade-strategy', 'install-options', 'global-option',
+    'root', 'prefix', 'no-binary', 'only-binary', 'index-url',
+    'extra-index-url', 'find-links', 'proxy', 'retries', 'timeout',
+    'exists-action', 'trusted-host', 'client-cert', 'cache-dir',
+]]
+
 
 def get_plugin_manager(plugins=()):
     # initialize plugin manager
@@ -124,6 +136,20 @@ class DepOption:
             else:
                 name = depline.strip()
                 ixserver = None
+
+                # we need to process options, in case they contain a space,
+                # as the subprocess call to pip install will otherwise fail.
+
+                # in case of a short option, we remove the space
+                for option in PIP_INSTALL_SHORT_OPTIONS_ARGUMENT:
+                    if name.startswith(option):
+                        name = option + name[len(option):].strip()
+
+                # in case of a long option, we add an equal sign
+                for option in PIP_INSTALL_LONG_OPTIONS_ARGUMENT:
+                    if name.startswith(option):
+                        name = option + '=' + name[len(option):].strip()
+
             name = self._replace_forced_dep(name, config)
             deps.append(DepConfig(name, ixserver))
         return deps


### PR DESCRIPTION
Add the moment, one cannot use options in deps like one does on the command line for pip:

`deps = -r foo`

gives an error, due to pip trying interpret `-r foo` as a requirement. This goes for all options that have an argument. The current situation is that on either has no space (short option) or an equal sign (long option). This is inconsistent with pip install itself, 

Previously, these would have given an error when trying to run `pip install`, now it will pass. This fixes #658.

For background, the arguments are processed again in the [_install method of class Virtualenv](https://github.com/tox-dev/tox/blob/f1a933b59c2682f40054c0cabe8c1f42a3635168/tox/venv.py#L311) and then in [method run_install_command it is given popen](https://github.com/tox-dev/tox/blob/f1a933b59c2682f40054c0cabe8c1f42a3635168/tox/venv.py#L307).