### PR TITLE
#773 revert breaking change of tox.cmdline not callable with no args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ htmlcov
 .idea
 .eggs/
 py27/
+
+.*_cache

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -2,6 +2,7 @@ import os
 import platform
 import re
 import subprocess
+import sys
 
 import py
 import pytest
@@ -902,8 +903,9 @@ def test_tox_quickstart_script():
 
 
 def test_tox_cmdline(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['caller_script', '--help'])
     with pytest.raises(SystemExit):
-        tox.cmdline(['caller_script', '--help'])
+        tox.cmdline()
 
 
 @pytest.mark.parametrize('exit_code', [0, 6])

--- a/tox/__init__.py
+++ b/tox/__init__.py
@@ -84,6 +84,6 @@ class exception:
             super(exception.MinVersionError, self).__init__(message)
 
 
-from .session import main as cmdline  # noqa
+from .session import run_main as cmdline  # noqa
 
 __all__ = ('hookspec', 'hookimpl', 'cmdline', 'exception', '__version__')


### PR DESCRIPTION
![fixed](https://media.tenor.co/images/5928958c42329cf6e101dda2ad295393/tenor.gif)