### PR TITLE
handle interpreter directives with long lengths

### DIFF
--- a/changelog/794.feature.rst
+++ b/changelog/794.feature.rst
@@ -1,0 +1,5 @@
+Add support to explicitly invoke interpreter directives for environments with
+long path lengths. In the event that ``tox`` cannot invoke scripts with a
+system-limited shebang (e.x. a Linux host running a Jenkins Pipeline), a user
+can set the environment variable ``TOX_LIMITED_SHEBANG`` to workaround the
+system's limitation (e.x. ``export TOX_LIMITED_SHEBANG=1``) - by @jdknight

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -699,6 +699,26 @@ With the previous configuration, it will install:
 - ``flake8`` package for ``py36`` environment.
 - ``flake8`` and ``coverage`` packages for ``coverage`` environment.
 
+Advanced settings
+-----------------
+
+Handle interpreter directives with long lengths
++++++++++++++++++++++++++++++++++++++++++++++++
+
+For systems supporting executable text files (scripts with a shebang), the
+system will attempt to parse the interpreter directive to determine the program
+to execute on the target text file. When ``tox`` prepares a virtual environment
+in a file container which has a large length (e.x. using Jenkins Pipelines), the
+system might not be able to invoke shebang scripts which define interpreters
+beyond system limits (e.x. Linux as a limit of 128; ``BINPRM_BUF_SIZE``). To
+workaround an environment which suffers from an interpreter directive limit, a
+user can bypass the system's interpreter parser by defining the
+``TOX_LIMITED_SHEBANG`` environment variable before invoking ``tox``::
+
+    export TOX_LIMITED_SHEBANG=1
+
+When the workaround is enabled, all tox-invoked text file executables will have
+their interpreter directive parsed by and explicitly executed by ``tox``.
 
 Other Rules and notes
 =====================


### PR DESCRIPTION
handle interpreter directives with long lengths

When preparing virtual environments in a file container which has large length, the system might not be able to invoke shebang scripts which define interpreters beyond system limits (i.e. Linux has a limit of 128; `BINPRM_BUF_SIZE` \[1\]). This wrapper can be used to check if the executable is a script containing a shebang line \[2\]. If so, read the first line for the interpreter and check if length exceeds "common" limit. If the interpreter exceeds the limit, adjust the argument list to directly call the interpreter.

\[1\]: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/tree/include/uapi/linux/binfmts.h?h=linux-4.16.y#n19
\[2\]: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/tree/fs/binfmt_script.c?h=linux-4.16.y#n24

----

Recently had an issue attempting to run tox in a Jenkins Multibranch Pipeline where I received the following error:

