### PR TITLE
[WIP] Fixed pip upgrades on Windows

### DIFF
--- a/changelog/701.bugfix.rst
+++ b/changelog/701.bugfix.rst
@@ -1,0 +1,12 @@
+fix performing pip upgrades on Windows using the tox's default install_command
+- by @jurko-gospodnetic
+
+Changes:
+
+- default `install_command` changed to ``python -m pip`` instead of the
+  setuptools based ``pip`` executable
+- now the install commands are run from the ``{toxinidir}/install_from_here``
+  folder to avoid install commands (e.g. ``python -m pip``) accidentally picking
+  up ``.egg-info`` folders in the current working folder as indications of
+  already installed packages, thus causing it to potentially not install those
+  packages into the target environment

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -140,7 +140,8 @@ def test_install_deps_wildcard(newmocksession):
     tox_testenv_install_deps(action=action, venv=venv)
     assert len(pcalls) == 2
     args = pcalls[-1].args
-    assert pcalls[-1].cwd == venv.envconfig.config.toxinidir
+    expected_cwd = venv.envconfig.config.toxinidir.join('install_from_here')
+    assert pcalls[-1].cwd == expected_cwd
     assert "pip" in str(args[0])
     assert args[1] == "install"
     args = [arg for arg in args if str(arg).endswith("dep1-1.1.zip")]
@@ -683,6 +684,8 @@ def test_run_install_command(newmocksession):
     assert 'install' in pcalls[0].args
     env = pcalls[0].env
     assert env is not None
+    expected_cwd = venv.envconfig.config.toxinidir.join('install_from_here')
+    assert pcalls[-1].cwd == expected_cwd
 
 
 def test_run_custom_install_command(newmocksession):
@@ -699,6 +702,8 @@ def test_run_custom_install_command(newmocksession):
     assert len(pcalls) == 1
     assert 'easy_install' in pcalls[0].args[0]
     assert pcalls[0].args[1:] == ['whatever']
+    expected_cwd = venv.envconfig.config.toxinidir.join('install_from_here')
+    assert pcalls[-1].cwd == expected_cwd
 
 
 def test_command_relative_issue36(newmocksession, tmpdir, monkeypatch):

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -142,8 +142,10 @@ def test_install_deps_wildcard(newmocksession):
     args = pcalls[-1].args
     expected_cwd = venv.envconfig.config.toxinidir.join('install_from_here')
     assert pcalls[-1].cwd == expected_cwd
-    assert "pip" in str(args[0])
-    assert args[1] == "install"
+    assert "python" in str(args[0])
+    assert "-m" == args[1]
+    assert "pip" == args[2]
+    assert "install" == args[3]
     args = [arg for arg in args if str(arg).endswith("dep1-1.1.zip")]
     assert len(args) == 1
 
@@ -407,7 +409,10 @@ def test_install_python3(tmpdir, newmocksession):
     venv._install(["hello"], action=action)
     assert len(pcalls) == 1
     args = pcalls[0].args
-    assert "pip" in args[0]
+    assert "python" in args[0]
+    assert "-m" == args[1]
+    assert "pip" == args[2]
+    assert "install" == args[3]
     for _ in args:
         assert "--download-cache" not in args, args
 
@@ -539,6 +544,7 @@ class TestVenvTest:
         monkeypatch.setenv("PIP_RESPECT_VIRTUALENV", "1")
         mocksession = newmocksession([], """
             [testenv:python]
+            install_command=install-command {packages}
             commands=abc
         """)
         venv = mocksession.getenv("python")
@@ -680,8 +686,10 @@ def test_run_install_command(newmocksession):
     venv.run_install_command(packages=["whatever"], action=action)
     pcalls = mocksession._pcalls
     assert len(pcalls) == 1
-    assert 'pip' in pcalls[0].args[0]
-    assert 'install' in pcalls[0].args
+    assert "python" in pcalls[0].args[0]
+    assert "-m" == pcalls[0].args[1]
+    assert "pip" == pcalls[0].args[2]
+    assert "install" == pcalls[0].args[3]
     env = pcalls[0].env
     assert env is not None
     expected_cwd = venv.envconfig.config.toxinidir.join('install_from_here')

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -239,7 +239,7 @@ def test_run_custom_install_command_error(cmd, initproj):
     initproj("interp123-0.5", filedefs={
         'tox.ini': '''
             [testenv]
-            install_command=./tox.ini {opts} {packages}
+            install_command={toxinidir}/tox.ini {opts} {packages}
         '''
     })
     result = cmd()

--- a/tox/config.py
+++ b/tox/config.py
@@ -214,7 +214,7 @@ class PosargsOption:
 class InstallcmdOption:
     name = "install_command"
     type = "argv"
-    default = "pip install {opts} {packages}"
+    default = "{envpython} -m pip install {opts} {packages}"
     help = "install command for dependencies and package under test."
 
     def postprocess(self, testenv_config, value):

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -301,9 +301,17 @@ class VirtualEnv(object):
                 )
                 os.environ.pop('PYTHONPATH')
 
+        # install from a neutral folder to avoid any adverse interactions
+        # between the current folder and the installation command, e.g.
+        # `python -m pip` command will add the current folder to the Python
+        # path, and thus fail to install any package located in that folder for
+        # which there also exists an `.egg-info` folder in that same folder
+        toxinidir = self.envconfig.config.toxinidir
+        install_command_cwd = toxinidir.join('install_from_here')
+
         old_stdout = sys.stdout
         sys.stdout = codecs.getwriter('utf8')(sys.stdout)
-        self._pcall(argv, cwd=self.envconfig.config.toxinidir, action=action,
+        self._pcall(argv, cwd=install_command_cwd, action=action,
                     redirect=self.session.report.verbosity < 2)
         sys.stdout = old_stdout
 


### PR DESCRIPTION
This is a fix for issue #701.

## Description
### run install_commands from a `{toxinidir}/install_from_here` folder

This avoids any adverse interactions between the current folder and the installation command, e.g. `python -m pip` command will add the current folder to the Python path, and thus fail to install any package located in that folder for which there also exists a `.egg-info` folder in that same folder.

### change default install command to `python -m pip`

This allows tox to upgrade pip on Windows, where this fails if you use the `pip.exe` runner script as Windows does not allow removing an executable that is currently being executed.

## Open tasks

- [x] add news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
- [ ] see if there is anything in the documentation that can be updated related to this
- [ ] consider how this impacts relative links give in `deps` settings or in included `requirements.txt` files referenced using something like a `-rrequirements.txt` `deps` setting (see related issue #102)

## Things to discuss:

- [ ] I found no clean way to test pip upgrade on Windows as a part of our test suite as any such attempt runs into the Windows path length limit
- [ ] should we change the `{toxinidir}/install_from_here` folder to just `{toxinidir}` or should we perhaps make it configurable, and if so, should it be a global or an environment specific configuration setting or both