### PR TITLE
Add a -q (quiet) option to tox

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,6 +19,7 @@ Eli Collins
 Eugene Yunak
 Fernando L. Pereira
 Henk-Jaap Wagenaar
+Ian Stapleton Cordasco
 Igor Duarte Cardoso
 Ionel Maries Cristian
 Itxaka Serrano

--- a/changelog/256.feature.rst
+++ b/changelog/256.feature.rst
@@ -1,1 +1,5 @@
-Add a ``-q`` option to progressively silence tox's output. By @sigmavirus24
+Add a ``-q`` option to progressively silence tox's output. For each time you specify ``-q`` to tox,
+the output provided by tox reduces. This option allows you to see only your command output without
+the default verbosity of what tox is doing. This also counter-acts usage of ``-v``. For example,
+running ``tox -v -q ...`` will provide you with the default verbosity. ``tox -vv -q`` is equivalent
+to ``tox -v``. By @sigmavirus24

--- a/changelog/256.feature.rst
+++ b/changelog/256.feature.rst
@@ -1,0 +1,1 @@
+Add a ``-q`` option to progressively silence tox's output. By @sigmavirus24

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1518,6 +1518,14 @@ class TestGlobalOptions:
         config = newconfig(["-vv"], "")
         assert config.option.verbosity == 2
 
+    def test_quiet(self, newconfig):
+        config = newconfig([], "")
+        assert config.option.quiet == 0
+        config = newconfig(["-q"], "")
+        assert config.option.quiet == 1
+        config = newconfig(["-qq"], "")
+        assert config.option.quiet == 2
+
     def test_substitution_jenkins_default(self, tmpdir,
                                           monkeypatch, newconfig):
         monkeypatch.setenv("HUDSON_URL", "xyz")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1512,19 +1512,21 @@ class TestGlobalOptions:
 
     def test_verbosity(self, newconfig):
         config = newconfig([], "")
-        assert config.option.verbosity == 0
+        assert config.option.verbose_level == 0
         config = newconfig(["-v"], "")
-        assert config.option.verbosity == 1
+        assert config.option.verbose_level == 1
         config = newconfig(["-vv"], "")
-        assert config.option.verbosity == 2
+        assert config.option.verbose_level == 2
 
-    def test_quiet(self, newconfig):
-        config = newconfig([], "")
-        assert config.option.quiet == 0
-        config = newconfig(["-q"], "")
-        assert config.option.quiet == 1
-        config = newconfig(["-qq"], "")
-        assert config.option.quiet == 2
+    @pytest.mark.parametrize('args, expected', [
+        ([], 0),
+        (["-q"], 1),
+        (["-qq"], 2),
+        (["-qqq"], 3),
+    ])
+    def test_quiet(self, args, expected, newconfig):
+        config = newconfig(args, "")
+        assert config.option.quiet_level == expected
 
     def test_substitution_jenkins_default(self, tmpdir,
                                           monkeypatch, newconfig):

--- a/tox/config.py
+++ b/tox/config.py
@@ -358,6 +358,8 @@ def tox_addoption(parser):
     parser.add_argument("-v", action='count', dest="verbosity", default=0,
                         help="increase verbosity of reporting output. -vv mode turns off "
                         "output redirection for package installation")
+    parser.add_argument("-q", action="count", dest="quiet", default=0,
+                        help="progressively silence reporting output.")
     parser.add_argument("--showconfig", action="store_true",
                         help="show configuration information for all environments. ")
     parser.add_argument("-l", "--listenvs", action="store_true",

--- a/tox/config.py
+++ b/tox/config.py
@@ -355,10 +355,10 @@ def tox_addoption(parser):
                         help="show help about options")
     parser.add_argument("--help-ini", "--hi", action="store_true", dest="helpini",
                         help="show help about ini-names")
