### PR TITLE
Revert "Fix bug with incorrectly defactorized dependencies (#772)"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+3.1.2 (2018-07-12)
+------------------
+
+Bugfixes
+^^^^^^^^
+
+- Revert "Fix bug with incorrectly defactorized dependencies (`#772 <https://github.com/tox-dev/tox/issues/772>`_)" - by :user:`obestwalter`
+
 3.1.1 (2018-07-09)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ with advance notice in the **Deprecations** section of releases.
 Bugfixes
 ^^^^^^^^
 
-- Revert "Fix bug with incorrectly defactorized dependencies (`#772 <https://github.com/tox-dev/tox/issues/772>`_)" - by :user:`obestwalter`
+- Revert "Fix bug with incorrectly defactorized dependencies (`#772 <https://github.com/tox-dev/tox/issues/772>`_)" due to a regression (`(#799) <https://github.com/tox-dev/tox/issues/899>`_) - by :user:`obestwalter`
 
 3.1.1 (2018-07-09)
 ------------------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -741,33 +741,6 @@ the following:
     - but not ``py2``, ``py36-sql`` or ``py36-mysql-dev``.
 
 
-Factors and values substitution are compatible
-++++++++++++++++++++++++++++++++++++++++++++++
-
-It is possible to mix both values substitution and factor expressions.
-For example:
-
-.. code-block:: ini
-
-    [tox]
-    envlist = py27,py36,coverage
-
-    [testenv]
-    deps =
-        flake8
-        coverage: coverage
-
-    [testenv:py27]
-    deps =
-        {[testenv]deps}
-        pytest
-
-With the previous configuration, it will install:
-
-- ``flake8`` and ``pytest`` packages for ``py27`` environment.
-- ``flake8`` package for ``py36`` environment.
-- ``flake8`` and ``coverage`` packages for ``coverage`` environment.
-
 Advanced settings
 -----------------
 

--- a/src/tox/config.py
+++ b/src/tox/config.py
@@ -1217,10 +1217,10 @@ class SectionReader:
         if x is None:
             x = default
         else:
-            x = self._replace_if_needed(x, name, replace, crossonly)
             x = self._apply_factors(x)
 
-        x = self._replace_if_needed(x, name, replace, crossonly)
+        if replace and x and hasattr(x, 'replace'):
+            x = self._replace(x, name=name, crossonly=crossonly)
         # print "getstring", self.section_name, name, "returned", repr(x)
         return x
 
@@ -1257,11 +1257,6 @@ class SectionReader:
                 )
             raise
         return replaced
-
-    def _replace_if_needed(self, x, name, replace, crossonly):
-        if replace and x and hasattr(x, "replace"):
-            x = self._replace(x, name=name, crossonly=crossonly)
-        return x
 
 
 class Replacer:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1440,9 +1440,11 @@ class TestConfigTestEnv:
         )
         conf = newconfig([], inisource).envconfigs["py27"]
         packages = [dep.name for dep in conf.deps]
-        assert packages == ["pytest", "pytest-cov", "fun", "frob>1.0,<2.0"]
+        assert packages == list(deps) + ['fun', 'frob>1.0,<2.0']
+        # assert packages == ["pytest", "pytest-cov", "fun", "frob>1.0,<2.0"]
 
     # https://github.com/tox-dev/tox/issues/706
+    @pytest.mark.xfail(reason="reproduce bug 706")
     @pytest.mark.parametrize("envlist", [["py27", "coverage", "other"]])
     def test_regression_test_issue_706(self, newconfig, envlist):
         inisource = """


### PR DESCRIPTION
Quick and dirty for a patch release fixing a regression.

This (partially) reverts commit 765c977

* leave original test for fix as reproducer
* leave changed assertion in previous test that is now failing commented out
