### PR TITLE
#773 allow cmdline to be called bot with and without args, make args use sys.args if not specified

### DIFF
--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -902,10 +902,15 @@ def test_tox_quickstart_script():
     assert result == 0
 
 
-def test_tox_cmdline(monkeypatch):
+def test_tox_cmdline_no_args(monkeypatch):
     monkeypatch.setattr(sys, 'argv', ['caller_script', '--help'])
     with pytest.raises(SystemExit):
         tox.cmdline()
+
+
+def test_tox_cmdline_args(monkeypatch):
+    with pytest.raises(SystemExit):
+        tox.cmdline(['caller_script', '--help'])
 
 
 @pytest.mark.parametrize('exit_code', [0, 6])

--- a/tox/session.py
+++ b/tox/session.py
@@ -34,8 +34,10 @@ def prepare(args):
     return config
 
 
-def run_main():
-    main(sys.argv[1:])
+def run_main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    main(args)
 
 
 def main(args):


### PR DESCRIPTION
Take two on fixing this :face_with_head_bandage: 