### PR TITLE
Allow to run multiple tox instances in parallel #849

### DIFF
--- a/changelog/849.feature.rst
+++ b/changelog/849.feature.rst
@@ -1,0 +1,2 @@
+Allow to run multiple tox instances in parallel by providing the
+```--parallel--safe-build`` flag. - by :user:`gaborbernat`

--- a/doc/example/jenkins.rst
+++ b/doc/example/jenkins.rst
@@ -188,4 +188,27 @@ Linux as a limit of 128). There are two methods to workaround this issue:
     :ref:`long interpreter directives` for more information).
 
 
+Running tox environments in parallel
+------------------------------------
+
+Jenkins has parallel stages allowing you to run commands in parallel, however tox package
+building it is not parallel safe. Use the ``--parallel--safe-build`` flag to enable parallel safe
+builds. Here's a generic stage definition demonstrating this:
+
+.. code-block:: groovy
+
+    stage('run tox envs') {
+      steps {
+        script {
+          def envs = sh(returnStdout: true, script: "tox -l").trim().split('\n')
+          def cmds = envs.collectEntries({ tox_env ->
+            [tox_env, {
+              sh "tox --parallel--safe-build -vve $tox_env"
+            }]
+          })
+          parallel(cmds)
+        }
+      }
+    }
+
 .. include:: ../links.rst

--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -42,7 +42,11 @@ def cmdline(args=None):
 def main(args):
     try:
         config = prepare(args)
-        retcode = Session(config).runcommand()
+        try:
+            retcode = Session(config).runcommand()
+        finally:
+            if config.option.parallel_safe_build:
+                config.distdir.remove(ignore_errors=True)
         if retcode is None:
             retcode = 0
         raise SystemExit(retcode)


### PR DESCRIPTION
At the moment the build phase is not thread safe. Running multiple
instances of tox will highly likely cause one of the instances
to fail as the two processes will step on each others toe while
creating the sdist package. This is especially annoying in CI
environments where you want to run tox targets in parallle (e..g
Jenkins).

By passing in ``--parallel--safe-build`` flag tox automatically
generates a unique dist folder for the current build. This way
each build can use it's own version built package (in the install
phase after the build), and we avoid the need to lock while
building. Once the tox session finishes remove such build folders
to avoid ever expanding source trees when using this feature.
