### PR TITLE
Remove redundant Python 2.6 code

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2216,7 +2216,7 @@ class TestCmdInvocation:
         initproj('listenvs_all_verbose_description', filedefs={
             'tox.ini': '''
             [tox]
-            envlist={py27,py36}-{windows,linux} # py26
+            envlist={py27,py36}-{windows,linux} # py35
             [testenv]
             description= py27: run pytest on Python 2.7
                          py36: run pytest on Python 3.6

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -689,9 +689,9 @@ def test_test_piphelp(initproj, cmd):
         # content of: tox.ini
         [testenv]
         commands=pip -h
-        [testenv:py26]
-        basepython=python
         [testenv:py27]
+        basepython=python
+        [testenv:py36]
         basepython=python
     """})
     result = cmd()

--- a/tox/_pytestplugin.py
+++ b/tox/_pytestplugin.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-import sys
 import textwrap
 import time
 from fnmatch import fnmatch
@@ -60,9 +59,6 @@ def cmd(request, capfd, monkeypatch):
     request.addfinalizer(py.path.local().chdir)
 
     def run(*argv):
-        if sys.version_info[:2] < (2, 7):
-            pytest.skip("can not run tests involving calling tox on python2.6. "
-                        "(and python2.6 is about to be deprecated anyway)")
         key = str(b'PYTHONPATH')
         python_paths = (i for i in (str(os.getcwd()), os.getenv(key)) if i)
         monkeypatch.setenv(key, os.pathsep.join(python_paths))

--- a/tox/interpreters.py
+++ b/tox/interpreters.py
@@ -177,10 +177,10 @@ else:
 
 def pyinfo():
     import sys
-    return dict(version_info=tuple(sys.version_info),
-                sysplatform=sys.platform)
+    return {"version_info": tuple(sys.version_info),
+            "sysplatform": sys.platform}
 
 
 def sitepackagesdir(envdir):
     import distutils.sysconfig
-    return dict(dir=distutils.sysconfig.get_python_lib(prefix=envdir))
+    return {"dir": distutils.sysconfig.get_python_lib(prefix=envdir)}

--- a/tox/result.py
+++ b/tox/result.py
@@ -21,11 +21,11 @@ class ResultLog:
         """
         :param py.path.local installpkg: Path ot the package.
         """
-        self.dict["installpkg"] = dict(
-            md5=installpkg.computehash("md5"),
-            sha256=installpkg.computehash("sha256"),
-            basename=installpkg.basename,
-        )
+        self.dict["installpkg"] = {
+            "md5": installpkg.computehash("md5"),
+            "sha256": installpkg.computehash("sha256"),
+            "basename": installpkg.basename,
+        }
 
     def get_envlog(self, name):
         testenvs = self.dict.setdefault("testenvs", {})
@@ -57,10 +57,11 @@ class EnvLog:
         executable = lines.pop(0)
         version_info = eval(lines.pop(0))
         version = "\n".join(lines)
-        self.dict["python"] = dict(
-            executable=executable,
-            version_info=version_info,
-            version=version)
+        self.dict["python"] = {
+            "executable": executable,
+            "version_info": version_info,
+            "version": version,
+        }
 
     def get_commandlog(self, name):
         return CommandLog(self, self.dict.setdefault(name, []))

--- a/tox/session.py
+++ b/tox/session.py
@@ -688,7 +688,7 @@ class Session:
     def showenvs(self, all_envs=False, description=False):
         env_conf = self.config.envconfigs  # this contains all environments
         default = self.config.envlist  # this only the defaults
-        extra = sorted([e for e in env_conf if e not in default]) if all_envs else []
+        extra = sorted(e for e in env_conf if e not in default) if all_envs else []
         if description:
             self.report.line('default environments:')
             max_length = max(len(env) for env in (default + extra))


### PR DESCRIPTION
* Remove some redundant Python 2.6 code saying that version will soon be deprecated -- it's already been dropped.

* Also replace some py26 in test examples with something a bit newer.

* Also rewrite dict calls as literals and replace a list comprehension with a generator.

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [n/a] updated/extended the documentation
- [n/a] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
