### PR TITLE
Update how python3 is installed on macOS builds

### DIFF
--- a/.travis-osx
+++ b/.travis-osx
@@ -1,6 +1,6 @@
 # Perform the manual steps on osx to install python3 and activate an environment
 brew update
-brew install python3
+brew upgrade python
 rm /usr/local/bin/python
 ln -s python3 /usr/local/bin/python
 ln -fs pip3 /usr/local/bin/pip


### PR DESCRIPTION
The Homebrew python package now points to python3 instead of python2.

Note:
- [ ] check that macOS build actually succeeds
- [ ] check that macOS build actually runs the tests