### PR TITLE
Package stat plugin

### DIFF
--- a/changelog/725.feature.rst
+++ b/changelog/725.feature.rst
@@ -1,0 +1,2 @@
+Add tox_runenvreport as a possible plugin, allowing the overriding of the default behaviour to execute a command
+to get the installed packages within a virtual environment - by @tonybaloney

--- a/tox/hookspecs.py
+++ b/tox/hookspecs.py
@@ -103,3 +103,11 @@ def tox_runtest_post(venv):
 
     This could be used to have per-venv test reporting of pass/fail status.
     """
+
+
+@hookspec(firstresult=True)
+def tox_runenvreport(venv, action):
+    """ [experimental] Get the installed packages and versions in this venv
+
+    This could be used for alternative (ie non-pip) package managers
+    """

--- a/tox/session.py
+++ b/tox/session.py
@@ -592,23 +592,22 @@ class Session:
                     else:
                         self.installpkg(venv, path)
 
-                # write out version dependency information
-                action = self.newaction(venv, "envreport")
-                with action:
-                    args = venv.envconfig.list_dependencies_command
-                    output = venv._pcall(args,
-                                         cwd=self.config.toxinidir,
-                                         action=action)
-                    # the output contains a mime-header, skip it
-                    output = output.split("\n\n")[-1]
-                    packages = output.strip().split("\n")
-                    action.setactivity("installed", ",".join(packages))
-                    envlog = self.resultlog.get_envlog(venv.name)
-                    envlog.set_installed(packages)
-
+                self.runenvreport(venv)
                 self.runtestenv(venv)
         retcode = self._summary()
         return retcode
+
+    def runenvreport(self, venv):
+        """
+        Run an environment report to show which package
+        versions are installed in the venv
+        """
+        action = self.newaction(venv, "envreport")
+        with action:
+            packages = self.hook.tox_runenvreport(venv=venv, action=action)
+        action.setactivity("installed", ",".join(packages))
+        envlog = self.resultlog.get_envlog(venv.name)
+        envlog.set_installed(packages)
 
     def runtestenv(self, venv, redirect=False):
         if not self.config.option.notest:

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -465,3 +465,17 @@ def tox_runtest(venv, redirect):
     venv.test(redirect=redirect)
     # Return non-None to indicate the plugin has completed
     return True
+
+
+@hookimpl
+def tox_runenvreport(venv, action):
+    # write out version dependency information
+    args = venv.envconfig.list_dependencies_command
+    output = venv._pcall(args,
+                         cwd=venv.envconfig.config.toxinidir,
+                         action=action)
+    # the output contains a mime-header, skip it
+    output = output.split("\n\n")[-1]
+    packages = output.strip().split("\n")
+    # Return non-None to indicate the plugin has completed
+    return packages


### PR DESCRIPTION
This pull request implements a plugin hook for reporting package versions as described in #725 

Implementation simply moves existing code into a static method and refactors existing calls to use hookimpl.

The expected result not a list, since `first_result` was used, I decided to match the behaviour of the installation of packages.