### PR TITLE
Optimize travis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
     hooks:
     -   id: black
         args: [--line-length=99, --safe]
-        language_version: python3.6
+        language_version: python3.7
 -   repo: https://github.com/asottile/blacken-docs
     rev: v0.2.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==18.6b4]
-        language_version: python3.6
+        language_version: python3.7
 -   repo: https://github.com/asottile/seed-isort-config
     rev: v1.0.1
     hooks:
@@ -29,7 +29,7 @@ repos:
     -   id: debug-statements
     -   id: flake8
         additional_dependencies: ["flake8-bugbear == 18.2.0"]
-        language_version: python3.6
+        language_version: python3.7
 -   repo: https://github.com/asottile/pyupgrade
     rev: v1.4.0
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,67 +1,64 @@
 group: travis_latest
-sudo: false
 language: python
+dist: xenial
+sudo: required
 cache: pip
 
 env:
   TOXENV=py
+  PYTEST_XDIST_PROC_NR=0
+
+stages:
+- test
+- name: deploy
+  if: type = pull_request
 
 jobs:
   include:
   - python: 2.7    # 2.7.14 pip  9.0.1
   - python: 3.4    # 3.4.6  pip  9.0.1
+    dist: trusty
   - python: 3.5    # 3.5.5  pip  9.0.1
   - python: 3.6    # 3.6.3  pip  9.0.1
   - python: 3.7    # 3.7.0  pip 10.0.1
-    dist: xenial
-    sudo: true
   - python: 3.8-dev
-    dist: xenial
-    sudo: true
-  - python: nightly
-    dist: xenial
-    sudo: true
   - python: pypy   # 2.7.13 pip  9.0.1
+    dist: trusty
   - python: pypy3  # 3.5.3  pip  9.0.1
+    dist: trusty
   - os: osx
     language: generic
   - python: 3.7
-    dist: xenial
-    sudo: true
     env: TOXENV=docs
-  - python: 3.6
+  - python: 3.7
     env: TOXENV=fix-lint
   - stage: deploy
     python: 3.7
-    dist: xenial
-    sudo: true
     install: pip install -U "pip >= 10.0.0"
     script: skip
     after_success: skip
     env: TOXENV=release
     deploy:
-      - provider: pypi
-        user: toxdev
-        distributions: sdist bdist_wheel
-        skip_upload_docs: true
-        password:
-          secure: GpPLWTVHMAOpHh2Jq+cYo9hE6cwTxPJ6fMA+q+ERWHtUAqSC88kBqoZ4DQb0cyFIlN24Z9f5J2vm80Q7Qv2UWCGVKeNaWMWFqvZ+P5czGEn7ARoeTsTaiyKTCC2w/7iDsne7dPcSHT/y8V2fO/35kcwcrc0EGr4peb9GDJ4asTFpffiVzW9l5OjV2+jQn+ihWNA0ujSB3AR4TLexXGH+Gf6O5uEHK/kPJ63NEDbJVEdciWqLbDiU+OwWl5Xb5hFX1fjKQ9dP4zA7SolNsNB6pqs4rLl2aHqKYOt1RYGgjWSvANDXKP7S46Q5LFIPkmt4QbOeWxX63NUMZUmWadbjoAF65q1d9Dq41IemsLmElSqpdfPaLtLgLCbNlgHRLNVH+nJVqxjc3bvdxi28K8DZ9BB9KGmPkrbbj4NB0prsPouKiBkUS9NyoQuDt1EzJ3Rn2FzMOH41X5gIqzdsdxcy+3DV2Bb+eozNgg+51n27ESf7vwiYMW9GFENw/6AcPkxIPYakQu4joJ+327wVfK4t0gdy/m4qu2n0Lx6wOJUdSOcOAT5bPaRBQV92gXAaVUsROKMfrzwlVLuA+GXcnj8fft8aMXem30+N3r7y5FjbiAts345qnbjSWV3w9qEbNjM/Z9mt7z1OfsqCarJ2Mj5wKQyYfewddYMjdk7aPW5/9gQ=
-        on:
-          tags: true
-          type: pull_request
-          repo: tox-dev/tox
+    - provider: pypi
+      user: toxdev
+      distributions: sdist bdist_wheel
+      skip_upload_docs: true
+      password:
+        secure: GpPLWTVHMAOpHh2Jq+cYo9hE6cwTxPJ6fMA+q+ERWHtUAqSC88kBqoZ4DQb0cyFIlN24Z9f5J2vm80Q7Qv2UWCGVKeNaWMWFqvZ+P5czGEn7ARoeTsTaiyKTCC2w/7iDsne7dPcSHT/y8V2fO/35kcwcrc0EGr4peb9GDJ4asTFpffiVzW9l5OjV2+jQn+ihWNA0ujSB3AR4TLexXGH+Gf6O5uEHK/kPJ63NEDbJVEdciWqLbDiU+OwWl5Xb5hFX1fjKQ9dP4zA7SolNsNB6pqs4rLl2aHqKYOt1RYGgjWSvANDXKP7S46Q5LFIPkmt4QbOeWxX63NUMZUmWadbjoAF65q1d9Dq41IemsLmElSqpdfPaLtLgLCbNlgHRLNVH+nJVqxjc3bvdxi28K8DZ9BB9KGmPkrbbj4NB0prsPouKiBkUS9NyoQuDt1EzJ3Rn2FzMOH41X5gIqzdsdxcy+3DV2Bb+eozNgg+51n27ESf7vwiYMW9GFENw/6AcPkxIPYakQu4joJ+327wVfK4t0gdy/m4qu2n0Lx6wOJUdSOcOAT5bPaRBQV92gXAaVUsROKMfrzwlVLuA+GXcnj8fft8aMXem30+N3r7y5FjbiAts345qnbjSWV3w9qEbNjM/Z9mt7z1OfsqCarJ2Mj5wKQyYfewddYMjdk7aPW5/9gQ=
+      on:
+        tags: true
+        repo: tox-dev/tox
 
 matrix:
   fast_finish: true
   allow_failures:
