### PR TITLE
do not show failed py launcher call stderr output

### DIFF
--- a/tests/test_interpreters.py
+++ b/tests/test_interpreters.py
@@ -26,8 +26,15 @@ def test_locate_via_py(monkeypatch):
         assert exe == 'py'
         return 'py'
 
-    def fake_popen(cmd, stdout):
+    def fake_popen(cmd, stdout, stderr):
         assert cmd[:3] == ('py', '-3.2', '-c')
+
+        # need to pipe all stdout to collect the version information & need to
+        # do the same for stderr output to avoid it being forwarded as the
+        # current process's output, e.g. when the python launcher reports the
+        # requested Python interpreter not being installed on the system
+        assert stdout is subprocess.PIPE
+        assert stderr is subprocess.PIPE
 
         class proc:
             returncode = 0

--- a/tox/interpreters.py
+++ b/tox/interpreters.py
@@ -168,9 +168,8 @@ else:
         script = "import sys; print(sys.executable)"
         py_exe = distutils.spawn.find_executable('py')
         if py_exe:
-            proc = subprocess.Popen(
-                (py_exe, ver, '-c', script), stdout=subprocess.PIPE,
-            )
+            proc = subprocess.Popen((py_exe, ver, '-c', script),
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, _ = proc.communicate()
             if not proc.returncode:
                 return out.decode('UTF-8').strip()


### PR DESCRIPTION
This avoid stderr output like `Requested Python version (X.Y) not installed` when running tox (at least on Windows) and there is a test environment defined in the tox configuration file for which a suitable Python interpreter version is not installed on the system.

The error described above was occurring even when just running tox with the `--help` command-line option, and even if explicitly requesting a different test environment using the `-e` command-line option.