### PR TITLE
Fix #755 by reverting the ``cmdline`` import to the old location and changing the entry point instead.

### DIFF
--- a/changelog/755.bugfix.rst
+++ b/changelog/755.bugfix.rst
@@ -1,0 +1,1 @@
+fix #755 by reverting the ``cmdline`` import to the old location and changing the entry point instead - by @fschulze

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def main():
         author='holger krekel',
         author_email='holger@merlinux.eu',
         packages=['tox'],
-        entry_points={'console_scripts': ['tox=tox:cmdline',
+        entry_points={'console_scripts': ['tox=tox.session:run_main',
                                           'tox-quickstart=tox._quickstart:main']},
         python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
         setup_requires=['setuptools_scm'],

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -2,7 +2,6 @@ import os
 import platform
 import re
 import subprocess
-import sys
 
 import py
 import pytest
@@ -901,6 +900,5 @@ def test_tox_quickstart_script():
 
 
 def test_tox_cmdline(monkeypatch):
-    monkeypatch.setattr(sys, 'argv', ['caller_script', '--help'])
     with pytest.raises(SystemExit):
-        tox.cmdline()
+        tox.cmdline(['caller_script', '--help'])

--- a/tox/__init__.py
+++ b/tox/__init__.py
@@ -52,6 +52,6 @@ class exception:
             super(exception.MinVersionError, self).__init__(message)
 
 
-from .session import run_main as cmdline  # noqa
+from .session import main as cmdline  # noqa
 
 __all__ = ('hookspec', 'hookimpl', 'cmdline', 'exception', '__version__')


### PR DESCRIPTION
My proposed fix for #755 