### PR TITLE
Whitespace hooks are still useful for non-python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,8 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.2.3
     hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: debug-statements
     -   id: flake8


### PR DESCRIPTION
This was removed in #813 but there are still lots of source files for which these hooks are still relevant:

```
.codecov.yml
.github/ISSUE_TEMPLATE.md
.github/PULL_REQUEST_TEMPLATE.md
.gitignore
.pre-commit-config.yaml
.travis-osx
.travis.yml
CHANGELOG.rst
CONTRIBUTING.rst
CONTRIBUTORS
HOWTORELEASE.rst
LICENSE
MANIFEST.in
README.rst
Vagrantfile
appveyor.yml
changelog/.gitkeep
changelog/706.bugfix.rst
changelog/754.misc.rst
changelog/794.feature.rst
changelog/797.doc.rst
changelog/798.feature.rst
changelog/799.doc.rst
changelog/800.misc.rst
changelog/801.misc.rst
changelog/802.misc.rst
changelog/examples.rst
changelog/template.jinja2
doc/Makefile
doc/_static/sphinxdoc.css
doc/_templates/localtoc.html
doc/announce/changelog-only.rst
doc/changelog.rst
doc/config.rst
doc/developers.rst
doc/drafts/extend-envs-and-packagebuilds.md
doc/drafts/tox_conda_notes_niccodemus.md
doc/example/basic.rst
doc/example/devenv.rst
doc/example/general.rst
doc/example/jenkins.rst
doc/example/nose.rst
doc/example/platform.rst
doc/example/pytest.rst
doc/example/result.rst
doc/example/unittest.rst
doc/examples.rst
doc/img/tox.svg
doc/index.rst
doc/install.rst
doc/links.rst
doc/plugins.rst
doc/support.rst
pyproject.toml
setup.cfg
tasks/pra.sh
tox.ini
```