### PR TITLE
Prevent test failure due to Travis pyenv misconfiguration

### DIFF
--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -385,11 +385,11 @@ def test_install_command_not_installed_bash(newmocksession):
 
 
 def test_install_python3(tmpdir, newmocksession):
-    if not py.path.local.sysfind('python3.6'):
-        pytest.skip("needs python3.6")
+    if not py.path.local.sysfind('python3'):
+        pytest.skip("needs python3")
     mocksession = newmocksession([], """
         [testenv:py123]
-        basepython=python3.6
+        basepython=python3
         deps=
             dep1
             dep2

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -385,11 +385,11 @@ def test_install_command_not_installed_bash(newmocksession):
 
 
 def test_install_python3(tmpdir, newmocksession):
-    if not py.path.local.sysfind('python3.5'):
-        pytest.skip("needs python3.5")
+    if not py.path.local.sysfind('python3.6'):
+        pytest.skip("needs python3.6")
     mocksession = newmocksession([], """
         [testenv:py123]
-        basepython=python3.5
+        basepython=python3.6
         deps=
             dep1
             dep2


### PR DESCRIPTION
Travis seems to occasionally misconfigure pyenv (see: travis-ci/travis-ci#8363). Previously, `python3.5` was misconfigured, but a more recent deployment seems to have broken `python3.6` instead. Per @asottile's [comment](https://github.com/tox-dev/tox-venv/pull/4), `python3` is a little more robust in this regard, and less dependent on one specific version of python being misconfigured.