### PR TITLE
Exclude inline comments from envlist

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2180,7 +2180,7 @@ class TestCmdInvocation:
         initproj('listenvs_all_verbose_description', filedefs={
             'tox.ini': '''
             [tox]
-            envlist={py27,py36}-{windows,linux}
+            envlist={py27,py36}-{windows,linux} # py26
             [testenv]
             description= py27: run pytest on Python 2.7
                          py36: run pytest on Python 3.6

--- a/tox/config.py
+++ b/tox/config.py
@@ -906,8 +906,8 @@ class parseini:
 def _split_env(env):
     """if handed a list, action="append" was used for -e """
     if not isinstance(env, list):
-        if '\n' in env:
-            env = ','.join(env.split('\n'))
+        env = [e.split('#', 1)[0].strip() for e in env.split('\n')]
+        env = ','.join([e for e in env if e])
         env = [env]
     return mapcat(_expand_envstr, env)
 


### PR DESCRIPTION
Using inline comments in envlist config
```ini
[tox]
envlist = one, # two,
          # three,
          four, # five
```
results in adding them as envs
```sh
$ tox -l
one
#two
four
#five
```
This PR fixes that
```sh
$ tox -l
one
four
```