### PR TITLE
Run pre-commit autoupdate to update blacken-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,13 @@ repos:
         args: [--line-length=99, --safe]
         language_version: python3.6
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v0.1.0
+    rev: v0.1.1
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==18.5b1]
         language_version: python3.6
 -   repo: https://github.com/asottile/seed-isort-config
-    rev: v0.1.0
+    rev: v1.0.0
     hooks:
     -   id: seed-isort-config
 -   repo: https://github.com/pre-commit/mirrors-isort
@@ -20,7 +20,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+    rev: v1.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer


### PR DESCRIPTION
Noticed there's a slight bug on windows with UTF-8 files here: https://github.com/pytest-dev/pytest/pull/3528#issuecomment-394141476