### PR TITLE
Fix bug with incorrectly defactorized dependencies

### DIFF
--- a/changelog/706.bugfix.rst
+++ b/changelog/706.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug with incorrectly defactorized dependencies - by @bartsanchez

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -674,6 +674,32 @@ the following:
     - but not ``py2``, ``py36-sql`` or ``py36-mysql-dev``.
 
 
+Factors and values substitution are compatible
+++++++++++++++++++++++++++++++++++++++++++++++
+
+It is possible to mix both values substitution and factor expressions.
+For example::
+
+    [tox]
+    envlist = py27,py36,coverage
+
+    [testenv]
+    deps =
+        flake8
+        coverage: coverage
+
+    [testenv:py27]
+    deps =
+        {{[testenv]deps}}
+        pytest
+
+With the previous configuration, it will install:
+
+- ``flake8`` and ``pytest`` packages for ``py27`` environment.
+- ``flake8`` package for ``py36`` environment.
+- ``flake8`` and ``coverage`` packages for ``coverage`` environment.
+
+
 Other Rules and notes
 =====================
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1294,7 +1294,36 @@ class TestConfigTestEnv:
         )
         conf = newconfig([], inisource).envconfigs['py27']
         packages = [dep.name for dep in conf.deps]
-        assert packages == list(deps) + ['fun', 'frob>1.0,<2.0']
+        assert packages == ['pytest', 'pytest-cov', 'fun', 'frob>1.0,<2.0']
+
+    # https://github.com/tox-dev/tox/issues/706
+    @pytest.mark.parametrize('envlist', [['py27', 'coverage', 'other']])
+    def test_regression_test_issue_706(self, newconfig, envlist):
+        inisource = """
+            [tox]
+            envlist = {envlist}
+            [testenv]
+            deps=
+              flake8
+              coverage: coverage
+            [testenv:py27]
+            deps=
+                {{[testenv]deps}}
+                fun
+        """.format(
+            envlist=','.join(envlist),
+        )
+        conf = newconfig([], inisource).envconfigs['coverage']
+        packages = [dep.name for dep in conf.deps]
+        assert packages == ['flake8', 'coverage']
+
+        conf = newconfig([], inisource).envconfigs['other']
+        packages = [dep.name for dep in conf.deps]
+        assert packages == ['flake8']
+
+        conf = newconfig([], inisource).envconfigs['py27']
+        packages = [dep.name for dep in conf.deps]
+        assert packages == ['flake8', 'fun']
 
     def test_take_dependencies_from_other_section(self, newconfig):
         inisource = """

--- a/tox/config.py
+++ b/tox/config.py
@@ -1076,10 +1076,10 @@ class SectionReader:
         if x is None:
             x = default
         else:
+            x = self._replace_if_needed(x, name, replace, crossonly)
             x = self._apply_factors(x)
 
-        if replace and x and hasattr(x, 'replace'):
-            x = self._replace(x, name=name, crossonly=crossonly)
+        x = self._replace_if_needed(x, name, replace, crossonly)
         # print "getstring", self.section_name, name, "returned", repr(x)
         return x
 
@@ -1114,6 +1114,11 @@ class SectionReader:
                     "section %r." % (value, section_name))
             raise
         return replaced
+
+    def _replace_if_needed(self, x, name, replace, crossonly):
+        if replace and x and hasattr(x, 'replace'):
+            x = self._replace(x, name=name, crossonly=crossonly)
+        return x
 
 
 class Replacer:


### PR DESCRIPTION
fixes #706

By performing dependencies replacement before applying factors,
since previously this function was being incorrectly called with
unrolled dependencies.

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