```
$ tox
GLOB sdist-make: /var/lib/jenkins/workspace/[...]-py_initial-devwork-RC5P2SZZC5BWPRXRA37BMA5XOH53QUYKJ5Z2625THIQZFTY2FL6Q/setup.py
py27 create: /var/lib/jenkins/workspace/[...]-py_initial-devwork-RC5P2SZZC5BWPRXRA37BMA5XOH53QUYKJ5Z2625THIQZFTY2FL6Q/.tox/py27
py27 installdeps: -r/var/lib/jenkins/workspace/[...]-py_initial-devwork-RC5P2SZZC5BWPRXRA37BMA5XOH53QUYKJ5Z2625THIQZFTY2FL6Q/requirements.txt
ERROR: invocation failed (errno 2), args: ['/var/lib/jenkins/workspace/[...]-py_initial-devwork-RC5P2SZZC5BWPRXRA37BMA5XOH53QUYKJ5Z2625THIQZFTY2FL6Q/.tox/py27/bin/pip', 'install', '-r/var/lib/jenkins/workspace/[...]-py_initial-devwork-RC5P2SZZC5BWPRXRA37BMA5XOH53QUYKJ5Z2625THIQZFTY2FL6Q/requirements.txt'], cwd: /var/lib/jenkins/workspace/[...]-py_initial-devwork-RC5P2SZZC5BWPRXRA37BMA5XOH53QUYKJ5Z2625THIQZFTY2FL6Q
Traceback (most recent call last):
  File "/bin/tox", line 11, in <module>
    sys.exit(run_main())
  File "/usr/lib/python2.7/site-packages/tox/session.py", line 40, in run_main
    main(args)
  File "/usr/lib/python2.7/site-packages/tox/session.py", line 46, in main
    retcode = Session(config).runcommand()
  File "/usr/lib/python2.7/site-packages/tox/session.py", line 415, in runcommand
    return self.subcommand_test()
  File "/usr/lib/python2.7/site-packages/tox/session.py", line 599, in subcommand_test
    if self.setupenv(venv):
  File "/usr/lib/python2.7/site-packages/tox/session.py", line 491, in setupenv
    status = venv.update(action=action)
  File "/usr/lib/python2.7/site-packages/tox/venv.py", line 171, in update
    self.hook.tox_testenv_install_deps(action=action, venv=self)
  File "/usr/lib/python2.7/site-packages/pluggy/__init__.py", line 617, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/usr/lib/python2.7/site-packages/pluggy/__init__.py", line 222, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/usr/lib/python2.7/site-packages/pluggy/__init__.py", line 216, in <lambda>
    firstresult=hook.spec_opts.get('firstresult'),
  File "/usr/lib/python2.7/site-packages/pluggy/callers.py", line 201, in _multicall
    return outcome.get_result()
  File "/usr/lib/python2.7/site-packages/pluggy/callers.py", line 77, in get_result
    _reraise(*ex)  # noqa
  File "/usr/lib/python2.7/site-packages/pluggy/callers.py", line 180, in _multicall
    res = hook_impl.function(*args)
  File "/usr/lib/python2.7/site-packages/tox/venv.py", line 452, in tox_testenv_install_deps
    venv._install(deps, action=action)
  File "/usr/lib/python2.7/site-packages/tox/venv.py", line 331, in _install
    action=action)
  File "/usr/lib/python2.7/site-packages/tox/venv.py", line 303, in run_install_command
    action=action, redirect=self.session.report.verbosity < 2)
  File "/usr/lib/python2.7/site-packages/tox/venv.py", line 409, in _pcall
    redirect=redirect, ignore_ret=ignore_ret)
  File "/usr/lib/python2.7/site-packages/tox/session.py", line 150, in popen
    stdout=stdout, stderr=subprocess.STDOUT)
  File "/usr/lib/python2.7/site-packages/tox/session.py", line 243, in _popen
    stdout=stdout, stderr=stderr, env=env)
  File "/usr/lib64/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

My tox version:

```
$ tox --version
3.0.0 
```

After some investigation, it appears to be an issue with the path length generated by Jenkins and the interpreter strings of scripts tox needs to invoke. This issue has been also discussed in #66 and #649 (and related pypa/pip#1773, pypa/virtualenv#596). This proposed change is an attempt to help provide a workaround for tox user's in long-path environments. After the above change, I was able to invoke a tox-support project under a long-path environment:

```
$ tox
GLOB sdist-make: /var/lib/jenkins/workspace/[...]-py_initial-devwork-RC5P2SZZC5BWPRXRA37BMA5XOH53QUYKJ5Z2625THIQZFTY2FL6Q/setup.py
py27 inst-nodeps: /var/lib/jenkins/workspace/[...]-py_initial-devwork-RC5P2SZZC5BWPRXRA37BMA5XOH53QUYKJ5Z2625THIQZFTY2FL6Q/.tox/dist/[...]-0.1.0.dev0.zip
py27 installed: enum34==1.1.6,[...]==0.1.0.dev0
py27 runtests: PYTHONHASHSEED='931962048'
...
```

(note: I don't know much about tox's internals, so this could be completely wrong; if workarounds like this are not desired, I have no problem in dropping this request)
