### PR TITLE
[wip] experimenting with type hint generation (pyannotate)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,12 @@ def main():
         install_requires=["py>=1.4.17", "pluggy>=0.3.0,<1.0", "six", "virtualenv>=1.11.2"],
         extras_require={
             "testing": [
-                "pytest >= 3.0.0", "pytest-cov", "pytest-mock", "pytest-timeout", "pytest-xdist"
+                "pytest >= 3.0.0",
+                "pytest-cov",
+                "pytest-mock",
+                "pytest-timeout",
+                "pytest-xdist",
+                "pyannotate",
             ],
             "docs": ["sphinx >= 1.6.3, < 2", "towncrier >= 17.8.0"],
             "lint": ["pre-commit == 1.8.2"],

--- a/tox.ini
+++ b/tox.ini
@@ -115,4 +115,4 @@ include_trailing_comma = True
 force_grid_wrap = 0
 line_length = 99
 known_first_party = tox
-known_third_party = pkg_resources,pluggy,py,pytest,setuptools,six
+known_third_party = pkg_resources,pluggy,py,pyannotate_runtime,pytest,setuptools,six

--- a/tox/_pytestplugin.py
+++ b/tox/_pytestplugin.py
@@ -39,6 +39,32 @@ def pytest_report_header():
     return "tox comes from: {!r}".format(tox.__file__)
 
 
+def pytest_collection_finish():
+    """Handle the pytest collection finish hook: configure pyannotate.
+    Explicitly delay importing `collect_types` until all tests have
+    been collected.  This gives gevent a chance to monkey patch the
+    world before importing pyannotate.
+    """
+    from pyannotate_runtime import collect_types
+
+    collect_types.init_types_collection()
+
+
+@pytest.fixture(autouse=True)
+def collect_types_fixture():
+    from pyannotate_runtime import collect_types
+
+    collect_types.resume()
+    yield
+    collect_types.pause()
+
+
+def pytest_sessionfinish():
+    from pyannotate_runtime import collect_types
+
+    collect_types.dump_stats("type_info.json")
+
+
 @pytest.fixture
 def work_in_clean_dir(tmpdir):
     with tmpdir.as_cwd():


### PR DESCRIPTION
I did not do much with this yet, just added the recommended boilerplate for pytest and ran the tests. On first view it only generated hints for the tests itself (where we definitely not would want them, I guess), but not for the production code.

Also see http://mypy-lang.blogspot.de/2017/11/dropbox-releases-pyannotate-auto.html

related issue: #831