### PR TITLE
remove unused hookimpl marker

### DIFF
--- a/tox/hookspecs.py
+++ b/tox/hookspecs.py
@@ -1,11 +1,9 @@
 """ Hook specifications for tox.
 
 """
-from pluggy import HookimplMarker
 from pluggy import HookspecMarker
 
 hookspec = HookspecMarker("tox")
-hookimpl = HookimplMarker("tox")
 
 
 @hookspec


### PR DESCRIPTION
it's confusing to have the hookimpl marker in the hookspec module.
