### PR TITLE
Display exit code with InvocationErrors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Chris Jerdonek
 Chris Rose
 Clark Boylan
 Cyril Roelandt
+Ederag
 Eli Collins
 Eugene Yunak
 Fernando L. Pereira

--- a/changelog/290.feature.rst
+++ b/changelog/290.feature.rst
@@ -1,0 +1,1 @@
+``tox`` displays exit code together with ``InvocationError`` - by @blueyed and @ederag.

--- a/doc/example/basic.rst
+++ b/doc/example/basic.rst
@@ -289,6 +289,7 @@ Integration with "setup.py test" command
   point it's maybe best to not go for any ``setup.py test`` integration.
 
 
+.. _`ignoring exit code`:
 
 Ignoring a command exit code
 ----------------------------

--- a/doc/example/general.rst
+++ b/doc/example/general.rst
@@ -204,3 +204,49 @@ There is an optimization coded in to not bother re-running the command if
 ``$projectname.egg-info`` is newer than ``setup.py`` or ``setup.cfg``.
 
 .. include:: ../links.rst
+
+
+Understanding ``InvocationError`` exit codes
+--------------------------------------------
+
+When a command (defined by ``commands =`` in ``tox.ini``) fails,
+it has a non-zero exit code,
+and an ``InvocationError`` exception is raised by ``tox``:
+
+.. code-block:: shell
+
+    ERROR: InvocationError for command
+           '<command defined in tox.ini>' (exited with code 1)
+
+If the command starts with ``pytest`` or ``python setup.py test`` for instance,
+then the `pytest exit codes`_ are relevant.
+
+On unix systems, there are some rather `common exit codes`_.
+This is why for exit codes larger than 128, an additional hint is given:
+
+.. code-block:: shell
+
+    ERROR: InvocationError for command
+           '<command defined in tox.ini>' (exited with code 139)
+    Note: On unix systems, an exit code larger than 128 often means a fatal error (e.g. 139=128+11: segmentation fault)
+
+The signal numbers (e.g. 11 for a segmentation fault) can be found in the
+"Standard signals" section of the `signal man page`_.
+Their meaning is described in `POSIX signals`_.
+
+Beware that programs may issue custom exit codes with any value,
+so their documentation should be consulted.
+
+
+Sometimes, no exit code is given at all.
+An example may be found in `pytest-qt issue #170`_,
+where Qt was calling ``abort()`` instead of ``exit()``.
+
+.. seealso:: :ref:`ignoring exit code`.
+
+.. _`pytest exit codes`: https://docs.pytest.org/en/latest/usage.html#possible-exit-codes
+.. _`common exit codes`: http://www.faqs.org/docs/abs/HTML/exitcodes.html
+.. _`abort()``: http://www.unix.org/version2/sample/abort.html
+.. _`pytest-qt issue #170` : https://github.com/pytest-dev/pytest-qt/issues/170
+.. _`signal man page`: http://man7.org/linux/man-pages/man7/signal.7.html
+.. _`POSIX signals`: https://en.wikipedia.org/wiki/Signal_(IPC)#POSIX_signals

--- a/tox/__init__.py
+++ b/tox/__init__.py
@@ -34,13 +34,10 @@ class exception:
 
     class InvocationError(Error):
         """ an error while invoking a script. """
-        def __init__(self, *args):
-            super(exception.Error, self).__init__(*args)
-            self.command = args[0]
-            try:
-                self.exitcode = args[1]
-            except IndexError:
-                self.exitcode = None
+        def __init__(self, command, exitcode=None):
+            super(exception.Error, self).__init__(command, exitcode)
+            self.command = command
+            self.exitcode = exitcode
 
         def __str__(self):
             str_ = "%s for command %s" % (self.__class__.__name__, self.command)

--- a/tox/__init__.py
+++ b/tox/__init__.py
@@ -43,10 +43,13 @@ class exception:
                 self.exitcode = None
 
         def __str__(self):
+            str_ = "%s for command %s" % (self.__class__.__name__, self.command)
             if self.exitcode:
-                return "%s: %s (exitcode %d)" % (self.__class__.__name__,
-                                                 self.command, self.exitcode)
-            return "%s: %s" % (self.__class__.__name__, self.command)
+                str_ += " (exited with code %d)" % (self.exitcode)
+                if self.exitcode > 128:
+                    str_ += ("\nNote: On unix systems, an exit code larger than 128 "
+                             "often means a fatal error (e.g. 139=128+11: segmentation fault)")
+            return str_
 
     class MissingFile(Error):
         """ an error while invoking a script. """

--- a/tox/__init__.py
+++ b/tox/__init__.py
@@ -34,6 +34,19 @@ class exception:
 
     class InvocationError(Error):
         """ an error while invoking a script. """
+        def __init__(self, *args):
+            super(exception.Error, self).__init__(*args)
+            self.command = args[0]
+            try:
+                self.exitcode = args[1]
+            except IndexError:
+                self.exitcode = None
+
+        def __str__(self):
+            if self.exitcode:
+                return "%s: %s (exitcode %d)" % (self.__class__.__name__,
+                                                 self.command, self.exitcode)
+            return "%s: %s" % (self.__class__.__name__, self.command)
 
     class MissingFile(Error):
         """ an error while invoking a script. """


### PR DESCRIPTION
This is a PR for @blueyed patch (Issue #290), supplemented with tests. 
For exit codes larger than 128, a hint is given: on unix systems this often means a fatal error.
(Not always, since an application might exit with a large custom error code)

Not showing this hint for windows platform was considered, but discarded to keep code short and
simplify tests.

Before:

> ERROR: InvocationError: '/home/ederag/share/prog/python/tox/.tox/exitcode/bin/python3.6 -c import sys; sys.exit(5)'

After:

> ERROR: InvocationError for command '/home/ederag/share/prog/python/tox/.tox/exitcode/bin/python3.6 -c import sys; sys.exit(5)' (exited with code 5)

or, for an exit code larger than 128:

> ERROR: InvocationError for command '/home/ederag/share/prog/python/tox/.tox/exitcode/bin/python3.6 -c import sys; sys.exit(129)' (exited with code 129)
> Note: On unix systems, an exit code larger than 128 often means a fatal error (e.g. 139=128+11: segmentation fault)

To generate these outputs, a section was added to `tox.ini`:
```
[testenv:exitcode]
basepython = python3.6
description = commands with several exit codes
skip_install = True
commands = python3.6 -c "import sys; sys.exit(5)"
```
and run with `python3 -m tox -e exitcode`.
The modified section is too specific to be included in the PR, isn't it ?


Tests have been added to `test_z_cmdline.py`.
Safely replacing these tests with faster ones (mock) would require someone experienced with this technique.


The documentation might be completed (still have to think about it).
Probably add a section "Understanding InvocationError exit codes"
in [example/general.html](https://tox.readthedocs.io/en/latest/example/general.html)
with links to `pytest` exit codes, to http://www.faqs.org/docs/abs/HTML/exitcodes.html, 
and explaining that no exit code is shown when the process has been aborted (like Qt does).
And for good measure, giving a link to [ignoring-a-command-exit-code](https://tox.readthedocs.io/en/latest/example/basic.html#ignoring-a-command-exit-code).


## Contribution checklist:

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
