### PR TITLE
Fix #426 by writing directly to stdout buffer if possible to prevent str vs bytes issues.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,6 +5,7 @@ Alexandre Conrad
 Allan Feldman
 Andrii Soldatenko
 Anthon van der Neuth
+Anthony Sottile
 Asmund Grammeltwedt
 Barry Warsaw
 Bartolome Sanchez Salado

--- a/changelog/426.bugfix.rst
+++ b/changelog/426.bugfix.rst
@@ -1,0 +1,1 @@
+Write directly to stdout buffer if possible to prevent str vs bytes issues - by @asottile

--- a/tox/session.py
+++ b/tox/session.py
@@ -160,6 +160,9 @@ class Action(object):
             try:
                 if resultjson and not redirect:
                     assert popen.stderr is None  # prevent deadlock
+                    # we read binary from the process and must write using a
+                    # binary stream
+                    buf = getattr(sys.stdout, 'buffer', sys.stdout)
                     out = None
                     last_time = time.time()
                     while 1:
@@ -167,12 +170,12 @@ class Action(object):
                         # might be no output for a long time with slow tests
                         data = fin.read(1)
                         if data:
-                            sys.stdout.write(data)
+                            buf.write(data)
                             if b'\n' in data or (time.time() - last_time) > 1:
                                 # we flush on newlines or after 1 second to
                                 # provide quick enough feedback to the user
                                 # when printing a dot per test
-                                sys.stdout.flush()
+                                buf.flush()
                                 last_time = time.time()
                         elif popen.poll() is not None:
                             if popen.stdout is not None:

--- a/tox/session.py
+++ b/tox/session.py
@@ -159,7 +159,9 @@ class Action(object):
             self.report.logpopen(popen, env=env)
             try:
                 if resultjson and not redirect:
-                    assert popen.stderr is None  # prevent deadlock
+                    if popen.stderr is not None:
+                        # prevent deadlock
+                        raise ValueError("stderr must not be piped here")
                     # we read binary from the process and must write using a
                     # binary stream
                     buf = getattr(sys.stdout, 'buffer', sys.stdout)


### PR DESCRIPTION
- [x] wrote descriptive pull request text
- [ ] added/updated test(s) (no idea how to write a test for this)
- [ ] updated/extended the documentation (not applicable)
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
