### PR TITLE
pre-commit: Burn the python2.6 bridges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
     hooks:
     -   id: reorder-python-imports
         language_version: python3.6
+-   repo: https://github.com/asottile/pyupgrade
+    sha: v1.2.0
+    hooks:
+    -   id: pyupgrade

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1463,7 +1463,7 @@ class TestConfigTestEnv:
             deps = b: test
         """
         configs = newconfig([], inisource).envconfigs
-        assert set(configs.keys()) == set(['py27-a', 'py27-b'])
+        assert set(configs.keys()) == {'py27-a', 'py27-b'}
 
     @pytest.mark.issue198
     def test_factors_groups_touch(self, newconfig):
@@ -1476,7 +1476,7 @@ class TestConfigTestEnv:
                 a,b,x,y: dep
         """
         configs = newconfig([], inisource).envconfigs
-        assert set(configs.keys()) == set(['a', 'a-x', 'b', 'b-x'])
+        assert set(configs.keys()) == {'a', 'a-x', 'b', 'b-x'}
 
     def test_period_in_factor(self, newconfig):
         inisource = """

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -632,7 +632,7 @@ def test_env_variables_added_to_pcall(tmpdir, mocksession, newconfig, monkeypatc
     assert pcalls[0].env["YY"] == "456"
     assert "YY" not in pcalls[1].env
 
-    assert set(["ENV_VAR", "VIRTUAL_ENV", "PYTHONHASHSEED", "X123", "PATH"])\
+    assert {"ENV_VAR", "VIRTUAL_ENV", "PYTHONHASHSEED", "X123", "PATH"}\
         .issubset(pcalls[1].env)
 
     # setenv does not trigger PYTHONPATH warnings

--- a/tox/config.py
+++ b/tox/config.py
@@ -31,11 +31,11 @@ hookimpl = pluggy.HookimplMarker("tox")
 
 _dummy = object()
 
-PIP_INSTALL_SHORT_OPTIONS_ARGUMENT = ['-{0}'.format(option) for option in [
+PIP_INSTALL_SHORT_OPTIONS_ARGUMENT = ['-{}'.format(option) for option in [
     'c', 'e', 'r', 'b', 't', 'd',
 ]]
 
-PIP_INSTALL_LONG_OPTIONS_ARGUMENT = ['--{0}'.format(option) for option in [
+PIP_INSTALL_LONG_OPTIONS_ARGUMENT = ['--{}'.format(option) for option in [
     'constraint', 'editable', 'requirement', 'build', 'target', 'download',
     'src', 'upgrade-strategy', 'install-options', 'global-option',
     'root', 'prefix', 'no-binary', 'only-binary', 'index-url',
@@ -143,14 +143,14 @@ class DepOption:
                 # in case of a short option, we remove the space
                 for option in PIP_INSTALL_SHORT_OPTIONS_ARGUMENT:
                     if name.startswith(option):
-                        name = '{0}{1}'.format(
+                        name = '{}{}'.format(
                             option, name[len(option):].strip()
                         )
 
                 # in case of a long option, we add an equal sign
                 for option in PIP_INSTALL_LONG_OPTIONS_ARGUMENT:
                     if name.startswith(option + ' '):
-                        name = '{0}={1}'.format(
+                        name = '{}={}'.format(
                             option, name[len(option):].strip()
                         )
 
@@ -508,9 +508,9 @@ def tox_addoption(parser):
             itertools.chain.from_iterable(
                 [x.split(' ') for x in value]))
 
-        passenv = set([
+        passenv = {
             "PATH", "PIP_INDEX_URL", "LANG", "LANGUAGE", "LD_LIBRARY_PATH"
-        ])
+        }
 
         # read in global passenv settings
         p = os.environ.get("TOX_TESTENV_PASSENV", None)
@@ -890,7 +890,7 @@ class parseini:
         envlist = _split_env(envstr)
 
         # collect section envs
-        all_envs = set(envlist) - set(["ALL"])
+        all_envs = set(envlist) - {"ALL"}
         for section in self._cfg:
             if section.name.startswith(testenvprefix):
                 all_envs.add(section.name[len(testenvprefix):])

--- a/tox/session.py
+++ b/tox/session.py
@@ -669,7 +669,7 @@ class Session:
         def report_env(e):
             if description:
                 text = env_conf[e].description or '[no description]'
-                msg = '{0} -> {1}'.format(e.ljust(max_length), text).strip()
+                msg = '{} -> {}'.format(e.ljust(max_length), text).strip()
             else:
                 msg = e
             self.report.line(msg)
@@ -689,7 +689,7 @@ class Session:
             stdout=subprocess.PIPE,
         )
         out, _ = proc.communicate()
-        versions.append('virtualenv-{0}'.format(out.decode('UTF-8').strip()))
+        versions.append('virtualenv-{}'.format(out.decode('UTF-8').strip()))
         self.report.keyvalue("tool-versions:", " ".join(versions))
 
     def _resolve_pkg(self, pkgspec):


### PR DESCRIPTION
Other than the `.pre-commit-config.yaml` change, this PR is entirely automatic