### PR TITLE
Skip alwayscopy tests for SuSE

### DIFF
--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -636,10 +636,8 @@ def _alwayscopy_not_supported():
     if hasattr(platform, 'linux_distribution'):
         _dist = platform.linux_distribution(full_distribution_name=False)
         (name, version, arch) = _dist
-        if any((
-                name == 'centos' and version[0] == '7',
-                name == 'SuSE' and arch == 'x86_64',
-               )):
+        if any(( name == 'centos' and version[0] == '7',
+                 name == 'SuSE' and arch == 'x86_64' )):
             return True
     return False
 

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -636,8 +636,8 @@ def _alwayscopy_not_supported():
     if hasattr(platform, 'linux_distribution'):
         _dist = platform.linux_distribution(full_distribution_name=False)
         (name, version, arch) = _dist
-        if any(( name == 'centos' and version[0] == '7',
-                 name == 'SuSE' and arch == 'x86_64' )):
+        if any((name == 'centos' and version[0] == '7',
+                name == 'SuSE' and arch == 'x86_64')):
             return True
     return False
 

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -636,10 +636,10 @@ def _alwayscopy_not_supported():
     if hasattr(platform, 'linux_distribution'):
         _dist = platform.linux_distribution(full_distribution_name=False)
         (name, version, arch) = _dist
-        if (
-            (name == 'centos' and version[0] == '7') or
-            (name == 'SuSE' and arch == 'x86_64')
-           ):
+        if any((
+                name == 'centos' and version[0] == '7',
+                name == 'SuSE' and arch == 'x86_64',
+               )):
             return True
     return False
 

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -636,7 +636,8 @@ def _alwayscopy_not_supported():
     if hasattr(platform, 'linux_distribution'):
         _dist = platform.linux_distribution(full_distribution_name=False)
         (name, version, arch) = _dist
-        if ((name == 'centos' and version[0] == '7') or
+        if (
+            (name == 'centos' and version[0] == '7') or
             (name == 'SuSE' and arch == 'x86_64')
            ):
             return True

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -635,7 +635,10 @@ def _alwayscopy_not_supported():
     # see: https://github.com/pypa/virtualenv/issues/565
     if hasattr(platform, 'linux_distribution'):
         _dist = platform.linux_distribution(full_distribution_name=False)
-        if _dist[0] == 'centos' and _dist[1][0] == '7':
+        (name, version, arch) = _dist
+        if ((name == 'centos' and version[0] == '7') or
+            (name == 'SuSE' and arch == 'x86_64')
+           ):
             return True
     return False
 


### PR DESCRIPTION
This is a fix to issue #752.
Now `tox` succeeds (with python versions: py27, py34, py36).
*a priori* the i686 arch should be able to run, so skip `test_alwayscopy`  only for the x86-64 arch.
