### PR TITLE
fix running internal tox test runs from path with spaces

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,14 @@ description = run the unit tests with pytest under {basepython}
 setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
 extras = testing
-commands = pytest {posargs:--cov-config={toxinidir}/tox.ini --cov={envsitepackagesdir}/tox --timeout=180 tests}
+commands = pytest {posargs:--cov-config="{toxinidir}/tox.ini" --cov="{envsitepackagesdir}/tox" --timeout=180 tests}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs, check that URIs are valid
 basepython = python3.6
 extras = docs
-commands = sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out --color -W -bhtml
-           sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out --color -W -blinkcheck
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml
+           sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -blinkcheck
 
 [testenv:fix-lint]
 basepython = python3.6
@@ -47,20 +47,20 @@ changedir = {toxworkdir}
 setenv = COVERAGE_FILE=.coverage
 commands = coverage erase
            coverage combine
-           coverage report --rcfile={toxinidir}/tox.ini
+           coverage report --rcfile="{toxinidir}/tox.ini"
            coverage xml
 
 [testenv:codecov]
 description = [only run on CI]: upload coverage data to codecov (depends on coverage running first)
 deps = codecov
 skip_install = True
-commands = codecov --file {toxworkdir}/coverage.xml
+commands = codecov --file "{toxworkdir}/coverage.xml"
 
 [testenv:pra]
 passenv = *
 description = "personal release assistant" - see HOWTORELEASE.rst
 extras = publish, docs
-commands = {toxinidir}/tasks/pra.sh {posargs}
+commands = "{toxinidir}/tasks/pra.sh" {posargs}
 
 [testenv:X]
 description = print the positional arguments passed in with echo


### PR DESCRIPTION
Fixed running internal tox test runs from path with spaces by adding quotes around command arguments that may contain spaces in them.