### PR TITLE
Updated verbosity check when printing messages regarding used configs.

### DIFF
--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -305,7 +305,7 @@ class Reporter(object):
             self.logline(msg)
 
     def using(self, msg):
-        if self.verbosity >= 1:
+        if self.verbosity >= Verbosity.INFO:
             self.logline("using {}".format(msg), bold=True)
 
     def keyboard_interrupt(self):


### PR DESCRIPTION
## Thanks for contributing a pull request!

The verbosity check was not using the `Verbosity` class, this is now fixed.

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [X] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
