### PR TITLE
Do not print empty headings

### DIFF
--- a/changelog/601.feature.rst
+++ b/changelog/601.feature.rst
@@ -1,0 +1,1 @@
+Headings like ``installed: <packages>`` will not be printed if there is no output to display after the :, unless verbosity is set. By @cryvate

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -673,6 +673,28 @@ def test_alwayscopy_default(initproj, cmd):
     assert "virtualenv --always-copy" not in result.stdout.str()
 
 
+def test_empty_activity_ignored(initproj, cmd):
+    initproj("example123", filedefs={'tox.ini': """
+            [testenv]
+            list_dependencies_command=echo
+            commands={envpython} --version
+    """})
+    result = cmd.run("tox")
+    assert not result.ret
+    assert "installed:" not in result.stdout.str()
+
+
+def test_empty_activity_shown_verbose(initproj, cmd):
+    initproj("example123", filedefs={'tox.ini': """
+            [testenv]
+            list_dependencies_command=echo
+            commands={envpython} --version
+    """})
+    result = cmd.run("tox", "-v")
+    assert not result.ret
+    assert "installed:" in result.stdout.str()
+
+
 def test_test_piphelp(initproj, cmd):
     initproj("example123", filedefs={'tox.ini': """
         # content of: tox.ini

--- a/tox/session.py
+++ b/tox/session.py
@@ -98,7 +98,10 @@ class Action(object):
 
     def setactivity(self, name, msg):
         self.activity = name
-        self.report.verbosity0("%s %s: %s" % (self.venvname, name, msg), bold=True)
+        if msg:
+            self.report.verbosity0("%s %s: %s" % (self.venvname, name, msg), bold=True)
+        else:
+            self.report.verbosity1("%s %s: %s" % (self.venvname, name, msg), bold=True)
 
     def info(self, name, msg):
         self.report.verbosity1("%s %s: %s" % (self.venvname, name, msg), bold=True)


### PR DESCRIPTION
Headings like installed: <packages> will not be printed if there is no output to display after the :, unless verbosity is set.

Fixes issue #601.
