### PR TITLE
Stop printing good logs if very quiet

### DIFF
--- a/tox/session.py
+++ b/tox/session.py
@@ -307,7 +307,8 @@ class Reporter(object):
         self.logline(msg, **opts)
 
     def good(self, msg):
-        self.logline(msg, green=True)
+        if self.verbosity >= Verbosity.QUIET:
+            self.logline(msg, green=True)
 
     def warning(self, msg):
         if self.verbosity >= Verbosity.QUIET:


### PR DESCRIPTION
The congratulations message is displayed even when using the `-qq` flag. This is due to the congratulations message using `self.report.good("  congratulations :)")`, a method that does not check for a specific level of verbosity. 

This is now fixed and _good_ logs will not be printed if the `-qq` flag is used. 

For more information, see issue #810.