### PR TITLE
Use git commit history to have a more accurate contributors list

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,62 +1,130 @@
-Alexander Schepanovski
-Alex Grönholm
 Alexander Loechel
+Alexander Schepanovski
 Alexandre Conrad
+Alex Gaynor
+Alex Grönholm
 Allan Feldman
+Anatoly Techtonik
+André Caron
+Andrei Fokau
+Andrei Pashkin
 Andrii Soldatenko
-Anthon van der Neuth
+Andrzej Ostrowski
+Anthon van der Neut
+Anthony Shaw
 Anthony Sottile
-Asmund Grammeltwedt
-Barry Warsaw
-Bartolome Sanchez Salado
-Bernat Gabor
+Armand Grillet
+Åsmund Grammeltvedt
+Bartolome Sanchez
+Bartolomé Sánchez Salado
+Bernát Gábor
+Borge Lanes
 Bruno Oliveira
 Carl Meyer
 Chris Jerdonek
 Chris Rose
 Clark Boylan
+Colin Dunklau
 Cyril Roelandt
-Ederag
+Daniel Hahler
+Danielle Jenkins
+Dan Ring
+David Donovan Riddle
+David Stanek
+Dougal Matthews
 Eli Collins
+Éric Araujo
 Eugene Yunak
-Fernando L. Pereira
+Evgeny Vereshchagin
+Felix Hummel
+Fernando Pereira
+Florian Bruhin
+Florian Ludwig
 Florian Schulze
+Floris Bruynooghe
+German Larrain
+Grégory Starck
+Gustavo Picon
 Hazal Ozturk
 Henk-Jaap Wagenaar
+Holger Krekel
+Hynek Schlawack
+Ian Cordasco
 Ian Stapleton Cordasco
 Igor Duarte Cardoso
+Ionel Cristian Mărieș
 Ionel Maries Cristian
-Itxaka Serrano
-Jake Windle
+Ivan Larin
+Jacob Windle
+James Elford
+James Knight
 Jannis Leidel
-Johannes Christ
+Jason R. Coombs
+Jihyeok Seo
+Joe Lombrozo
+John Anderson
+John-Scott Atlakson
+John Vandenberg
 Josh Smeaton
+Joshua Pereyda
 Julian Krause
 Jurko Gospodnetić
 Krisztian Fekete
-Laszlo Vasko
+Labrys of Knossos
 Lukasz Balcerzak
-Lukasz Rogalski
+Łukasz Rogalski
 Manuel Jacob
 Marc Abramowitz
-Marc Schlaich
+Marius Gedminas
 Mariusz Rusiniak
 Mark Hirota
+Martin Andrysík
+Mathieu Agopian
 Matt Good
+Matthew Schinckel
+Matthias Bach
 Matt Jeffery
-Mattieu Agopian
-Mikhail Kyshtymov
+Matt Wheeler
+Michael  Aquilina
+Michael Foord
 Monty Taylor
 Morgan Fainberg
+Ned Batchelder
 Nick Douma
+Nyiro Gergo
 Oliver Bestwalter
+Ollie Walsh
+Patrick Mezard
+Paul Moore
 Paweł Adamczak
+Peter Bittner
+Peter Cock
 Philip Thiem
-Pierre-Luc Tessier Gagné
+Piet Delport
+Rebecka Gulliksson
+Roman Bogorodskiy
 Ronald Evers
 Ronny Pfannschmidt
+Ryan P Kilby
+Sachi King
 Selim Belhaouane
+Simon Sapin
+Stefano Mazzucco
+Stefan Scherfke
+Steffen Allner
+Stephan Obermann
 Stephen Finucane
-Sridhar Ratnakumar
+Steven Myint
+Steve Piercy
+Thijs Triemstra
+Thomas Khyn
+Tom Dalton
+Tres Seaver
+Trevor Bekolay
+Vaskó László
+Viktor Kharkovets
 Ville Skyttä
-anatoly techtonik
+Volodymyr Vitvitskyi
+Walter Scheper
+Wieland Hoffmann
+William Jamir Silva

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -63,7 +63,7 @@ def get_message_body(release_version: Version, prev_version: Version) -> str:
 
                 tox aims to automate and standardize testing in Python. It is part of a larger vision of easing the packaging, testing and release process of Python software.
 
-                For details about the fix(es),please check the CHANGELOG: https://pypi.org/project/tox/{release_version}/#changelog
+                For details about the fix(es), please check the CHANGELOG: https://pypi.org/project/tox/{release_version}/#changelog
 
                 We thank all present and past contributors to tox. Have a look at https://github.com/tox-dev/tox/blob/master/CONTRIBUTORS to see who contributed.
 


### PR DESCRIPTION
Comparing against the list we can see quite a few people omitted. Our Github bot should check automatically that new users add themselves (or even better ideally automatically inject it if it detects not added). 