### PR TITLE
Adopt Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,68 @@
+group: travis_latest
 sudo: false
 language: python
 cache: pip
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7-dev
-  - nightly
-  - pypy
+
 env:
   TOXENV=py
+
+stages:
+  - quick # first run quick tests: lint and doc
+  - test  # make sure we run first mandatory tests
+  - extra # then run tests which can fail
+
+jobs:
+  include:
+  - python: 2.7    # 2.7.14 pip  9.0.1
+  - python: 3.4    # 3.4.6  pip  9.0.1
+  - python: 3.5    # 3.5.5  pip  9.0.1
+  - python: 3.6    # 3.6.3  pip  9.0.1
+  - python: 3.7    # 3.7.0  pip 10.0.1
+    dist: xenial
+    sudo: true
+  - python: 3.8-dev
+    dist: xenial
+    sudo: true
+    stage: extra
+  - python: nightly
+    dist: xenial
+    sudo: true
+    stage: extra
+  - python: pypy   # 2.7.13 pip  9.0.1
+    stage: extra
+  - python: pypy3  # 3.5.3  pip  9.0.1
+    stage: extra
+  - os: osx
+    language: generic
+    stage: extra
+  - python: 3.7
+    dist: xenial
+    sudo: true
+    env: TOXENV=docs
+    stage: quick
+  - python: 3.6
+    stage: quick
+    env: TOXENV=fix-lint
 
 matrix:
   fast_finish: true
   allow_failures:
   - os:  osx
-  - python: 3.7-dev
+  - python: 3.8-dev
   - python: nightly
   - python: pypy
-  include:
-    - python: 3.6
-      env: TOXENV=docs
-    - python: 3.6
-      env: TOXENV=fix-lint
-    - os: osx
-      language: generic
+  - python: pypy3
 
 before_install:
- - pyenv versions
- - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis-osx; fi
+- pyenv versions
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis-osx; fi
 
 install:
-  - pip install -U six
-  - pip install --pre -U tox
+- pip install -U six
+- pip install --pre -U tox
 
 script:
-  - tox
+- tox
 
 after_success:
-  - if [[ $TOXENV == "py" ]]; then tox -e coverage,codecov; fi
+- if [[ $TOXENV == "py" ]]; then tox -e coverage,codecov; fi

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27,
           py34,
           py35,
           py36,
+          py37,
           pypy,
           coverage,
           fix-lint,
@@ -22,7 +23,7 @@ commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxin
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs and check that all links are valid
-basepython = python3.6
+basepython = python3.7
 extras = docs
 changedir = {toxinidir}
 commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
@@ -71,11 +72,11 @@ commands = codecov --file "{toxworkdir}/coverage.xml"
 [testenv:exit_code]
 # to see how the InvocationError is displayed, use
 # PYTHONPATH=.:$PYTHONPATH python3 -m tox -e exit_code
-basepython = python3.6
+basepython = python3.7
 description = commands with several exit codes
 skip_install = True
 changedir = {toxinidir}
-commands = python3.6 -c "import sys; sys.exit(139)"
+commands = python3.7 -c "import sys; sys.exit(139)"
 
 [testenv:pra]
 platform = linux
@@ -95,7 +96,7 @@ description = generate a DEV environment
 extras = testing, docs
 # required to make looponfail reload on every source code change
 usedevelop = True
-basepython = python3.6
+basepython = python3.7
 changedir = {toxinidir}
 commands = python -m pip list --format=columns
            python -c 'import sys; print(sys.executable)'


### PR DESCRIPTION
- add Python 3.8 dev tests as failure allowed
- Python 3.7 tests are no longer allowed to fail