### PR TITLE
Parralelize and randomize test runs by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,11 +59,12 @@ def main():
         ],
         extras_require={
             "testing": [
-                "pytest >= 3.0.0",
-                "pytest-cov",
-                "pytest-mock",
-                "pytest-timeout",
-                "pytest-xdist",
+                "pytest >= 3.0.0, <4",
+                "pytest-cov >= 2.5.1, <3",
+                "pytest-mock >= 1.10.0, <2",
+                "pytest-timeout >= 1.3.0, <2",
+                "pytest-xdist >= 1.22.2, <2",
+                "pytest-randomly >= 1.2.3, <2",
             ],
             "docs": ["sphinx >= 1.7.5, < 2", "towncrier >= 18.5.0"],
         },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2576,7 +2576,7 @@ class TestCmdInvocation:
 
 
 @pytest.mark.parametrize(
-    "cmdline,envlist",
+    "cli_args,run_envlist",
     [
         ("-e py36", ["py36"]),
         ("-e py36,py34", ["py36", "py34"]),
@@ -2584,10 +2584,22 @@ class TestCmdInvocation:
         ("-e py36,py34 -e py34,py27", ["py36", "py34", "py34", "py27"]),
     ],
 )
-def test_env_spec(cmdline, envlist):
-    args = cmdline.split()
+def test_env_spec(initproj, cli_args, run_envlist):
+    initproj(
+        "env_spec",
+        filedefs={
+            "tox.ini": """
+                [tox]
+                envlist =
+
+                [testenv]
+                commands = python -c ""
+                """
+        },
+    )
+    args = cli_args.split()
     config = parseconfig(args)
-    assert config.envlist == envlist
+    assert config.envlist == run_envlist
 
 
 class TestCommandParser:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2314,13 +2314,15 @@ class TestParseEnv:
 
 
 class TestCmdInvocation:
-    def test_help(self, cmd):
+    def test_help(self, cmd, initproj):
+        initproj("help", filedefs={"tox.ini": ""})
         result = cmd("-h")
         assert not result.ret
         assert not result.err
         assert re.match(r"usage:.*help.*", result.out, re.DOTALL)
 
-    def test_version_simple(self, cmd):
+    def test_version_simple(self, cmd, initproj):
+        initproj("help", filedefs={"tox.ini": ""})
         result = cmd("--version")
         assert not result.ret
         assert "{} imported from".format(tox.__version__) in result.out

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -663,9 +663,8 @@ class TestVenvTest:
         assert pcalls[1].env["PYTHONPATH"] == "/my/awesome/library"
 
 
-# FIXME this test fails when run in isolation - find what this depends on
-# AssertionError: found warning('*Discarding $PYTHONPATH [...]
 def test_env_variables_added_to_pcall(tmpdir, mocksession, newconfig, monkeypatch):
+    monkeypatch.delenv("PYTHONPATH", raising=False)
     pkg = tmpdir.ensure("package.tar.gz")
     monkeypatch.setenv("X123", "123")
     monkeypatch.setenv("YY", "456")

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -985,23 +985,27 @@ def test_missing_env_fails(initproj, cmd):
     )
 
 
-def test_tox_console_script():
+def test_tox_console_script(initproj):
+    initproj("help", filedefs={"tox.ini": ""})
     result = subprocess.check_call(["tox", "--help"])
     assert result == 0
 
 
-def test_tox_quickstart_script():
+def test_tox_quickstart_script(initproj):
+    initproj("help", filedefs={"tox.ini": ""})
     result = subprocess.check_call(["tox-quickstart", "--help"])
     assert result == 0
 
 
-def test_tox_cmdline_no_args(monkeypatch):
+def test_tox_cmdline_no_args(monkeypatch, initproj):
+    initproj("help", filedefs={"tox.ini": ""})
     monkeypatch.setattr(sys, "argv", ["caller_script", "--help"])
     with pytest.raises(SystemExit):
         tox.cmdline()
 
 
-def test_tox_cmdline_args():
+def test_tox_cmdline_args(initproj):
+    initproj("help", filedefs={"tox.ini": ""})
     with pytest.raises(SystemExit):
         tox.cmdline(["caller_script", "--help"])
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE TOXENV CI TRAVIS TRAVIS_
 deps =
 extras = testing
 changedir = {toxinidir}/tests
-commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 .}
+commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n auto}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs and check that all links are valid


### PR DESCRIPTION
By running tests in parallel we can significantly speed up our CI and
local tests. We also randomize the order of the tests to make sure we
don't have any latent dependencies in between tests.
