### PR TITLE
Touch '.egg-info' directory after install (#909)

### DIFF
--- a/changelog/909.bugfix.rst
+++ b/changelog/909.bugfix.rst
@@ -1,0 +1,5 @@
+A caching issue that caused the ``develop-inst-nodeps`` action, which
+reinstalls the package under test, to always run has been resolved. The
+``develop-inst-noop`` action, which, as the name suggests, is a no-op, will now
+run unless there are changes to ``setup.py`` or ``setup.cfg`` files that have
+not been reflected - by @stephenfin

--- a/src/tox/config.py
+++ b/src/tox/config.py
@@ -1219,7 +1219,7 @@ class SectionReader:
         else:
             x = self._apply_factors(x)
 
-        if replace and x and hasattr(x, 'replace'):
+        if replace and x and hasattr(x, "replace"):
             x = self._replace(x, name=name, crossonly=crossonly)
         # print "getstring", self.section_name, name, "returned", repr(x)
         return x

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -238,10 +238,19 @@ class VirtualEnv(object):
                 break
         else:
             return True
-        return any(
+        needs_reinstall = any(
             conf_file.check() and conf_file.mtime() > egg_info.mtime()
             for conf_file in (setup_py, setup_cfg)
         )
+
+        # Ensure the modification time of the egg-info folder is updated so we
+        # won't need to do this again.
+        # TODO(stephenfin): Remove once the minimum version of setuptools is
+        # high enough to include https://github.com/pypa/setuptools/pull/1427/
+        if needs_reinstall:
+            egg_info.setmtime()
+
+        return needs_reinstall
 
     def developpkg(self, setupdir, action):
         assert action is not None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1440,7 +1440,7 @@ class TestConfigTestEnv:
         )
         conf = newconfig([], inisource).envconfigs["py27"]
         packages = [dep.name for dep in conf.deps]
-        assert packages == list(deps) + ['fun', 'frob>1.0,<2.0']
+        assert packages == list(deps) + ["fun", "frob>1.0,<2.0"]
         # assert packages == ["pytest", "pytest-cov", "fun", "frob>1.0,<2.0"]
 
     # https://github.com/tox-dev/tox/issues/706


### PR DESCRIPTION
When a project is using `skipsdist = True` and `usedevelop = True`, tox will attempt to determine when it needs to reinstall the package (the `develop-inst-nodeps` activity) and when it does not (the `develop-inst-noop` target). It does this by comparing the last modified timestamps of the 'setup.py' or 'setup.cfg' files with that of the `.egg-info` directory.

Unfortunately, this is a flawed check as, even after running the `develop-inst-nodeps` activity (which executes a variant of `pip install -e $setupdir --no-deps`) the timestamp of the `.egg-info` directory is not updated. This is a particularly irritating issue for larger projects when the install step can take many seconds or even minutes.

The ideal fix would be in setuptools. However, while we wait on this, we can fix it ourselves by simply `touch`ing the `.egg-info` directory after a reinstall. We do this.