### PR TITLE
drop Python 2.6 and 3.3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@ htmlcov
 .idea
 .eggs/
 py27/
-
-.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ sudo: false
 language: python
 cache: python
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ matrix:
   - os: osx
     language: generic
 
-before_install: if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis-osx; fi
+before_install:
+ - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis-osx; fi
+ # work around https://github.com/travis-ci/travis-ci/issues/8363
+ - pyenv global system 3.5
 install: pip install -U six && pip install --pre -U tox
 script: tox -e py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 before_install:
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis-osx; fi
  # work around https://github.com/travis-ci/travis-ci/issues/8363
- - pyenv global system 3.5
+ - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then pyenv global system 3.5; fi
 install: pip install -U six && pip install --pre -U tox
 script: tox -e py
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,7 @@
 environment:
   matrix:
     - TOXENV: fix-lint
-    - TOXENV: py26
     - TOXENV: py27
-    - TOXENV: py33
     - TOXENV: py34
     - TOXENV: py35
     - TOXENV: py36
@@ -15,8 +13,8 @@ build: false  # Not a C# project
 install: C:\Python36\python -m pip install --pre -U tox
 test_script: C:\Python36\scripts\tox
 after_test:
-  - if exist .coverage.* (C:\Python36\scripts\tox -e coverage) else (echo no .coverage files)
-  - if exist coverage.xml (C:\Python36\scripts\tox -e codecov) else (echo no coverage.xml)
+  - if exist .tox\.coverage.* (C:\Python36\scripts\tox -e coverage) else (echo no .coverage files)
+  - if exist .tox\coverage.xml (C:\Python36\scripts\tox -e codecov) else (echo no coverage.xml)
 
 cache:
   - '%LOCALAPPDATA%\pip\cache'

--- a/changelog/679.feature.rst
+++ b/changelog/679.feature.rst
@@ -1,0 +1,2 @@
+drop Pyhton ``2.6`` and ``3.3`` support: ``setuptools`` dropped supporting these, and as we depend on it we'll follow
+up with doing the same (use ``tox <= 2.9.1`` if you still need this support) - by @gaborbernat

--- a/changelog/679.feature.rst
+++ b/changelog/679.feature.rst
@@ -1,2 +1,2 @@
-drop Pyhton ``2.6`` and ``3.3`` support: ``setuptools`` dropped supporting these, and as we depend on it we'll follow
+drop Python ``2.6`` and ``3.3`` support: ``setuptools`` dropped supporting these, and as we depend on it we'll follow
 up with doing the same (use ``tox <= 2.9.1`` if you still need this support) - by @gaborbernat

