### PR TITLE
add safety wrapper around sys.stdout assignment

### DIFF
--- a/changelog/723.bugfix.rst
+++ b/changelog/723.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed an issue where invocation of Tox from the Python package, where
+invocation errors (failed actions) occur results in a change in the 
+sys.stdout stream encoding in Python 3.x.
+New behaviour is that sys.stdout is reset back to its original encoding
+after invocation errors - by @tonybaloney

--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,14 @@ description = run the unit tests with pytest under {basepython}
 setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
 extras = testing
-commands = pytest {posargs:--cov-config={toxinidir}/tox.ini --cov={envsitepackagesdir}/tox --timeout=180 tests}
+commands = pytest {posargs:--cov-config="{toxinidir}/tox.ini" --cov="{envsitepackagesdir}/tox" --timeout=180 tests}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs, check that URIs are valid
 basepython = python3.6
 extras = docs
-commands = sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out --color -W -bhtml
-           sphinx-build -d {toxworkdir}/docs_doctree doc {toxworkdir}/docs_out --color -W -blinkcheck
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml
+           sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -blinkcheck
 
 [testenv:fix-lint]
 basepython = python3.6
@@ -47,20 +47,20 @@ changedir = {toxworkdir}
 setenv = COVERAGE_FILE=.coverage
 commands = coverage erase
            coverage combine
-           coverage report --rcfile={toxinidir}/tox.ini
+           coverage report --rcfile="{toxinidir}/tox.ini"
            coverage xml
 
 [testenv:codecov]
 description = [only run on CI]: upload coverage data to codecov (depends on coverage running first)
 deps = codecov
 skip_install = True
-commands = codecov --file {toxworkdir}/coverage.xml
+commands = codecov --file "{toxworkdir}/coverage.xml"
 
 [testenv:pra]
 passenv = *
 description = "personal release assistant" - see HOWTORELEASE.rst
 extras = publish, docs
-commands = {toxinidir}/tasks/pra.sh {posargs}
+commands = "{toxinidir}/tasks/pra.sh" {posargs}
 
 [testenv:X]
 description = print the positional arguments passed in with echo

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -303,9 +303,11 @@ class VirtualEnv(object):
 
         old_stdout = sys.stdout
         sys.stdout = codecs.getwriter('utf8')(sys.stdout)
-        self._pcall(argv, cwd=self.envconfig.config.toxinidir, action=action,
-                    redirect=self.session.report.verbosity < 2)
-        sys.stdout = old_stdout
+        try:
+            self._pcall(argv, cwd=self.envconfig.config.toxinidir,
+                        action=action, redirect=self.session.report.verbosity < 2)
+        finally:
+            sys.stdout = old_stdout
 
     def _install(self, deps, extraopts=None, action=None):
         if not deps:


### PR DESCRIPTION
See #723 for details on why this PR is being raised

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
