### PR TITLE
Migrate to readme-rendered for checking the setup.py readme #879

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,11 +33,11 @@ commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_ou
 [testenv:package-description]
 description = check that the long description is valid
 basepython = python3.7
-deps = collective.checkdocs >= 0.2
+deps = readme-renderer >= 21.0
 changedir = {toxinidir}
 skip_install = true
 extras =
-commands = python setup.py checkdocs
+commands =  python setup.py check -r -s
 
 [testenv:fix-lint]
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically


### PR DESCRIPTION
As pointed out in the review it's safer to use the upstream checkers.