-  - os:  osx
   - python: 3.8-dev
-  - python: nightly
   - python: pypy
   - python: pypy3
+  - os:  osx
 
 before_install:
-- pyenv versions
+- python -c 'import sys; print(sys.version)'
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source .travis-osx; fi
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,33 @@
 build: false  # Not a C# project
+
+only_commits: # we only run tests here, so only trigger if we modify the source files or the config
+  files:
+  - src/**/*
+  - tests/**/*
+  - appveyor.yml
+  - setup.py
+  - tox.ini
+  - MANIFEST.in
+
 environment:
   matrix:
-    - TOXENV: py27
-    - TOXENV: py34
-    - TOXENV: py35
-    - TOXENV: py36
+  - TOXENV: py27
+  - TOXENV: py34
+  - TOXENV: py35
+  - TOXENV: py36
 
 matrix:
   fast_finish: true
 
 install:
-  - C:\Python36\python -m pip install --pre -U tox
+- C:\Python36\python -m pip install --pre -U tox
 
 test_script:
-  - C:\Python36\scripts\tox
+- C:\Python36\scripts\tox
 
 after_test:
-  - C:\Python36\scripts\tox -e coverage,codecov
+- C:\Python36\scripts\tox -e coverage,codecov
 
 cache:
-  - '%LOCALAPPDATA%\pip\cache'
-  - '%USERPROFILE%\.cache\pre-commit'
+- '%LOCALAPPDATA%\pip\cache'
+- '%USERPROFILE%\.cache\pre-commit'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1669,7 +1669,7 @@ class TestConfigTestEnv:
         assert len(config.envconfigs) == 1
         envconfig = config.envconfigs["py27"]
         assert envconfig.basepython == "python2.7"
-        assert len(record) == 0
+        assert len(record) == 0, "\n".join(repr(r.message) for r in record)
 
     @pytest.mark.issue188
     def test_factors_in_boolean(self, newconfig):

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE TOXENV CI TRAVIS TRAVIS_
 deps =
 extras = testing
 changedir = {toxinidir}/tests
-commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n auto}
+commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto} }
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs and check that all links are valid
@@ -31,14 +31,14 @@ commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_ou
 
 [testenv:fix-lint]
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically
-basepython = python3.6
+basepython = python3.7
 passenv = {[testenv]passenv}
           HOMEPATH
           # without PROGRAMDATA cloning using git for Windows will fail with an
           # `error setting certificate verify locations` error
           PROGRAMDATA
 extras = lint
-deps = pre-commit == 1.10.1
+deps = pre-commit == 1.10.3
 skip_install = True
 changedir = {toxinidir}
 commands = pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
Don't run tests in parallel on Travis. Running the test suite in parallel on Travis does not speed it up, therefore we drop it. It also crashes pypy runs.

Move sudo required and dist xenial to base.

Remove testing against Python nigthly. Testing against dev is enough.

Skip the deploy stage entirely if not a PR.

Bump pre-commit version.
