### PR TITLE
Use pipes.quote when displaying command

### DIFF
--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -1,6 +1,7 @@
 import ast
 import codecs
 import os
+import pipes
 import re
 import sys
 
@@ -361,7 +362,9 @@ class VirtualEnv(object):
             for i, argv in enumerate(self.envconfig.commands):
                 # have to make strings as _pcall changes argv[0] to a local()
                 # happens if the same environment is invoked twice
-                message = "commands[{}] | {}".format(i, " ".join([str(x) for x in argv]))
+                message = "commands[{}] | {}".format(
+                    i, " ".join([pipes.quote(str(x)) for x in argv])
+                )
                 action.setactivity("runtests", message)
                 # check to see if we need to ignore the return code
                 # if so, we need to alter the command line arguments


### PR DESCRIPTION
WIP for #845

Some example output:

```
fix-lint runtests: commands[0] | pre-commit run --all-files --show-diff-on-failure
...
fix-lint runtests: commands[1] | python -c 'print("hint: run /tmp/tox/.tox/fix-lint/bin/pre-commit install to add checks as pre-commit hook")'
...
```