### PR TITLE
Fixed running the internal tox test suite from a path containing spaces

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps = pytest >= 3.0.0
        pytest-xdist
 ;NOTE --cov-config={toxinidir}/tox.ini is necessary until
 ;https://github.com/pytest-dev/pytest-cov/issues/168 is fixed
-commands = pytest {posargs:tests} --cov-config={toxinidir}/tox.ini --cov={envsitepackagesdir}/tox --timeout=180
+commands = pytest {posargs:tests} --cov-config="{toxinidir}/tox.ini" --cov="{envsitepackagesdir}/tox" --timeout=180
 
 [testenv:dev]
 description = DEV environment, if no posarg is specified: run pytest
@@ -26,8 +26,8 @@ basepython = python3.6
 deps = sphinx >= 1.6.3, < 2
        towncrier >= 17.8.0
        {[testenv]deps}
-commands = sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out --color -W -bhtml
-           sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out --color -W -blinkcheck
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml
+           sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -blinkcheck
 
 [testenv:fix-lint]
 basepython = python3.6
@@ -75,7 +75,7 @@ skip_install = True
 deps = devpi
        towncrier
        twine
-commands = {toxinidir}/tasks/pra.sh {posargs}
+commands = "{toxinidir}/tasks/pra.sh" {posargs}
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Quoted `config.ini` command paths potentially containing spaces.

This avoids code like the code-coverage pytest plugin failing due to tests being run when the tox project's development folder path contains spaces.

Seen fail on Windows, so not 100% positive the change is ok for non-Windows platforms.