### PR TITLE
venv: Stop ignoring PYTHONDONTWRITEBYTECODE

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -55,6 +55,7 @@ Pierre-Luc Tessier Gagné
 Ronald Evers
 Ronny Pfannschmidt
 Selim Belhaouane
+Stephen Finucane
 Sridhar Ratnakumar
 Ville Skyttä
 anatoly techtonik

--- a/changelog/744.trivial.rst
+++ b/changelog/744.trivial.rst
@@ -1,0 +1,2 @@
+The ``PYTHONDONTWRITEBYTECODE`` environment variable is no longer unset - by
+@stephenfin.

--- a/tox/venv.py
+++ b/tox/venv.py
@@ -397,8 +397,7 @@ class VirtualEnv(object):
 
     def _pcall(self, args, cwd, venv=True, testcommand=False,
                action=None, redirect=True, ignore_ret=False):
-        for name in ("VIRTUALENV_PYTHON", "PYTHONDONTWRITEBYTECODE"):
-            os.environ.pop(name, None)
+        os.environ.pop('VIRTUALENV_PYTHON', None)
 
         cwd.ensure(dir=1)
         args[0] = self.getcommandpath(args[0], venv, cwd)


### PR DESCRIPTION
'tox' has ignored the 'PYTHONDONTWRITEBYTECODE' environment option since 1.6.0 (commit 3a9c591f [1]). In the commit, an unknown issue with 'setuptools' was reported. However, this was incorrect: the issue at the time lay not with 'setuptools' but rather with 'virtualenv'.  When using particular versions of 'virtualenv', the following message would be shown and the application would exit:

    The PYTHONDONTWRITEBYTECODE environment variable is not
    compatible with setuptools. Either use --distribute or unset
    PYTHONDONTWRITEBYTECODE.

The offending message was added and later refined in virtualenv 1.7 (commits a1b8632b [2] and 32367828 [3]). However, this log was removed when support for 'setuptools' 0.7 and greater was added in 'virtualenv' 1.10 (commit cb01d9f9 [4]) There are no references to 'PYTHONDONTWRITEBYTECODE' in virtualenv 12.0 or any major release since then, suggesting the issue works as expected. Meanwhile, setuptools appears to have supported the 'PYTHONDONTWRITEBYTECODE' flag since 0.6.11 (commit 3a9c591f [5]).

All in all, it appears any release of 'virtualenv' or 'setuptools' made in the past 5+ years is more than happy to work with this option and there is therefore no reason for tox to treat it any differently. Stop special casing this option and allow people to use it if they so desire.

[1] https://github.com/tox-dev/tox/commit/700c8777c651809f72bd8fd2fbc495097c98c676
[2] https://github.com/pypa/virtualenv/commit/a1b8632b86f429710a6297098ad1ef890fab8d01
[3] https://github.com/pypa/virtualenv/commit/32367828895b8d79830e84c59173cfe81ac54f02
[4] https://github.com/pypa/virtualenv/commit/cb01d9f9c8b6bc968d5e19cdc396e8e8a8bebb39
[5] https://github.com/pypa/setuptools/commit/3a9c591f47b69048b513e5654e5d98efe3f2365a

Signed-off-by: Stephen Finucane <stephen@that.guru>
Fixes: #744