### PR TITLE
No longer hard-code pythons

### DIFF
--- a/changelog/914.feature.rst
+++ b/changelog/914.feature.rst
@@ -1,0 +1,7 @@
+Python version testenvs are now automatically detected instead of comparing
+against a hard-coded list of supported versions.  This enables ``py38`` and
+eventually ``py39`` / ``py40`` / etc. to work without requiring an upgrade to
+``tox``.  As such, the following public constants are now deprecated
+(and scheduled for removal in ``tox`` 4.0: ``CPYTHON_VERSION_TUPLES``,
+``PYPY_VERSION_TUPLES``, ``OTHER_PYTHON_INTERPRETERS``, and ``DEFAULT_FACTORS`` -
+by :user:`asottile`

--- a/src/tox/constants.py
+++ b/src/tox/constants.py
@@ -2,11 +2,12 @@
 
 They live in the tox namespace and can be accessed as tox.[NAMESPACE.]NAME
 """
-import sys as _sys
+import re
+import sys
 
 
 def _construct_default_factors(cpython_versions, pypy_versions, other_interpreters):
-    default_factors = {"py": _sys.executable, "py2": "python2", "py3": "python3"}
+    default_factors = {"py": sys.executable, "py2": "python2", "py3": "python3"}
     default_factors.update(
         {
             "py{}{}".format(major, minor): "python{}.{}".format(major, minor)
@@ -25,6 +26,8 @@ def _construct_default_factors(cpython_versions, pypy_versions, other_interprete
 
 
 class PYTHON:
+    PY_FACTORS_RE = re.compile("^(?!py$)(py|pypy|jython)([2-9][0-9]?)?$")
+    PY_FACTORS_MAP = {"py": "python", "pypy": "pypy", "jython": "jython"}
     CPYTHON_VERSION_TUPLES = [(2, 7), (3, 4), (3, 5), (3, 6), (3, 7), (3, 8)]
     PYPY_VERSION_TUPLES = [(2, 7), (3, 5)]
     OTHER_PYTHON_INTERPRETERS = ["jython"]
@@ -39,7 +42,7 @@ class PYTHON:
 
 class INFO:
     DEFAULT_CONFIG_NAME = "tox.ini"
-    IS_WIN = _sys.platform == "win32"
+    IS_WIN = sys.platform == "win32"
 
 
 class PIP:


### PR DESCRIPTION
WIP -- I'll fill out changelog and such if it works and if it seems like a good idea.  It always struck me as odd that tox hardcoded this list of interpreters and that I'd be forced to upgrade my tox installation to use new things.  This patch adds support for python2.0 - python9.9, hopefully leaving us some headroom.

Here's hoping python3.10 isn't coming out soon, eh?

If this is good, the lists of interpreters can be deprecated and eventually removed I would imagine