### PR TITLE
Fix pypy test

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1661,18 +1661,18 @@ class TestGlobalOptions:
         config = newconfig([], "[tox]\nenvlist=%s" % ", ".join(envlist))
         assert config.envlist == envlist
         for name in config.envlist:
-            env = config.envconfigs[name]
+            basepython = config.envconfigs[name].basepython
             if name == "jython":
-                assert env.basepython == "jython"
+                assert basepython == "jython"
             elif name.startswith("pypy"):
-                assert env.basepython == name
+                assert basepython == name
             elif name in ("py2", "py3"):
-                assert env.basepython == 'python' + name[-1]
+                assert basepython == 'python' + name[-1]
             elif name == 'py':
-                assert 'python' in env.basepython
+                assert 'python' in basepython
             else:
                 assert name.startswith("py")
-                assert env.basepython == "python%s.%s" % (name[2], name[3])
+                assert basepython == "python{}.{}".format(name[2], name[3])
 
     def test_envlist_expansion(self, newconfig):
         inisource = """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1669,7 +1669,7 @@ class TestGlobalOptions:
             elif name in ("py2", "py3"):
                 assert basepython == 'python' + name[-1]
             elif name == 'py':
-                assert 'python' in basepython
+                assert 'python' in basepython or "pypy" in basepython
             else:
                 assert name.startswith("py")
                 assert basepython == "python{}.{}".format(name[2], name[3])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1656,7 +1656,7 @@ class TestGlobalOptions:
         env = config.envconfigs['py']
         assert str(env.basepython) == sys.executable
 
-    def test_default_factors(self, newconfig):
+    def test_correct_basepython_chosen_from_default_factors(self, newconfig):
         envlist = list(tox.PYTHON.DEFAULT_FACTORS.keys())
         config = newconfig([], "[tox]\nenvlist=%s" % ", ".join(envlist))
         assert config.envlist == envlist

--- a/tox.ini
+++ b/tox.ini
@@ -105,7 +105,7 @@ source = tox
          {toxworkdir}/pypy*/site-packages/tox
 
 [pytest]
-addopts = -rsxX --showlocals
+addopts = -rsxX -vvv --showlocals
 rsyncdirs = tests tox
 looponfailroots = tox tests
 norecursedirs = .hg .tox


### PR DESCRIPTION
I had adjusted the test to also test the py env explicittly without taking into consideration that run on a pypy interpreter basepython is pypy

Also adjusted test and pytest settings to give more helpful output on test failure to be able to debug things like this easier, when they fail on CI.

Also using more informative test name (hopefully).