### PR TITLE
Fix generation of JSON files with --skip-missing-interpreters option. Fixes #672 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ doc/_build/
 tox.egg-info
 .tox
 .cache
+.python-version
 
 coverage.xml
 htmlcov

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ Lukasz Rogalski
 Manuel Jacob
 Marc Abramowitz
 Marc Schlaich
+Mariusz Rusiniak
 Mark Hirota
 Matt Good
 Matt Jeffery

--- a/changelog/672.bugfix.rst
+++ b/changelog/672.bugfix.rst
@@ -1,0 +1,1 @@
+fix #672 reporting to json file when skip-missing-interpreters option is used - by @r2dan

--- a/tox/session.py
+++ b/tox/session.py
@@ -490,9 +490,9 @@ class Session:
                         "not supported by virtualenv. Error details: %r" % e)
             except tox.exception.InvocationError as e:
                 status = (
-                    "Error creating virtualenv. Note that some special "
-                    "characters (e.g. ':' and unicode symbols) in paths are "
-                    "not supported by virtualenv. Error details: %r" % e)
+                        "Error creating virtualenv. Note that some special "
+                        "characters (e.g. ':' and unicode symbols) in paths are "
+                        "not supported by virtualenv. Error details: %r" % e)
             except tox.exception.InterpreterNotFound as e:
                 status = e
                 if self.config.option.skip_missing_interpreters:

--- a/tox/session.py
+++ b/tox/session.py
@@ -478,6 +478,7 @@ class Session:
         action = self.newaction(venv, "getenv", venv.envconfig.envdir)
         with action:
             venv.status = 0
+            default_ret_code = 1
             envlog = self.resultlog.get_envlog(venv.name)
             try:
                 status = venv.update(action=action)
@@ -489,14 +490,21 @@ class Session:
                         "not supported by virtualenv. Error details: %r" % e)
             except tox.exception.InvocationError as e:
                 status = (
-                        "Error creating virtualenv. Note that some special "
-                        "characters (e.g. ':' and unicode symbols) in paths are "
-                        "not supported by virtualenv. Error details: %r" % e)
+                    "Error creating virtualenv. Note that some special "
+                    "characters (e.g. ':' and unicode symbols) in paths are "
+                    "not supported by virtualenv. Error details: %r" % e)
+            except tox.exception.InterpreterNotFound as e:
+                status = e
+                if self.config.option.skip_missing_interpreters:
+                    default_ret_code = 0
             if status:
                 commandlog = envlog.get_commandlog("setup")
-                commandlog.add_command(["setup virtualenv"], str(status), 1)
+                commandlog.add_command(["setup virtualenv"], str(status), default_ret_code)
                 venv.status = status
-                self.report.error(str(status))
+                if default_ret_code == 0:
+                    self.report.skip(str(status))
+                else:
+                    self.report.error(str(status))
                 return False
             commandpath = venv.getcommandpath("python")
             envlog.set_python_info(commandpath)

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -170,8 +170,6 @@ class VirtualEnv(object):
             self.just_created = True
         except tox.exception.UnsupportedInterpreter:
             return sys.exc_info()[1]
-        except tox.exception.InterpreterNotFound:
-            return sys.exc_info()[1]
         try:
             self.hook.tox_testenv_install_deps(action=action, venv=self)
         except tox.exception.InvocationError:


### PR DESCRIPTION
Fixes execution of tox with --result-json and --skip-missing-interpreters-option. The reported JSON file contains return code 0 if no interpreter is found. See example output below. Fixes #672

```
"python": {
  "setup": [
  {
    "command": [
    "setup virtualenv"
    ],
    "output": "InterpreterNotFound: xyz_unknown_interpreter",
    "retcode": "0"
   }
   ]
}
```
