### PR TITLE
Skip whitespace in envstr.

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -567,6 +567,11 @@ You can still list environments explicitly along with generated ones::
 
     envlist = {py26,py27}-django{15,16}, docs, flake
 
+Keep in mind that whitespace characters (except newline) within ``{}``
+are stripped, so the following line defines the same environment names::
+
+    envlist = {py26, py27}-django{ 15, 16 }, docs, flake
+
 .. note::
 
     To help with understanding how the variants will produce section values,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,7 +160,7 @@ class TestConfigPlatform:
         monkeypatch.setattr(sys, "platform", "win32")
         config = newconfig([], """
             [tox]
-            envlist = py27-{win,lin,osx}
+            envlist = py27-{win, lin,osx }
             [testenv]
             platform =
                 win: win32

--- a/tox/config.py
+++ b/tox/config.py
@@ -895,7 +895,7 @@ def _expand_envstr(envstr):
 
     def expand(env):
         tokens = re.split(r'\{([^}]+)\}', env)
-        parts = [token.split(',') for token in tokens]
+        parts = [re.sub('\s+', '', token).split(',') for token in tokens]
         return [''.join(variant) for variant in itertools.product(*parts)]
 
     return mapcat(expand, envlist)


### PR DESCRIPTION
This change would allow the following version matrix:

```ini
[tox]
envlist = py24-django{ 12, 13                                       },
          py25-django{ 12, 13, 14                                   },
          py26-django{     13, 14, 15, 16                           },
          py27-django{         14, 15, 16, 17, 18, 19, 110, 111     },
          py32-django{             15, 16, 17, 18                   },
          py33-django{             15, 16, 17, 18                   },
          py34-django{                     17, 18, 19, 110, 111, 20 },
          py35-django{                         18, 19, 110, 111, 20 },
          py36-django{                                      111, 20 }
```

In the meanwhile, one can install `tox` enabling such config by
```
pip install git+https://github.com/andreif/tox@feature/skip-whitespace-in-envstr
```