-    parser.add_argument("-v", action='count', dest="verbosity", default=0,
+    parser.add_argument("-v", action='count', dest="verbose_level", default=0,
                         help="increase verbosity of reporting output. -vv mode turns off "
                         "output redirection for package installation")
-    parser.add_argument("-q", action="count", dest="quiet", default=0,
+    parser.add_argument("-q", action="count", dest="quiet_level", default=0,
                         help="progressively silence reporting output.")
     parser.add_argument("--showconfig", action="store_true",
                         help="show configuration information for all environments. ")

--- a/tox/session.py
+++ b/tox/session.py
@@ -230,6 +230,14 @@ class Action(object):
                                   stdout=stdout, stderr=stderr, env=env)
 
 
+class Verbosity(object):
+    DEBUG = 2
+    INFO = 1
+    DEFAULT = 0
+    QUIET = -1
+    EXTRA_QUIET = -2
+
+
 class Reporter(object):
     actionchar = "-"
 
@@ -242,9 +250,10 @@ class Reporter(object):
     @property
     def verbosity(self):
         if self.session:
-            return self.session.config.option.verbosity - self.session.config.option.quiet
+            return (self.session.config.option.verbose_level -
+                    self.session.config.option.quiet_level)
         else:
-            return 2
+            return Verbosity.DEBUG
 
     def logpopen(self, popen, env):
         """ log information about the action.popen() created process. """
@@ -268,11 +277,11 @@ class Reporter(object):
         delattr(action, '_starttime')
 
     def startsummary(self):
-        if self.verbosity >= -1:
+        if self.verbosity >= Verbosity.QUIET:
             self.tw.sep("_", "summary")
 
     def info(self, msg):
-        if self.verbosity >= 2:
+        if self.verbosity >= Verbosity.DEBUG:
             self.logline(msg)
 
     def using(self, msg):
@@ -299,15 +308,15 @@ class Reporter(object):
         self.logline(msg, green=True)
 
     def warning(self, msg):
-        if self.verbosity >= -1:
+        if self.verbosity >= Verbosity.QUIET:
             self.logline("WARNING:" + msg, red=True)
 
     def error(self, msg):
-        if self.verbosity >= -1:
+        if self.verbosity >= Verbosity.QUIET:
             self.logline("ERROR: " + msg, red=True)
 
     def skip(self, msg):
-        if self.verbosity >= -1:
+        if self.verbosity >= Verbosity.QUIET:
             self.logline("SKIPPED:" + msg, yellow=True)
 
     def logline(self, msg, **opts):
@@ -315,15 +324,15 @@ class Reporter(object):
         self.tw.line("%s" % msg, **opts)
 
     def verbosity0(self, msg, **opts):
-        if self.verbosity >= 0:
+        if self.verbosity >= Verbosity.DEFAULT:
             self.logline("%s" % msg, **opts)
 
     def verbosity1(self, msg, **opts):
-        if self.verbosity >= 1:
+        if self.verbosity >= Verbosity.INFO:
             self.logline("%s" % msg, **opts)
 
     def verbosity2(self, msg, **opts):
-        if self.verbosity >= 2:
+        if self.verbosity >= Verbosity.DEBUG:
             self.logline("%s" % msg, **opts)
 
     # def log(self, msg):
@@ -388,12 +397,13 @@ class Session:
 
     def runcommand(self):
         self.report.using("tox-%s from %s" % (tox.__version__, tox.__file__))
+        verbosity = (self.report.verbosity > Verbosity.DEFAULT)
         if self.config.option.showconfig:
             self.showconfig()
         elif self.config.option.listenvs:
-            self.showenvs(all_envs=False, description=self.config.option.verbosity > 0)
+            self.showenvs(all_envs=False, description=verbosity)
         elif self.config.option.listenvs_all:
-            self.showenvs(all_envs=True, description=self.config.option.verbosity > 0)
+            self.showenvs(all_envs=True, description=verbosity)
         else:
             return self.subcommand_test()
 

--- a/tox/session.py
+++ b/tox/session.py
@@ -242,7 +242,7 @@ class Reporter(object):
     @property
     def verbosity(self):
         if self.session:
-            return self.session.config.option.verbosity
+            return self.session.config.option.verbosity - self.session.config.option.quiet
         else:
             return 2
 
@@ -268,7 +268,8 @@ class Reporter(object):
         delattr(action, '_starttime')
 
     def startsummary(self):
-        self.tw.sep("_", "summary")
+        if self.verbosity >= -1:
+            self.tw.sep("_", "summary")
 
     def info(self, msg):
         if self.verbosity >= 2:
@@ -298,13 +299,16 @@ class Reporter(object):
         self.logline(msg, green=True)
 
     def warning(self, msg):
-        self.logline("WARNING:" + msg, red=True)
+        if self.verbosity >= -1:
+            self.logline("WARNING:" + msg, red=True)
 
     def error(self, msg):
-        self.logline("ERROR: " + msg, red=True)
+        if self.verbosity >= -1:
+            self.logline("ERROR: " + msg, red=True)
 
     def skip(self, msg):
-        self.logline("SKIPPED:" + msg, yellow=True)
+        if self.verbosity >= -1:
+            self.logline("SKIPPED:" + msg, yellow=True)
 
     def logline(self, msg, **opts):
         self._reportedlines.append(msg)


### PR DESCRIPTION
Sometimes the output of tox in addition to the output of the command(s)
tox is running can be a overwhelming and confusing. Allowing users to
silence tox's output is incredibly useful in focusing on the
command(s)'s output.

Resolves #256

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
