### PR TITLE
Session: use realpath when ensuring that logdir exists

### DIFF
--- a/tox/session.py
+++ b/tox/session.py
@@ -336,7 +336,7 @@ class Session:
         self.resultlog = ResultLog()
         self.report = Report(self)
         self.make_emptydir(config.logdir)
-        config.logdir.ensure(dir=1)
+        config.logdir.realpath().ensure(dir=1)
         # self.report.using("logdir %s" %(self.config.logdir,))
         self.report.using("tox.ini: %s" % (self.config.toxinipath,))
         self._spec2pkg = {}


### PR DESCRIPTION
This allows for having a dangling symlink `.tox` (e.g. to somewhere into
`/tmp`), and the directory will be created instead of causing an error
(because it is not a dir, but exists already):

    Traceback (most recent call last):
      File "/usr/lib/python3.6/site-packages/py/_error.py", line 66, in checked_call
        return func(*args, **kwargs)
    FileExistsError: [Errno 17] File exists: '…/src/covimerage/.tox'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/bin/tox", line 11, in <module>
        load_entry_point('tox==2.9.1', 'console_scripts', 'tox')()
      File "/usr/lib/python3.6/site-packages/tox/session.py", line 40, in main
        retcode = Session(config).runcommand()
      File "/usr/lib/python3.6/site-packages/tox/session.py", line 337, in __init__
        config.logdir.ensure(dir=1)
      File "/usr/lib/python3.6/site-packages/py/_path/local.py", line 530, in ensure
        return p._ensuredirs()
      File "/usr/lib/python3.6/site-packages/py/_path/local.py", line 512, in _ensuredirs
        parent._ensuredirs()
      File "/usr/lib/python3.6/site-packages/py/_path/local.py", line 515, in _ensuredirs
        self.mkdir()
      File "/usr/lib/python3.6/site-packages/py/_path/local.py", line 465, in mkdir
        py.error.checked_call(os.mkdir, fspath(p))
      File "/usr/lib/python3.6/site-packages/py/_error.py", line 86, in checked_call
        raise cls("%s%r" % (func.__name__, args))
    py.error.EEXIST: [File exists]: mkdir('…/src/covimerage/.tox',)

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
