### PR TITLE
Fix description of tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -129,7 +129,7 @@ known_first_party = tox
 known_third_party = apiclient,git,httplib2,oauth2client,packaging,pkg_resources,pluggy,py,pytest,setuptools,six
 
 [testenv:release]
-decription = do a release, required posarg of the version number
+description = do a release, required posarg of the version number
 basepython = python3.7
 passenv = *
 deps = gitpython >= 2.1.10
@@ -138,7 +138,7 @@ deps = gitpython >= 2.1.10
 commands = python {toxinidir}/tasks/release.py {posargs}
 
 [testenv:notify]
-decription = notify people about the release of the library
+description = notify people about the release of the library
 basepython = python3.7
 skip_install = true
 passenv = *


### PR DESCRIPTION
A typo in the config key caused to inherit description for tests.