--- a/doc/_static/sphinxdoc.css
+++ b/doc/_static/sphinxdoc.css
@@ -257,7 +257,7 @@ td.linenos pre {
 
 div.quotebar {
     background-color: #f8f8f8;
-    max-width: 250px;
+    max-width: 350px;
     float: right;
     padding: 2px 7px;
     border: 1px solid #ccc;

--- a/doc/config-v2.rst
+++ b/doc/config-v2.rst
@@ -62,7 +62,7 @@ namely these goals:
 Example: Generating and selecting variants
 ----------------------------------------------
 
-Suppose you want to test your package against python2.6, python2.7 and on the
+Suppose you want to test your package against python3.6, python2.7 and on the
 windows and linux platforms.  Today you would have to
 write down 2*2 = 4 ``[testenv:*]`` sections and then instruct
 tox to run a specific list of environments on each platform.
@@ -71,7 +71,7 @@ With tox-1.X you can directlys specify combinations::
 
     # combination syntax gives 2 * 2 = 4 testenv names
     #
-    envlist = {py26,py27}-{win,linux}
+    envlist = {py27,py36}-{win,linux}
 
     [testenv]
     deps = pytest
@@ -79,19 +79,19 @@ With tox-1.X you can directlys specify combinations::
            win: windows
            linux: linux
     basepython =
-           py26: python2.6
            py27: python2.7
+           py36: python3.6
     commands = pytest
 
 Let's go through this step by step::
 
-    envlist = {py26,py27}-{windows,linux}
+    envlist = {py27,py36}-{windows,linux}
 
 This is bash-style syntax and will create ``2*2=4`` environment names
 like this::
 
-    py26-windows
-    py26-linux
+    py36-windows
+    py36-linux
     py27-windows
     py27-linux
 
@@ -110,10 +110,10 @@ The next configuration item in the ``testenv`` section deals with
 the python interpreter::
 
     basepython =
-           py26: python2.6
+           py36: python3.6
            py27: python2.7
 
-This defines a python executable, depending on if ``py26`` or ``py27``
+This defines a python executable, depending on if ``py36`` or ``py27``
 appears in the environment name.
 
 The last config item is simply the invocation of the test runner::
@@ -128,7 +128,7 @@ Nothing special here :)
     settings, so the above ini-file can be further reduced::
 
         [tox]
-        envlist = {py26,py27}-{win,linux}
+        envlist = {py27,py36}-{win,linux}
 
         [testenv]
         deps = pytest
@@ -185,7 +185,7 @@ If you want to have your package installed with both easy_install
 and pip, you can list them in your envlist likes this::
 
     [tox]
-    envlist = py[26,27,32]-django[13,14]-[easy,pip]
+    envlist = py[36,27,35]-django[13,14]-[easy,pip]
 
 If no installer is specified, ``pip`` will be used.
 
@@ -195,7 +195,7 @@ Default settings related to environments names/variants
 tox comes with predefined settings for certain variants, namely:
 
 * ``{easy,pip}`` use easy_install or pip respectively
-* ``{py24,py25,py26,py27,py31,py32,py33,py34,pypy19]`` use the respective
+* ``{py27,py36,py35,py34,pypy19]`` use the respective
   pythonNN or PyPy interpreter
 * ``{win32,linux,darwin}`` defines the according ``platform``.
 
@@ -221,7 +221,7 @@ file has 159 lines and a lot of repetition, the new one would +have 20
 lines and almost no repetition::
 
      [tox]
-     envlist = {py25,py26,py27}-{django12,django13}{,-example}
+     envlist = {py35,py27,py36}-{django12,django13}{,-example}
 
      [testenv]
      deps=
@@ -253,13 +253,13 @@ Another `tox.ini
 has 233 lines and runs tests against multiple Postgres and Mysql
 engines.  It also performs backend-specific test commands, passing
 different command line options to the test script.  With the new tox-1.X
-we not only can do the same with 32 non-repetive configuration lines but
+we not only can do the same with 35 non-repetive configuration lines but
 we also produce 36 specific testenvs with specific dependencies and test
 commands::
 
     [tox]
     envlist =
-     {py24,py25,py26,py27}-{django11,django12,django13}-{nodb,pg,mysql}, docs
+     {py34,py35,py27,py36}-{django11,django12,django13}-{nodb,pg,mysql}, docs
 
     [testenv:docs]
     changedir = docs

--- a/doc/config-v2.rst
+++ b/doc/config-v2.rst
@@ -90,10 +90,10 @@ Let's go through this step by step::
 This is bash-style syntax and will create ``2*2=4`` environment names
 like this::
 
-    py36-windows
-    py36-linux
     py27-windows
     py27-linux
+    py36-windows
+    py36-linux
 
 Our ``[testenv]`` uses a new templating style for the ``platform`` definition::
 
@@ -110,8 +110,8 @@ The next configuration item in the ``testenv`` section deals with
 the python interpreter::
 
     basepython =
-           py36: python3.6
            py27: python2.7
+           py36: python3.6
 
 This defines a python executable, depending on if ``py36`` or ``py27``
 appears in the environment name.
@@ -185,7 +185,7 @@ If you want to have your package installed with both easy_install
 and pip, you can list them in your envlist likes this::
 
     [tox]
-    envlist = py[36,27,35]-django[13,14]-[easy,pip]
+    envlist = py[27,35,36]-django[13,14]-[easy,pip]
 
 If no installer is specified, ``pip`` will be used.
 
@@ -195,7 +195,7 @@ Default settings related to environments names/variants
 tox comes with predefined settings for certain variants, namely:
 
 * ``{easy,pip}`` use easy_install or pip respectively
-* ``{py27,py36,py35,py34,pypy19]`` use the respective
+* ``{py27,py34,py35,py36,pypy19]`` use the respective
   pythonNN or PyPy interpreter
 * ``{win32,linux,darwin}`` defines the according ``platform``.
 
@@ -217,11 +217,11 @@ Transforming the examples: django-rest
 
 The original `django-rest-framework tox.ini
 <https://github.com/encode/django-rest-framework/blob/b001a146d73348af18cfc4c943d87f2f389349c9/tox.ini>`_
-file has 159 lines and a lot of repetition, the new one would +have 20
+file has 159 lines and a lot of repetition, the new one would have ``20+``
 lines and almost no repetition::
 
      [tox]
-     envlist = {py35,py27,py36}-{django12,django13}{,-example}
+     envlist = {py27,py35,py36}-{django12,django13}{,-example}
 
      [testenv]
      deps=
@@ -259,7 +259,7 @@ commands::
 
     [tox]
     envlist =
-     {py34,py35,py27,py36}-{django11,django12,django13}-{nodb,pg,mysql}, docs
+     {py27,py34,py35,py36}-{django11,django12,django13}-{nodb,pg,mysql}, docs
 
     [testenv:docs]
     changedir = docs

--- a/doc/config-v2.rst
+++ b/doc/config-v2.rst
@@ -253,7 +253,7 @@ Another `tox.ini
 has 233 lines and runs tests against multiple Postgres and Mysql
 engines.  It also performs backend-specific test commands, passing
 different command line options to the test script.  With the new tox-1.X
-we not only can do the same with 35 non-repetive configuration lines but
+we not only can do the same with 32 non-repetive configuration lines but
 we also produce 36 specific testenvs with specific dependencies and test
 commands::
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -515,7 +515,7 @@ Generating environments, conditional settings
 
 .. versionadded:: 1.8
 
-Suppose you want to test your package against python2.6, python2.7 and against
+Suppose you want to test your package against python3.6, python2.7 and against
 several versions of a dependency, say Django 1.5 and Django 1.6. You can
 accomplish that by writing down 2*2 = 4 ``[testenv:*]`` sections and then
 listing all of them in ``envlist``.
@@ -523,17 +523,17 @@ listing all of them in ``envlist``.
 However, a better approach looks like this::
 
     [tox]
-    envlist = {py26,py27}-django{15,16}
+    envlist = {py36,py27}-django{15,16}
 
     [testenv]
     basepython =
-        py26: python2.6
+        py36: python3.6
         py27: python2.7
     deps =
         pytest
         django15: Django>=1.5,<1.6
         django16: Django>=1.6,<1.7
-        py26: unittest2
+        py36: unittest2
     commands = pytest
 
 This uses two new facilities of tox-1.8:
@@ -553,24 +553,24 @@ Generative envlist
 
 ::
 
-    envlist = {py26,py27}-django{15,16}
+    envlist = {py36,py27}-django{15,16}
 
 This is bash-style syntax and will create ``2*2=4`` environment names
 like this::
 
-    py26-django15
-    py26-django16
+    py36-django15
+    py36-django16
     py27-django15
     py27-django16
 
 You can still list environments explicitly along with generated ones::
 
-    envlist = {py26,py27}-django{15,16}, docs, flake
+    envlist = {py36,py27}-django{15,16}, docs, flake
 
 Keep in mind that whitespace characters (except newline) within ``{}``
 are stripped, so the following line defines the same environment names::
 
-    envlist = {py26, py27}-django{ 15, 16 }, docs, flake
+    envlist = {py36, py27}-django{ 15, 16 }, docs, flake
 
 .. note::
 
@@ -578,8 +578,8 @@ are stripped, so the following line defines the same environment names::
     you can ask tox to show their expansion with a new option::
 
         $ tox -l
-        py26-django15
-        py26-django16
+        py36-django15
+        py36-django16
         py27-django15
         py27-django16
         docs
@@ -595,12 +595,12 @@ Parts of an environment name delimited by hyphens are called factors and can
 be used to set values conditionally::
 
     basepython =
-        py26: python2.6
+        py36: python3.6
         py27: python2.7
 
-This conditional setting will lead to either ``python2.6`` or
-``python2.7`` used as base python, e.g. ``python2.6`` is selected if current
-environment contains ``py26`` factor.
+This conditional setting will lead to either ``python3.6`` or
+``python2.7`` used as base python, e.g. ``python3.6`` is selected if current
+environment contains ``py36`` factor.
 
 In list settings such as ``deps`` or ``commands`` you can freely intermix
 optional lines with unconditional ones::
@@ -609,14 +609,14 @@ optional lines with unconditional ones::
         pytest
         django15: Django>=1.5,<1.6
         django16: Django>=1.6,<1.7
-        py26: unittest2
+        py36: unittest2
 
 Reading it line by line:
 
 - ``pytest`` will be included unconditionally,
 - ``Django>=1.5,<1.6`` will be included for environments containing ``django15`` factor,
 - ``Django>=1.6,<1.7`` similarly depends on ``django16`` factor,
-- ``unittest`` will be loaded for Python 2.6 environments.
+- ``unittest`` will be loaded for Python 3.6 environments.
 
 .. note::
 
@@ -632,25 +632,25 @@ Sometimes you need to specify the same line for several factors or create a
 special case for a combination of factors. Here is how you do it::
 
     [tox]
-    envlist = py{26,27,33}-django{15,16}-{sqlite,mysql}
+    envlist = py{36,27,34}-django{15,16}-{sqlite,mysql}
 
     [testenv]
     deps =
-        py33-mysql: PyMySQL     ; use if both py33 and mysql are in an env name
-        py26,py27: urllib3      ; use if any of py26 or py27 are in an env name
-        py{26,27}-sqlite: mock  ; mocking sqlite in python 2.x
+        py34-mysql: PyMySQL     ; use if both py34 and mysql are in an env name
+        py36,py27: urllib3      ; use if any of py36 or py27 are in an env name
+        py{36,27}-sqlite: mock  ; mocking sqlite in python 2.x
 
 Take a look at first ``deps`` line. It shows how you can special case something
 for a combination of factors, you just join combining factors with a hyphen.
 This particular line states that ``PyMySQL`` will be loaded for python 3.3,
-mysql environments, e.g. ``py33-django15-mysql`` and ``py33-django16-mysql``.
+mysql environments, e.g. ``py34-django15-mysql`` and ``py34-django16-mysql``.
 
 The second line shows how you use same line for several factors - by listing
 them delimited by commas. It's possible to list not only simple factors, but
-also their combinations like ``py26-sqlite,py27-sqlite``.
+also their combinations like ``py36-sqlite,py27-sqlite``.
 
 Finally, factor expressions are expanded the same way as envlist, so last
-example could be rewritten as ``py{26,27}-sqlite``.
+example could be rewritten as ``py{36,27}-sqlite``.
 
 .. note::
 
@@ -659,11 +659,11 @@ example could be rewritten as ``py{26,27}-sqlite``.
     expression are also factors of an env then that condition is considered
     hold.
 
-    For example, environment ``py26-mysql``:
+    For example, environment ``py36-mysql``:
 
-    - could be matched with expressions ``py26``, ``py26-mysql``,
-      ``mysql-py26``,
-    - but not with ``py2`` or ``py26-sql``.
+    - could be matched with expressions ``py36``, ``py36-mysql``,
+      ``mysql-py36``,
+    - but not with ``py2`` or ``py36-sql``.
 
 
 Other Rules and notes

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -515,7 +515,7 @@ Generating environments, conditional settings
 
 .. versionadded:: 1.8
 
-Suppose you want to test your package against python3.6, python2.7 and against
+Suppose you want to test your package against python2.7, python3.6 and against
 several versions of a dependency, say Django 1.5 and Django 1.6. You can
 accomplish that by writing down 2*2 = 4 ``[testenv:*]`` sections and then
 listing all of them in ``envlist``.
@@ -523,12 +523,12 @@ listing all of them in ``envlist``.
 However, a better approach looks like this::
 
     [tox]
-    envlist = {py36,py27}-django{15,16}
+    envlist = {py27,py36}-django{15,16}
 
     [testenv]
     basepython =
-        py36: python3.6
         py27: python2.7
+        py36: python3.6
     deps =
         pytest
         django15: Django>=1.5,<1.6
@@ -558,19 +558,19 @@ Generative envlist
 This is bash-style syntax and will create ``2*2=4`` environment names
 like this::
 
-    py36-django15
-    py36-django16
     py27-django15
     py27-django16
+    py36-django15
+    py36-django16
 
 You can still list environments explicitly along with generated ones::
 
-    envlist = {py36,py27}-django{15,16}, docs, flake
+    envlist = {py27,py36}-django{15,16}, docs, flake
 
 Keep in mind that whitespace characters (except newline) within ``{}``
 are stripped, so the following line defines the same environment names::
 
-    envlist = {py36, py27}-django{ 15, 16 }, docs, flake
+    envlist = {py27,py36}-django{ 15, 16 }, docs, flake
 
 .. note::
 
@@ -578,10 +578,10 @@ are stripped, so the following line defines the same environment names::
     you can ask tox to show their expansion with a new option::
 
         $ tox -l
-        py36-django15
-        py36-django16
         py27-django15
         py27-django16
+        py36-django15
+        py36-django16
         docs
         flake
 
@@ -595,8 +595,8 @@ Parts of an environment name delimited by hyphens are called factors and can
 be used to set values conditionally::
 
     basepython =
-        py36: python3.6
         py27: python2.7
+        py36: python3.6
 
 This conditional setting will lead to either ``python3.6`` or
 ``python2.7`` used as base python, e.g. ``python3.6`` is selected if current
@@ -632,13 +632,13 @@ Sometimes you need to specify the same line for several factors or create a
 special case for a combination of factors. Here is how you do it::
 
     [tox]
-    envlist = py{36,27,34}-django{15,16}-{sqlite,mysql}
+    envlist = py{27,34,36}-django{15,16}-{sqlite,mysql}
 
     [testenv]
     deps =
         py34-mysql: PyMySQL     ; use if both py34 and mysql are in an env name
-        py36,py27: urllib3      ; use if any of py36 or py27 are in an env name
-        py{36,27}-sqlite: mock  ; mocking sqlite in python 2.x
+        py27,py36: urllib3      ; use if any of py36 or py27 are in an env name
+        py{27,36}-sqlite: mock  ; mocking sqlite in python 2.x
 
 Take a look at first ``deps`` line. It shows how you can special case something
 for a combination of factors, you just join combining factors with a hyphen.
@@ -647,10 +647,10 @@ mysql environments, e.g. ``py34-django15-mysql`` and ``py34-django16-mysql``.
 
 The second line shows how you use same line for several factors - by listing
 them delimited by commas. It's possible to list not only simple factors, but
-also their combinations like ``py36-sqlite,py27-sqlite``.
+also their combinations like ``py27-sqlite,py36-sqlite``.
 
 Finally, factor expressions are expanded the same way as envlist, so last
-example could be rewritten as ``py{36,27}-sqlite``.
+example could be rewritten as ``py{27,36}-sqlite``.
 
 .. note::
 

--- a/doc/example/basic.rst
+++ b/doc/example/basic.rst
@@ -12,7 +12,7 @@ reside next to your ``setup.py`` file:
 
     # content of: tox.ini , put in same dir as setup.py
     [tox]
-    envlist = py26,py27
+    envlist = py36,py27
     [testenv]
     deps=pytest # or 'nose' or ...
     commands=pytest  # or 'nosetests' or ...
@@ -30,9 +30,9 @@ the specified command in each of them.  With:
 
 .. code-block:: shell
 
-    tox -e py26
+    tox -e py36
 
-you can run restrict the test run to the python2.6 environment.
+you can run restrict the test run to the python3.6 environment.
 
 Available "default" test environments names are:
 
@@ -40,10 +40,8 @@ Available "default" test environments names are:
 
     py
     py2
-    py26
     py27
     py3
-    py33
     py34
     py35
     py36
@@ -319,15 +317,15 @@ use :ref:`generative-envlist` and :ref:`conditional settings <factors>` to expre
 .. code-block:: ini
 
     [tox]
-    envlist = py{26,27,33}-django{15,16}-{sqlite,mysql}
+    envlist = py{36,27,34}-django{15,16}-{sqlite,mysql}
 
     [testenv]
     deps =
         django15: Django>=1.5,<1.6
         django16: Django>=1.6,<1.7
-        py33-mysql: PyMySQL     ; use if both py33 and mysql are in an env name
-        py26,py27: urllib3      ; use if any of py26 or py27 are in an env name
-        py{26,27}-sqlite: mock  ; mocking sqlite in python 2.x
+        py34-mysql: PyMySQL     ; use if both py34 and mysql are in an env name
+        py36,py27: urllib3      ; use if any of py36 or py27 are in an env name
+        py{36,27}-sqlite: mock  ; mocking sqlite in python 2.x
 
 Prevent symbolic links in virtualenv
 ------------------------------------

--- a/doc/example/basic.rst
+++ b/doc/example/basic.rst
@@ -12,7 +12,7 @@ reside next to your ``setup.py`` file:
 
     # content of: tox.ini , put in same dir as setup.py
     [tox]
-    envlist = py36,py27
+    envlist = py27,py36
     [testenv]
     deps=pytest # or 'nose' or ...
     commands=pytest  # or 'nosetests' or ...
@@ -317,15 +317,15 @@ use :ref:`generative-envlist` and :ref:`conditional settings <factors>` to expre
 .. code-block:: ini
 
     [tox]
-    envlist = py{36,27,34}-django{15,16}-{sqlite,mysql}
+    envlist = py{27,34,36}-django{15,16}-{sqlite,mysql}
 
     [testenv]
     deps =
         django15: Django>=1.5,<1.6
         django16: Django>=1.6,<1.7
         py34-mysql: PyMySQL     ; use if both py34 and mysql are in an env name
-        py36,py27: urllib3      ; use if any of py36 or py27 are in an env name
-        py{36,27}-sqlite: mock  ; mocking sqlite in python 2.x
+        py27,py36: urllib3      ; use if any of py36 or py27 are in an env name
+        py{27,36}-sqlite: mock  ; mocking sqlite in python 2.x
 
 Prevent symbolic links in virtualenv
 ------------------------------------

--- a/doc/example/general.rst
+++ b/doc/example/general.rst
@@ -74,7 +74,7 @@ which will make the sphinx tests part of your test run.
 Selecting one or more environments to run tests against
 --------------------------------------------------------
 
-Using the ``-e ENV[,ENV2,...]``  option you explicitly list
+Using the ``-e ENV[,ENV236,...]``  option you explicitly list
 the environments where you want to run tests against. For
 example, given the previous sphinx example you may call:
 
@@ -88,9 +88,9 @@ one environment like this:
 
 .. code-block:: shell
 
-    tox -e py25,py26
+    tox -e py27,py36
 
-which would run the commands of the ``py25`` and ``py26`` testenvironments
+which would run the commands of the ``py27`` and ``py36`` testenvironments
 respectively.  The special value ``ALL`` selects all environments.
 
 You can also specify an environment list in your ``tox.ini``:
@@ -98,14 +98,14 @@ You can also specify an environment list in your ``tox.ini``:
 .. code-block:: ini
 
     [tox]
-    envlist = py25,py26
+    envlist = py27,py36
 
 or override it from the command line or from the environment variable
 ``TOXENV``:
 
 .. code-block:: shell
 
-    export TOXENV=py25,py26 # in bash style shells
+    export TOXENV=py27,py36 # in bash style shells
 
 .. _artifacts:
 

--- a/doc/example/general.rst
+++ b/doc/example/general.rst
@@ -74,7 +74,7 @@ which will make the sphinx tests part of your test run.
 Selecting one or more environments to run tests against
 --------------------------------------------------------
 
-Using the ``-e ENV[,ENV236,...]``  option you explicitly list
+Using the ``-e ENV[,ENV36,...]``  option you explicitly list
 the environments where you want to run tests against. For
 example, given the previous sphinx example you may call:
 

--- a/doc/example/nose.rst
+++ b/doc/example/nose.rst
@@ -25,7 +25,7 @@ and the following ``tox.ini`` content:
 
 you can invoke ``tox`` in the directory where your ``tox.ini`` resides.
 ``tox`` will sdist-package your project create two virtualenv environments
-with the ``python3.6`` and ``python2.5`` interpreters, respectively, and will
+with the ``python3.6`` and ``python2.7`` interpreters, respectively, and will
 then run the specified test command.
 
 

--- a/doc/example/nose.rst
+++ b/doc/example/nose.rst
@@ -25,7 +25,7 @@ and the following ``tox.ini`` content:
 
 you can invoke ``tox`` in the directory where your ``tox.ini`` resides.
 ``tox`` will sdist-package your project create two virtualenv environments
-with the ``python2.6`` and ``python2.5`` interpreters, respectively, and will
+with the ``python3.6`` and ``python2.5`` interpreters, respectively, and will
 then run the specified test command.
 
 

--- a/doc/example/nose.rst
+++ b/doc/example/nose.rst
@@ -25,7 +25,7 @@ and the following ``tox.ini`` content:
 
 you can invoke ``tox`` in the directory where your ``tox.ini`` resides.
 ``tox`` will sdist-package your project create two virtualenv environments
-with the ``python3.6`` and ``python2.7`` interpreters, respectively, and will
+with the ``python2.7`` and ``python3.6`` interpreters, respectively, and will
 then run the specified test command.
 
 

--- a/doc/example/pytest.rst
+++ b/doc/example/pytest.rst
@@ -22,7 +22,7 @@ and the following ``tox.ini`` content:
 .. code-block:: ini
 
     [tox]
-    envlist = py36,py35
+    envlist = py35,py36
 
     [testenv]
     deps = pytest               # PYPI package providing pytest
@@ -30,7 +30,7 @@ and the following ``tox.ini`` content:
 
 you can now invoke ``tox`` in the directory where your ``tox.ini`` resides.
 ``tox`` will sdist-package your project, create two virtualenv environments
-with the ``python3.6`` and ``python3.1`` interpreters, respectively, and will
+with the ``python3.5`` and ``python3.6`` interpreters, respectively, and will
 then run the specified test command in each of them.
 
 Extended example: change dir before test and use per-virtualenv tempdir
@@ -49,7 +49,7 @@ and the following ``tox.ini`` content:
 .. code-block:: ini
 
     [tox]
-    envlist = py36,py3531
+    envlist = py35,py36
     [testenv]
     changedir=tests
     deps=pytest

--- a/doc/example/pytest.rst
+++ b/doc/example/pytest.rst
@@ -22,7 +22,7 @@ and the following ``tox.ini`` content:
 .. code-block:: ini
 
     [tox]
-    envlist = py26,py31
+    envlist = py36,py35
 
     [testenv]
     deps = pytest               # PYPI package providing pytest
@@ -30,7 +30,7 @@ and the following ``tox.ini`` content:
 
 you can now invoke ``tox`` in the directory where your ``tox.ini`` resides.
 ``tox`` will sdist-package your project, create two virtualenv environments
-with the ``python2.6`` and ``python3.1`` interpreters, respectively, and will
+with the ``python3.6`` and ``python3.1`` interpreters, respectively, and will
 then run the specified test command in each of them.
 
 Extended example: change dir before test and use per-virtualenv tempdir
@@ -49,7 +49,7 @@ and the following ``tox.ini`` content:
 .. code-block:: ini
 
     [tox]
-    envlist = py26,py31
+    envlist = py36,py3531
     [testenv]
     changedir=tests
     deps=pytest

--- a/doc/example/result.rst
+++ b/doc/example/result.rst
@@ -40,7 +40,7 @@ This will create a json-formatted result file using this schema:
       "platform": "linux2",
       "installpkg": {
         "basename": "tox-1.6.0.dev1.zip",
-        "sha356": "b6982dde5789a167c4c35af0d34ef72176d0575955f5331ad04aee9f23af4336",
+        "sha256": "b6982dde5789a167c4c35af0d34ef72176d0575955f5331ad04aee9f23af4326",
         "md5": "27ead99fd7fa39ee7614cede6bf175a6"
       },
       "toxversion": "1.6.0.dev1",

--- a/doc/example/result.rst
+++ b/doc/example/result.rst
@@ -40,7 +40,7 @@ This will create a json-formatted result file using this schema:
       "platform": "linux2",
       "installpkg": {
         "basename": "tox-1.6.0.dev1.zip",
-        "sha256": "b6982dde5789a167c4c35af0d34ef72176d0575955f5331ad04aee9f23af4326",
+        "sha356": "b6982dde5789a167c4c35af0d34ef72176d0575955f5331ad04aee9f23af4336",
         "md5": "27ead99fd7fa39ee7614cede6bf175a6"
       },
       "toxversion": "1.6.0.dev1",

--- a/doc/example/unittest.rst
+++ b/doc/example/unittest.rst
@@ -19,7 +19,7 @@ and add the following ``tox.ini`` to it:
 .. code-block:: ini
 
     [tox]
-    envlist = py25,py26,py27
+    envlist = py35,py36,py27
 
     [testenv]
     changedir = tests
@@ -50,13 +50,13 @@ the checkout has a tox.ini_ that looks like this:
 .. code-block:: ini
 
     [tox]
-    envlist = py24,py25,py26,py27
+    envlist = py34,py35,py36,py27
 
     [testenv]
     deps = unittest2
     commands = unit2 discover []
 
-    [testenv:py26]
+    [testenv:py36]
     commands =
         unit2 discover []
         sphinx-build -b doctest docs html
@@ -76,8 +76,8 @@ the checkout has a tox.ini_ that looks like this:
 
 mock uses unittest2_ to run the tests. Invoking ``tox`` starts test
 discovery by executing the ``unit2 discover``
-commands on Python 2.4, 2.5, 2.6 and 2.7 respectively.  Against
-Python2.6 and Python2.7 it will additionally run sphinx-mediated
+commands on Python 2.4, 2.5, 3.6 and 2.7 respectively.  Against
+Python3.6 and Python2.7 it will additionally run sphinx-mediated
 doctests. If building the docs fails, due to a reST error, or
 any of the doctests fails, it will be reported by the tox run.
 

--- a/doc/example/unittest.rst
+++ b/doc/example/unittest.rst
@@ -19,7 +19,7 @@ and add the following ``tox.ini`` to it:
 .. code-block:: ini
 
     [tox]
-    envlist = py35,py36,py27
+    envlist = py27,py35,py36
 
     [testenv]
     changedir = tests
@@ -50,7 +50,7 @@ the checkout has a tox.ini_ that looks like this:
 .. code-block:: ini
 
     [tox]
-    envlist = py34,py35,py36,py27
+    envlist = py27,py34,py35,py36
 
     [testenv]
     deps = unittest2
@@ -76,7 +76,7 @@ the checkout has a tox.ini_ that looks like this:
 
 mock uses unittest2_ to run the tests. Invoking ``tox`` starts test
 discovery by executing the ``unit2 discover``
-commands on Python 2.4, 2.5, 3.6 and 2.7 respectively.  Against
+commands on Python 2.7, 3.4, 3.5 and 3.6 respectively.  Against
 Python3.6 and Python2.7 it will additionally run sphinx-mediated
 doctests. If building the docs fails, due to a reST error, or
 any of the doctests fails, it will be reported by the tox run.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -68,7 +68,7 @@ Current features
 * uses pip_ and setuptools_ by default.  Support for configuring the installer command
   through :confval:`install_command=ARGV`.
 
-* **cross-Python compatible**: CPython-2.7, 3.3 and higher,
+* **cross-Python compatible**: CPython-2.7, 3.4 and higher,
   Jython and pypy_.
 
 * **cross-platform**: Windows and Unix style environments

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,7 +32,7 @@ right next to your ``setup.py`` file::
 
     # content of: tox.ini , put in same dir as setup.py
     [tox]
-    envlist = py26,py27
+    envlist = py27,py36
     [testenv]
     deps=pytest       # install pytest in the venvs
     commands=pytest  # or 'nosetests' or ...
@@ -40,11 +40,11 @@ right next to your ``setup.py`` file::
 You can also try generating a ``tox.ini`` file automatically, by running
 ``tox-quickstart`` and then answering a few simple questions.
 
-To sdist-package, install and test your project against Python2.6 and Python2.7, just type::
+To sdist-package, install and test your project against Python2.7 and Python3.6, just type::
 
     tox
 
-and watch things happening (you must have python2.6 and python2.7 installed in your
+and watch things happening (you must have python3.6 and python2.7 installed in your
 environment otherwise you will see errors).  When you run ``tox`` a second time
 you'll note that it runs much faster because it keeps track of virtualenv details
 and will not recreate or re-install dependencies.  You also might want to
@@ -68,7 +68,7 @@ Current features
 * uses pip_ and setuptools_ by default.  Support for configuring the installer command
   through :confval:`install_command=ARGV`.
 
-* **cross-Python compatible**: CPython-2.6, 2.7, 3.2 and higher,
+* **cross-Python compatible**: CPython-2.7, 3.3 and higher,
   Jython and pypy_.
 
 * **cross-platform**: Windows and Unix style environments

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,7 +44,7 @@ To sdist-package, install and test your project against Python2.7 and Python3.6,
 
     tox
 
-and watch things happening (you must have python3.6 and python2.7 installed in your
+and watch things happening (you must have python2.7 and python3.6 installed in your
 environment otherwise you will see errors).  When you run ``tox`` a second time
 you'll note that it runs much faster because it keeps track of virtualenv details
 and will not recreate or re-install dependencies.  You also might want to

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -4,7 +4,7 @@ tox installation
 Install info in a nutshell
 ----------------------------------
 
-**Pythons**: CPython 2.6-3.6, Jython-2.5.1, pypy-1.9ff
+**Pythons**: CPython 2.7 and 3.4 or later, Jython-2.5.1, pypy-1.9ff
 
 **Operating systems**: Linux, Windows, OSX, Unix
 

--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,6 @@ def get_long_description():
 
 
 def main():
-    virtualenv_open = ['virtualenv>=1.11.2']
-    install_requires = ['py>=1.4.17', 'pluggy>=0.3.0,<1.0', 'six']
-    extras_require = {}
-    if has_environment_marker_support():
-        extras_require[':python_version!="3.2"'] = virtualenv_open
-    else:
-        install_requires.append(virtualenv_open)
     setuptools.setup(
         name='tox',
         description='virtualenv-based automation of test activities',
@@ -53,8 +46,10 @@ def main():
         entry_points={'console_scripts': 'tox=tox:cmdline\ntox-quickstart=tox._quickstart:main'},
         python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
         setup_requires=['setuptools_scm'],
-        install_requires=install_requires,
-        extras_require=extras_require,
+        install_requires=['py>=1.4.17',
+                          'pluggy>=0.3.0,<1.0',
+                          'six',
+                          'virtualenv>=1.11.2'],
         classifiers=['Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Developers',
                      'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -32,21 +32,13 @@ def get_long_description():
 
 
 def main():
-    version = sys.version_info[:2]
     virtualenv_open = ['virtualenv>=1.11.2']
-    virtualenv_capped = ['virtualenv>=1.11.2,<14']
     install_requires = ['py>=1.4.17', 'pluggy>=0.3.0,<1.0', 'six']
     extras_require = {}
     if has_environment_marker_support():
-        extras_require[':python_version=="2.6"'] = ['argparse']
-        extras_require[':python_version=="3.2"'] = virtualenv_capped
         extras_require[':python_version!="3.2"'] = virtualenv_open
     else:
-        if version < (2, 7):
-            install_requires += ['argparse']
-        install_requires += (
-            virtualenv_capped if version == (3, 2) else virtualenv_open
-        )
+        install_requires.append(virtualenv_open)
     setuptools.setup(
         name='tox',
         description='virtualenv-based automation of test activities',
@@ -59,21 +51,21 @@ def main():
         author_email='holger@merlinux.eu',
         packages=['tox'],
         entry_points={'console_scripts': 'tox=tox:cmdline\ntox-quickstart=tox._quickstart:main'},
+        python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
         setup_requires=['setuptools_scm'],
         install_requires=install_requires,
         extras_require=extras_require,
-        classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'Intended Audience :: Developers',
-            'License :: OSI Approved :: MIT License',
-            'Operating System :: POSIX',
-            'Operating System :: Microsoft :: Windows',
-            'Operating System :: MacOS :: MacOS X',
-            'Topic :: Software Development :: Testing',
-            'Topic :: Software Development :: Libraries',
-            'Topic :: Utilities'] + [
-                ('Programming Language :: Python :: %s' % x) for x in
-                '2 2.6 2.7 3 3.3 3.4 3.5 3.6'.split()]
+        classifiers=['Development Status :: 5 - Production/Stable',
+                     'Intended Audience :: Developers',
+                     'License :: OSI Approved :: MIT License',
+                     'Operating System :: POSIX',
+                     'Operating System :: Microsoft :: Windows',
+                     'Operating System :: MacOS :: MacOS X',
+                     'Topic :: Software Development :: Testing',
+                     'Topic :: Software Development :: Libraries',
+                     'Topic :: Utilities'] + [
+                        ('Programming Language :: Python :: {}'.format(x)) for
+                        x in '2 2.7 3 3.4 3.5 3.6'.split()]
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,7 @@ class TestVenvConfig:
             deps=
                 world1
                 :xyz:http://hello/world
-        """ % (tmpdir, ))
+        """ % (tmpdir,))
         assert config.toxworkdir == tmpdir
         assert len(config.envconfigs) == 2
         assert config.envconfigs['py1'].envdir == tmpdir.join("py1")
@@ -1022,7 +1022,7 @@ class TestConfigTestEnv:
             changedir=xyz
             [testenv:python]
             changedir=abc
-            basepython=python2.6
+            basepython=python3.6
         """)
         assert len(config.envconfigs) == 1
         envconfig = config.envconfigs['python']
@@ -1075,13 +1075,13 @@ class TestConfigTestEnv:
 
     def test_simple(tmpdir, newconfig):
         config = newconfig("""
-            [testenv:py26]
-            basepython=python2.6
+            [testenv:py36]
+            basepython=python3.6
             [testenv:py27]
             basepython=python2.7
         """)
         assert len(config.envconfigs) == 2
-        assert "py26" in config.envconfigs
+        assert "py36" in config.envconfigs
         assert "py27" in config.envconfigs
 
     def test_substitution_error(tmpdir, newconfig):
@@ -1279,10 +1279,10 @@ class TestConfigTestEnv:
         (['py27', 'py34'], ('pytest', 'py{27,34}: pytest-cov')),
     ])
     def test_take_dependencies_from_other_testenv(
-        self,
-        newconfig,
-        envlist,
-        deps
+            self,
+            newconfig,
+            envlist,
+            deps
     ):
         inisource = """
             [tox]
@@ -1388,7 +1388,7 @@ class TestConfigTestEnv:
         conf = newconfig([], inisource)
         configs = conf.envconfigs
         assert [dep.name for dep in configs['a-x'].deps] == \
-            ["dep-all", "dep-a", "dep-x"]
+               ["dep-all", "dep-a", "dep-x"]
         assert [dep.name for dep in configs['b'].deps] == ["dep-all", "dep-b"]
 
     def test_factor_ops(self, newconfig):
@@ -1415,7 +1415,7 @@ class TestConfigTestEnv:
     def test_default_factors(self, newconfig):
         inisource = """
             [tox]
-            envlist = py{26,27,33,34}-dep
+            envlist = py{27,34,36}-dep
 
             [testenv]
             deps=
@@ -1430,7 +1430,7 @@ class TestConfigTestEnv:
     def test_factors_in_boolean(self, newconfig):
         inisource = """
             [tox]
-            envlist = py{27,33}
+            envlist = py{27,36}
 
             [testenv]
             recreate =
@@ -1438,13 +1438,13 @@ class TestConfigTestEnv:
         """
         configs = newconfig([], inisource).envconfigs
         assert configs["py27"].recreate
-        assert not configs["py33"].recreate
+        assert not configs["py36"].recreate
 
     @pytest.mark.issue190
     def test_factors_in_setenv(self, newconfig):
         inisource = """
             [tox]
-            envlist = py27,py26
+            envlist = py27,py36
 
             [testenv]
             setenv =
@@ -1452,7 +1452,7 @@ class TestConfigTestEnv:
         """
         configs = newconfig([], inisource).envconfigs
         assert configs["py27"].setenv["X"] == "1"
-        assert "X" not in configs["py26"].setenv
+        assert "X" not in configs["py36"].setenv
 
     @pytest.mark.issue191
     def test_factor_use_not_checked(self, newconfig):
@@ -1491,8 +1491,7 @@ class TestConfigTestEnv:
         """
         configs = newconfig([], inisource).envconfigs
         assert sorted(configs) == ["py27-django1.6", "py27-django1.7"]
-        assert [d.name for d in configs["py27-django1.6"].deps] \
-            == ["Django==1.6"]
+        assert [d.name for d in configs["py27-django1.6"].deps] == ["Django==1.6"]
 
     def test_ignore_outcome(self, newconfig):
         inisource = """
@@ -1558,28 +1557,26 @@ class TestGlobalOptions:
     def test_env_selection(self, tmpdir, newconfig, monkeypatch):
         inisource = """
             [tox]
-            envlist = py26
-            [testenv:py26]
-            basepython=python2.6
-            [testenv:py31]
-            basepython=python3.1
+            envlist = py36
+            [testenv:py36]
+            basepython=python3.6
+            [testenv:py35]
+            basepython=python3.5
             [testenv:py27]
             basepython=python2.7
         """
-        # pytest.raises(tox.exception.ConfigError,
-        #    "newconfig(['-exyz'], inisource)")
         config = newconfig([], inisource)
-        assert config.envlist == ["py26"]
-        config = newconfig(["-epy31"], inisource)
-        assert config.envlist == ["py31"]
-        monkeypatch.setenv("TOXENV", "py31,py26")
+        assert config.envlist == ["py36"]
+        config = newconfig(["-epy35"], inisource)
+        assert config.envlist == ["py35"]
+        monkeypatch.setenv("TOXENV", "py35,py36")
         config = newconfig([], inisource)
-        assert config.envlist == ["py31", "py26"]
+        assert config.envlist == ["py35", "py36"]
         monkeypatch.setenv("TOXENV", "ALL")
         config = newconfig([], inisource)
-        assert config.envlist == ['py26', 'py27', 'py31']
+        assert config.envlist == ['py27', 'py35', 'py36']
         config = newconfig(["-eALL"], inisource)
-        assert config.envlist == ['py26', 'py27', 'py31']
+        assert config.envlist == ['py27', 'py35', 'py36']
 
     def test_py_venv(self, tmpdir, newconfig, monkeypatch):
         config = newconfig(["-epy"], "")
@@ -1587,7 +1584,7 @@ class TestGlobalOptions:
         assert str(env.basepython) == sys.executable
 
     def test_default_environments(self, tmpdir, newconfig, monkeypatch):
-        envs = "py26,py27,py32,py33,py34,py35,py36,py37,jython,pypy,pypy3,py2,py3"
+        envs = "py27,py34,py35,py36,py37,jython,pypy,pypy3,py2,py3"
         inisource = """
             [tox]
             envlist = %s
@@ -1611,19 +1608,19 @@ class TestGlobalOptions:
     def test_envlist_expansion(self, newconfig):
         inisource = """
             [tox]
-            envlist = py{26,27},docs
+            envlist = py{36,27},docs
         """
         config = newconfig([], inisource)
-        assert config.envlist == ["py26", "py27", "docs"]
+        assert config.envlist == ["py36", "py27", "docs"]
 
     def test_envlist_cross_product(self, newconfig):
         inisource = """
             [tox]
-            envlist = py{26,27}-dep{1,2}
+            envlist = py{36,27}-dep{1,2}
         """
         config = newconfig([], inisource)
-        assert config.envlist == \
-            ["py26-dep1", "py26-dep2", "py27-dep1", "py27-dep2"]
+        envs = ["py36-dep1", "py36-dep2", "py27-dep1", "py27-dep2"]
+        assert config.envlist == envs
 
     def test_envlist_multiline(self, newconfig):
         inisource = """
@@ -1633,8 +1630,7 @@ class TestGlobalOptions:
               py34
         """
         config = newconfig([], inisource)
-        assert config.envlist == \
-            ["py27", "py34"]
+        assert config.envlist == ["py27", "py34"]
 
     def test_minversion(self, tmpdir, newconfig, monkeypatch):
         inisource = """
@@ -1690,7 +1686,6 @@ class TestHashseedOption:
                 [testenv]
             """
         if make_hashseed is None:
-
             def make_hashseed():
                 return '123456789'
 
@@ -1772,11 +1767,13 @@ class TestHashseedOption:
             [testenv:hash2]
         """
         next_seed = [1000]
+
         # This function is guaranteed to generate a different value each time.
 
         def make_hashseed():
             next_seed[0] += 1
             return str(next_seed[0])
+
         # Check that make_hashseed() works.
         assert make_hashseed() == '1001'
         envconfigs = self._get_envconfigs(newconfig, tox_ini=tox_ini,
@@ -2064,6 +2061,7 @@ class TestCmdInvocation:
             class MockEggInfo:
                 project_name = 'some-project'
                 version = '1.0'
+
             return [(MockModule, MockEggInfo)]
 
         pm = PluginManager('fakeproject')
@@ -2084,6 +2082,7 @@ class TestCmdInvocation:
             class MockEggInfo:
                 project_name = 'some-project'
                 version = '1.0'
+
             return [(MockModule(), MockEggInfo)]
 
         pm = PluginManager('fakeproject')
@@ -2099,9 +2098,9 @@ class TestCmdInvocation:
         initproj('listenvs', filedefs={
             'tox.ini': '''
             [tox]
-            envlist=py26,py27,py33,pypy,docs
+            envlist=py36,py27,py34,pypy,docs
             description= py27: run pytest on Python 2.7
-                         py33: run pytest on Python 3.6
+                         py34: run pytest on Python 3.6
                          pypy: publish to pypy
                          docs: document stuff
                          notincluded: random extra
@@ -2115,9 +2114,9 @@ class TestCmdInvocation:
         })
         result = cmd.run("tox", "-l")
         result.stdout.fnmatch_lines("""
-            py26
+            py36
             py27
-            py33
+            py34
             pypy
             docs
         """)
@@ -2126,11 +2125,11 @@ class TestCmdInvocation:
         initproj('listenvs_verbose_description', filedefs={
             'tox.ini': '''
             [tox]
-            envlist=py26,py27,py33,pypy,docs
+            envlist=py36,py27,py34,pypy,docs
             [testenv]
-            description= py26: run pytest on Python 2.6
+            description= py36: run pytest on Python 3.6
                          py27: run pytest on Python 2.7
-                         py33: run pytest on Python 3.3
+                         py34: run pytest on Python 3.4
                          pypy: publish to pypy
                          docs: document stuff
                          notincluded: random extra
@@ -2146,9 +2145,9 @@ class TestCmdInvocation:
         result = cmd.run("tox", "-lv")
         result.stdout.fnmatch_lines("""
             default environments:
-            py26 -> run pytest on Python 2.6
+            py36 -> run pytest on Python 3.6
             py27 -> run pytest on Python 2.7
-            py33 -> run pytest on Python 3.3
+            py34 -> run pytest on Python 3.4
             pypy -> publish to pypy
             docs -> let me overwrite that
         """)
@@ -2157,7 +2156,7 @@ class TestCmdInvocation:
         initproj('listenvs_all', filedefs={
             'tox.ini': '''
             [tox]
-            envlist=py26,py27,py33,pypy,docs
+            envlist=py36,py27,py34,pypy,docs
 
             [testenv:notincluded]
             changedir = whatever
@@ -2168,9 +2167,9 @@ class TestCmdInvocation:
         })
         result = cmd.run("tox", "-a")
         result.stdout.fnmatch_lines("""
-            py26
+            py36
             py27
-            py33
+            py34
             pypy
             docs
             notincluded
@@ -2295,10 +2294,10 @@ class TestCmdInvocation:
 
 
 @pytest.mark.parametrize("cmdline,envlist", [
-    ("-e py26", ['py26']),
-    ("-e py26,py33", ['py26', 'py33']),
-    ("-e py26,py26", ['py26', 'py26']),
-    ("-e py26,py33 -e py33,py27", ['py26', 'py33', 'py33', 'py27'])
+    ("-e py36", ['py36']),
+    ("-e py36,py34", ['py36', 'py34']),
+    ("-e py36,py36", ['py36', 'py36']),
+    ("-e py36,py34 -e py34,py27", ['py36', 'py34', 'py34', 'py27'])
 ])
 def test_env_spec(cmdline, envlist):
     args = cmdline.split()
@@ -2365,8 +2364,8 @@ class TestCommandParser:
     @pytest.mark.skipif("sys.platform != 'win32'")
     def test_commands_with_backslash(self, newconfig):
         config = newconfig([r"hello\world"], """
-            [testenv:py26]
+            [testenv:py36]
             commands = some {posargs}
         """)
-        envconfig = config.envconfigs["py26"]
+        envconfig = config.envconfigs["py36"]
         assert envconfig.commands[0] == ["some", r"hello\world"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1387,8 +1387,7 @@ class TestConfigTestEnv:
         """
         conf = newconfig([], inisource)
         configs = conf.envconfigs
-        assert [dep.name for dep in configs['a-x'].deps] == \
-               ["dep-all", "dep-a", "dep-x"]
+        assert [dep.name for dep in configs['a-x'].deps] == ["dep-all", "dep-a", "dep-x"]
         assert [dep.name for dep in configs['b'].deps] == ["dep-all", "dep-b"]
 
     def test_factor_ops(self, newconfig):

--- a/tests/test_interpreters.py
+++ b/tests/test_interpreters.py
@@ -49,7 +49,7 @@ def test_tox_get_python_executable():
         envname = "pyxx"
     p = tox_get_python_executable(envconfig)
     assert p == py.path.local(sys.executable)
-    for ver in [""] + "2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3".split():
+    for ver in "2.7 3.4 3.5 3.6".split():
         name = "python%s" % ver
         if sys.platform == "win32":
             pydir = "python%s" % ver.replace(".", "")
@@ -63,9 +63,10 @@ def test_tox_get_python_executable():
         envconfig.basepython = name
         p = tox_get_python_executable(envconfig)
         assert p
-        popen = subprocess.Popen([str(p), '-V'], stderr=subprocess.PIPE)
+        popen = subprocess.Popen([str(p), '-V'], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         stdout, stderr = popen.communicate()
-        assert ver in stderr.decode('ascii')
+        assert not stdout or not stderr
+        assert ver in stderr.decode('ascii') or ver in stdout.decode('ascii')
 
 
 def test_find_executable_extra(monkeypatch):

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -32,18 +32,15 @@ class TestToxQuickstartMain(object):
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '4',         # Python versions: choose one by one
-                    'Y',         # py26
-                    'Y',         # py27
-                    'Y',         # py32
-                    'Y',         # py33
-                    'Y',         # py34
-                    'Y',         # py35
-                    'Y',         # py36
-                    'Y',         # pypy
-                    'N',         # jython
-                    'py.test',   # command to run tests
-                    'pytest'     # test dependencies
+                    '4',  # Python versions: choose one by one
+                    'Y',  # py27
+                    'Y',  # py34
+                    'Y',  # py35
+                    'Y',  # py36
+                    'Y',  # pypy
+                    'N',  # jython
+                    'py.test',  # command to run tests
+                    'pytest'  # test dependencies
                 ]
             )
         )
@@ -57,7 +54,7 @@ class TestToxQuickstartMain(object):
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 commands = py.test
@@ -65,7 +62,7 @@ deps =
     pytest
 """.lstrip()
         result = read_tox()
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_choose_individual_pythons_and_nose_adds_deps(
             self,
@@ -74,18 +71,15 @@ deps =
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '4',          # Python versions: choose one by one
-                    'Y',          # py26
-                    'Y',          # py27
-                    'Y',          # py32
-                    'Y',          # py33
-                    'Y',          # py34
-                    'Y',          # py35
-                    'Y',          # py36
-                    'Y',          # pypy
-                    'N',          # jython
+                    '4',  # Python versions: choose one by one
+                    'Y',  # py27
+                    'Y',  # py34
+                    'Y',  # py35
+                    'Y',  # py36
+                    'Y',  # pypy
+                    'N',  # jython
                     'nosetests',  # command to run tests
-                    ''            # test dependencies
+                    ''  # test dependencies
                 ]
             )
         )
@@ -99,7 +93,7 @@ deps =
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 commands = nosetests
@@ -107,7 +101,7 @@ deps =
     nose
 """.lstrip()
         result = read_tox()
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_choose_individual_pythons_and_trial_adds_deps(
             self,
@@ -116,18 +110,15 @@ deps =
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '4',          # Python versions: choose one by one
-                    'Y',          # py26
-                    'Y',          # py27
-                    'Y',          # py32
-                    'Y',          # py33
-                    'Y',          # py34
-                    'Y',          # py35
-                    'Y',          # py36
-                    'Y',          # pypy
-                    'N',          # jython
-                    'trial',      # command to run tests
-                    ''            # test dependencies
+                    '4',  # Python versions: choose one by one
+                    'Y',  # py27
+                    'Y',  # py34
+                    'Y',  # py35
+                    'Y',  # py36
+                    'Y',  # pypy
+                    'N',  # jython
+                    'trial',  # command to run tests
+                    ''  # test dependencies
                 ]
             )
         )
@@ -141,7 +132,7 @@ deps =
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 commands = trial
@@ -149,7 +140,7 @@ deps =
     twisted
 """.lstrip()
         result = read_tox()
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_choose_individual_pythons_and_pytest_adds_deps(
             self,
@@ -158,18 +149,15 @@ deps =
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '4',          # Python versions: choose one by one
-                    'Y',          # py26
-                    'Y',          # py27
-                    'Y',          # py32
-                    'Y',          # py33
-                    'Y',          # py34
-                    'Y',          # py35
-                    'Y',          # py36
-                    'Y',          # pypy
-                    'N',          # jython
-                    'py.test',    # command to run tests
-                    ''            # test dependencies
+                    '4',  # Python versions: choose one by one
+                    'Y',  # py27
+                    'Y',  # py34
+                    'Y',  # py35
+                    'Y',  # py36
+                    'Y',  # pypy
+                    'N',  # jython
+                    'py.test',  # command to run tests
+                    ''  # test dependencies
                 ]
             )
         )
@@ -182,7 +170,7 @@ deps =
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 commands = py.test
@@ -190,7 +178,7 @@ deps =
     pytest
 """.lstrip()
         result = read_tox()
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_choose_py27_and_pytest_adds_deps(
             self,
@@ -199,9 +187,9 @@ deps =
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '1',          # py27
-                    'py.test',    # command to run tests
-                    ''            # test dependencies
+                    '1',  # py27
+                    'py.test',  # command to run tests
+                    ''  # test dependencies
                 ]
             )
         )
@@ -223,18 +211,18 @@ deps =
     pytest
 """.lstrip()
         result = read_tox()
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
-    def test_quickstart_main_choose_py27_and_py33_and_pytest_adds_deps(
+    def test_quickstart_main_choose_py27_and_py34_and_pytest_adds_deps(
             self,
             monkeypatch):
         monkeypatch.setattr(
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '2',          # py27 and py33
-                    'py.test',    # command to run tests
-                    ''            # test dependencies
+                    '2',  # py27 and py36
+                    'py.test',  # command to run tests
+                    ''  # test dependencies
                 ]
             )
         )
@@ -248,7 +236,7 @@ deps =
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33
+envlist = py27, py36
 
 [testenv]
 commands = py.test
@@ -256,7 +244,7 @@ deps =
     pytest
 """.lstrip()
         result = read_tox()
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_choose_all_pythons_and_pytest_adds_deps(
             self,
@@ -265,9 +253,9 @@ deps =
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '3',          # all Python versions
-                    'py.test',    # command to run tests
-                    ''            # test dependencies
+                    '3',  # all Python versions
+                    'py.test',  # command to run tests
+                    ''  # test dependencies
                 ]
             )
         )
@@ -281,7 +269,7 @@ deps =
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy, jython
+envlist = py27, py34, py35, py36, pypy, jython
 
 [testenv]
 commands = py.test
@@ -289,7 +277,7 @@ deps =
     pytest
 """.lstrip()
         result = read_tox()
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_choose_individual_pythons_and_defaults(
             self,
@@ -299,17 +287,14 @@ deps =
             self.get_mock_term_input(
                 [
                     '4',  # Python versions: choose one by one
-                    '',   # py26
-                    '',   # py27
-                    '',   # py32
-                    '',   # py33
-                    '',   # py34
-                    '',   # py35
-                    '',   # py36
-                    '',   # pypy
-                    '',   # jython
-                    '',   # command to run tests
-                    ''    # test dependencies
+                    '',  # py27
+                    '',  # py34
+                    '',  # py35
+                    '',  # py36
+                    '',  # pypy
+                    '',  # jython
+                    '',  # command to run tests
+                    ''  # test dependencies
                 ]
             )
         )
@@ -323,7 +308,7 @@ deps =
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy, jython
+envlist = py27, py34, py35, py36, pypy, jython
 
 [testenv]
 commands = {envpython} setup.py test
@@ -331,7 +316,7 @@ deps =
 
 """.lstrip()
         result = read_tox()
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_existing_tox_ini(self, monkeypatch):
         try:
@@ -345,18 +330,15 @@ deps =
             self.get_mock_term_input(
                 [
                     '4',  # Python versions: choose one by one
-                    '',   # py26
-                    '',   # py27
-                    '',   # py32
-                    '',   # py33
-                    '',   # py34
-                    '',   # py35
-                    '',   # py36
-                    '',   # pypy
-                    '',   # jython
-                    '',   # command to run tests
-                    '',   # test dependencies
-                    '',   # tox.ini already exists; overwrite?
+                    '',  # py27
+                    '',  # py34
+                    '',  # py35
+                    '',  # py36
+                    '',  # pypy
+                    '',  # jython
+                    '',  # command to run tests
+                    '',  # test dependencies
+                    '',  # tox.ini already exists; overwrite?
                 ]
             )
         )
@@ -370,7 +352,7 @@ deps =
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy, jython
+envlist = py27, py34, py35, py36, pypy, jython
 
 [testenv]
 commands = {envpython} setup.py test
@@ -378,7 +360,7 @@ deps =
 
 """.lstrip()
         result = read_tox('tox-generated.ini')
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_tox_ini_location_can_be_overridden(
             self,
@@ -388,9 +370,9 @@ deps =
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '1',          # py27 and py33
-                    'py.test',    # command to run tests
-                    '',            # test dependencies
+                    '1',  # py27 and py34
+                    'py.test',  # command to run tests
+                    '',  # test dependencies
                 ]
             )
         )
@@ -417,7 +399,7 @@ deps =
     pytest
 """.lstrip()
         result = read_tox(fname=tox_ini_path.strpath)
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_custom_tox_ini_location_with_existing_tox_ini(
             self,
@@ -427,10 +409,10 @@ deps =
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '1',          # py27 and py33
-                    'py.test',    # command to run tests
-                    '',            # test dependencies
-                    '',           # tox.ini already exists; overwrite?
+                    '1',  # py27 and py34
+                    'py.test',  # command to run tests
+                    '',  # test dependencies
+                    '',  # tox.ini already exists; overwrite?
                 ]
             )
         )
@@ -459,7 +441,7 @@ deps =
     pytest
 """.lstrip()
         result = read_tox(fname=tox_ini_path.strpath)
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_quickstart_main_custom_nonexistent_tox_ini_location(
             self,
@@ -469,9 +451,9 @@ deps =
             tox._quickstart, 'term_input',
             self.get_mock_term_input(
                 [
-                    '1',          # py27 and py33
-                    'py.test',    # command to run tests
-                    '',           # test dependencies
+                    '1',  # py27 and py34
+                    'py.test',  # command to run tests
+                    '',  # test dependencies
                 ]
             )
         )
@@ -484,10 +466,7 @@ deps =
 class TestToxQuickstart(object):
     def test_pytest(self):
         d = {
-            'py26': True,
             'py27': True,
-            'py32': True,
-            'py33': True,
             'py34': True,
             'pypy': True,
             'commands': 'py.test',
@@ -500,7 +479,7 @@ class TestToxQuickstart(object):
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py27, py34, pypy
 
 [testenv]
 commands = py.test
@@ -511,11 +490,11 @@ deps =
         tox._quickstart.generate(d)
         result = read_tox()
         # print(result)
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_setup_py_test(self):
         d = {
-            'py26': True,
+            'py36': True,
             'py27': True,
             'commands': 'python setup.py test',
             'deps': '',
@@ -527,7 +506,7 @@ deps =
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27
+envlist = py27, py36
 
 [testenv]
 commands = python setup.py test
@@ -538,7 +517,7 @@ deps =
         tox._quickstart.generate(d)
         result = read_tox()
         # print(result)
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_trial(self):
         d = {
@@ -564,13 +543,11 @@ deps =
         tox._quickstart.generate(d)
         result = read_tox()
         # print(result)
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
     def test_nosetests(self):
         d = {
             'py27': True,
-            'py32': True,
-            'py33': True,
             'py34': True,
             'py35': True,
             'pypy': True,
@@ -584,7 +561,7 @@ deps =
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py32, py33, py34, py35, pypy
+envlist = py27, py34, py35, pypy
 
 [testenv]
 commands = nosetests -v
@@ -595,7 +572,7 @@ deps =
         tox._quickstart.generate(d)
         result = read_tox()
         # print(result)
-        assert(result == expected_tox_ini)
+        assert (result == expected_tox_ini)
 
 
 def read_tox(fname='tox.ini'):

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -49,7 +49,7 @@ def test_set_header(pkg):
 def test_addenv_setpython(pkg):
     replog = ResultLog()
     replog.set_header(installpkg=pkg)
-    envlog = replog.get_envlog("py26")
+    envlog = replog.get_envlog("py36")
     envlog.set_python_info(py.path.local(sys.executable))
     assert envlog.dict["python"]["version_info"] == list(sys.version_info)
     assert envlog.dict["python"]["version"] == sys.version
@@ -59,7 +59,7 @@ def test_addenv_setpython(pkg):
 def test_get_commandlog(pkg):
     replog = ResultLog()
     replog.set_header(installpkg=pkg)
-    envlog = replog.get_envlog("py26")
+    envlog = replog.get_envlog("py36")
     assert "setup" not in envlog.dict
     setuplog = envlog.get_commandlog("setup")
     setuplog.add_command(["virtualenv", "..."], "venv created", 0)
@@ -67,5 +67,5 @@ def test_get_commandlog(pkg):
                               "output": "venv created",
                               "retcode": "0"}]
     assert envlog.dict["setup"]
-    setuplog2 = replog.get_envlog("py26").get_commandlog("setup")
+    setuplog2 = replog.get_envlog("py36").get_commandlog("setup")
     assert setuplog2.list == setuplog.list

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -384,11 +384,11 @@ def test_install_command_not_installed_bash(newmocksession):
 
 
 def test_install_python3(tmpdir, newmocksession):
-    if not py.path.local.sysfind('python3.3'):
-        pytest.skip("needs python3.3")
+    if not py.path.local.sysfind('python3.5'):
+        pytest.skip("needs python3.5")
     mocksession = newmocksession([], """
         [testenv:py123]
-        basepython=python3.3
+        basepython=python3.5
         deps=
             dep1
             dep2
@@ -699,7 +699,7 @@ def test_run_custom_install_command(newmocksession):
     assert pcalls[0].args[1:] == ['whatever']
 
 
-def test_command_relative_issue26(newmocksession, tmpdir, monkeypatch):
+def test_command_relative_issue36(newmocksession, tmpdir, monkeypatch):
     mocksession = newmocksession([], """
         [testenv]
     """)

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -716,7 +716,7 @@ def test_test_piphelp(initproj, cmd):
         # content of: tox.ini
         [testenv]
         commands=pip -h
-        [testenv:py26]
+        [testenv:py36]
         basepython=python
         [testenv:py27]
         basepython=python
@@ -728,19 +728,19 @@ def test_test_piphelp(initproj, cmd):
 def test_notest(initproj, cmd):
     initproj("example123", filedefs={'tox.ini': """
         # content of: tox.ini
-        [testenv:py26]
+        [testenv:py36]
         basepython=python
     """})
     result = cmd.run("tox", "-v", "--notest")
     assert not result.ret
     result.stdout.fnmatch_lines([
         "*summary*",
-        "*py26*skipped tests*",
+        "*py36*skipped tests*",
     ])
-    result = cmd.run("tox", "-v", "--notest", "-epy26")
+    result = cmd.run("tox", "-v", "--notest", "-epy36")
     assert not result.ret
     result.stdout.fnmatch_lines([
-        "*py26*reusing*",
+        "*py36*reusing*",
     ])
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py27,py26,py34,py33,py35,py36,pypy,style,py26-bare,docs
+envlist = py27,py34,py35,py36,pypy,style,docs
 minversion = 2.7.0
 
 [testenv]
 description = run the unit tests with pytest under the current Python env
-setenv = COVERAGE_FILE=.coverage.{envname}
-passenv = CI TRAVIS TRAVIS_*
+setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
+passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE CI TRAVIS TRAVIS_*
 deps = pytest >= 3.0.0
        pytest-cov
        pytest-timeout
@@ -22,11 +22,10 @@ commands = {posargs:py.test -s -x -f -v}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs, check that URIs are valid
-basepython = python
+basepython = python3.6
 deps = sphinx >= 1.6.3, < 2
        towncrier >= 17.8.0
        {[testenv]deps}
-passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE
 commands = sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out --color -W -bhtml
            sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out --color -W -blinkcheck
 
@@ -48,17 +47,6 @@ commands = python -m flake8 --show-source tox setup.py {posargs}
 max-complexity = 22
 max-line-length = 99
 
-[testenv:py26-bare]
-description = invoke the tox help message under Python 2.6
-install_command = pip install {opts} {packages}
-list_dependencies_command = pip freeze
-deps =
-commands = tox -h
-
-[testenv:py26]
-install_command = pip install {opts} {packages}
-list_dependencies_command = pip freeze
-
 [testenv:X]
 description = print the positional arguments passed in with echo
 commands = echo {posargs}
@@ -66,6 +54,7 @@ commands = echo {posargs}
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create reports
 skip_install = True
+changedir={toxworkdir}
 setenv = COVERAGE_FILE=.coverage
 deps = coverage
 commands = coverage erase
@@ -97,8 +86,8 @@ omit = tox/__main__.py
 
 [coverage:paths]
 source = tox
-         .tox/*/lib/python*/site-packages/tox
-         .tox/pypy*/site-packages/tox
+         {toxworkdir}/*/lib/python*/site-packages/tox
+         {toxworkdir}/pypy*/site-packages/tox
 
 [coverage:report]
 exclude_lines = if __name__ == ["']__main__["']:
@@ -107,5 +96,5 @@ exclude_lines = if __name__ == ["']__main__["']:
 addopts = -rsxX
 rsyncdirs = tests tox
 looponfailroots = tox tests
-norecursedirs = .hg .tox
+norecursedirs = .hg {toxworkdir}
 xfail_strict = True

--- a/tox.ini
+++ b/tox.ini
@@ -53,8 +53,7 @@ commands = echo {posargs}
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create reports
 skip_install = True
-changedir = {toxworkdir}
-setenv = COVERAGE_FILE=.coverage
+setenv = COVERAGE_FILE={toxworkdir}/.coverage
 deps = coverage
 commands = coverage erase
            coverage combine

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,8 @@ commands = sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out -
 
 [testenv:fix-lint]
 basepython = python3.6
-passenv =
-    {[testenv]passenv}
-    HOMEPATH
+passenv = {[testenv]passenv}
+          HOMEPATH
 deps = flake8 == 3.4.1
        flake8-bugbear == 17.4.0
        pre-commit == 1.3.0
@@ -54,7 +53,7 @@ commands = echo {posargs}
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create reports
 skip_install = True
-changedir={toxworkdir}
+changedir = {toxworkdir}
 setenv = COVERAGE_FILE=.coverage
 deps = coverage
 commands = coverage erase
@@ -96,5 +95,5 @@ exclude_lines = if __name__ == ["']__main__["']:
 addopts = -rsxX
 rsyncdirs = tests tox
 looponfailroots = tox tests
-norecursedirs = .hg {toxworkdir}
+norecursedirs = .hg .tox
 xfail_strict = True

--- a/tox/_pytestplugin.py
+++ b/tox/_pytestplugin.py
@@ -202,9 +202,6 @@ class Cmd:
         return subprocess.Popen(argv, stdout=stdout, stderr=stderr, **kw)
 
     def run(self, *argv):
-        if argv[0] == "tox" and sys.version_info[:2] < (2, 7):
-            pytest.skip("can not run tests involving calling tox on python2.6. "
-                        "(and python2.6 is about to be deprecated anyway)")
         argv = [str(x) for x in argv]
         assert py.path.local.sysfind(str(argv[0])), argv[0]
         p1 = self.tmpdir.join("stdout")

--- a/tox/_quickstart.py
+++ b/tox/_quickstart.py
@@ -56,7 +56,7 @@ except NameError:
     term_input = input
 
 
-all_envs = ['py26', 'py27', 'py32', 'py33', 'py34', 'py35', 'py36', 'pypy', 'jython']
+all_envs = ['py27', 'py34', 'py35', 'py36', 'pypy', 'jython']
 
 PROMPT_PREFIX = '> '
 
@@ -160,7 +160,7 @@ accept a default value, if one is given in brackets).''')
     print('''
 What Python versions do you want to test against? Choices:
     [1] py27
-    [2] py27, py33
+    [2] py27, py36
     [3] (All versions) %s
     [4] Choose each one-by-one''' % ', '.join(all_envs))
     do_prompt(d, 'canned_pyenvs', 'Enter the number of your choice',
@@ -169,7 +169,7 @@ What Python versions do you want to test against? Choices:
     if d['canned_pyenvs'] == '1':
         d['py27'] = True
     elif d['canned_pyenvs'] == '2':
-        for pyenv in ('py27', 'py33'):
+        for pyenv in ('py27', 'py36'):
             d[pyenv] = True
     elif d['canned_pyenvs'] == '3':
         for pyenv in all_envs:

--- a/tox/config.py
+++ b/tox/config.py
@@ -24,7 +24,7 @@ iswin32 = sys.platform == "win32"
 
 default_factors = {'jython': 'jython', 'pypy': 'pypy', 'pypy3': 'pypy3',
                    'py': sys.executable, 'py2': 'python2', 'py3': 'python3'}
-for version in '26,27,32,33,34,35,36,37'.split(','):
+for version in '27,34,35,36,37'.split(','):
     default_factors['py' + version] = 'python%s.%s' % tuple(version)
 
 hookimpl = pluggy.HookimplMarker("tox")

--- a/tox/interpreters.py
+++ b/tox/interpreters.py
@@ -17,7 +17,7 @@ class Interpreters:
 
     def get_executable(self, envconfig):
         """ return path object to the executable for the given
-        name (e.g. python3.6, python2.7, python etc.)
+        name (e.g. python2.7, python3.6, python etc.)
         if name is already an existing path, return name.
         If an interpreter cannot be found, return None.
         """

--- a/tox/interpreters.py
+++ b/tox/interpreters.py
@@ -17,7 +17,7 @@ class Interpreters:
 
     def get_executable(self, envconfig):
         """ return path object to the executable for the given
-        name (e.g. python2.6, python2.7, python etc.)
+        name (e.g. python3.6, python2.7, python etc.)
         if name is already an existing path, return name.
         If an interpreter cannot be found, return None.
         """


### PR DESCRIPTION
Resolves #679. 

Took the opportunity to also update our documentation, so we no longer refer to ``Python <2.7`` or ``Python <=3.3`` in there.