### PR TITLE
pass the `PROGRAMDATA` envrionment variable when invoking fix-lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,9 @@ commands = sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out -
 basepython = python3.6
 passenv = {[testenv]passenv}
           HOMEPATH
+          # without PROGRAMDATA cloning using git for Windows will fail with an
+          # `error setting certificate verify locations` error
+          PROGRAMDATA
 extras = lint
 description = run static analysis and style check using flake8
 commands = python -m flake8 --show-source tox setup.py {posargs}


### PR DESCRIPTION
Pass the `PROGRAMDATA` environment variable when invoking `fix-lint`, fixing `error setting certificate verify locations` errors when cloning a git repo using git for Windows.