### PR TITLE
Fix issue #727

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,6 +18,7 @@ Cyril Roelandt
 Eli Collins
 Eugene Yunak
 Fernando L. Pereira
+Florian Schulze
 Hazal Ozturk
 Henk-Jaap Wagenaar
 Ian Stapleton Cordasco

--- a/changelog/727.bugfix.rst
+++ b/changelog/727.bugfix.rst
@@ -1,0 +1,1 @@
+The reading of command output sometimes failed with ``IOError: [Errno 0] Error`` on Windows, this was fixed by using a simpler method to update the read buffers. - by @fschulze

--- a/tox/session.py
+++ b/tox/session.py
@@ -135,7 +135,7 @@ class Action(object):
             fout.write("actionid: %s\nmsg: %s\ncmdargs: %r\n\n" % (self.id, self.msg, args))
             fout.flush()
             outpath = py.path.local(fout.name)
-            fin = outpath.open()
+            fin = outpath.open('rb')
             fin.read()  # read the header, so it won't be written to stdout
             stdout = fout
         elif returnout:
@@ -163,13 +163,12 @@ class Action(object):
                     out = None
                     last_time = time.time()
                     while 1:
-                        fin_pos = fin.tell()
                         # we have to read one byte at a time, otherwise there
                         # might be no output for a long time with slow tests
                         data = fin.read(1)
                         if data:
                             sys.stdout.write(data)
-                            if '\n' in data or (time.time() - last_time) > 1:
+                            if b'\n' in data or (time.time() - last_time) > 1:
                                 # we flush on newlines or after 1 second to
                                 # provide quick enough feedback to the user
                                 # when printing a dot per test
@@ -181,7 +180,8 @@ class Action(object):
                             break
                         else:
                             time.sleep(0.1)
-                            fin.seek(fin_pos)
+                            # the seek updates internal read buffers
+                            fin.seek(0, 1)
                     fin.close()
                 else:
                     out, err = popen.communicate()


### PR DESCRIPTION
The reading of command output sometimes failed with ``IOError: [Errno 0] Error`` on Windows, this was fixed by using a simpler method to update the read buffers.
