### PR TITLE
Prefer -m to invoke modules instead of direct executable

### DIFF
--- a/changelog/xxx.feature.rst
+++ b/changelog/xxx.feature.rst
@@ -1,0 +1,2 @@
+Switch pip invocations to use the module ``-m pip`` instead of direct invocation. This could help
+avoid some of the shebang limitations.  - by :user:`gaborbernat`

--- a/src/tox/config.py
+++ b/src/tox/config.py
@@ -191,7 +191,7 @@ class PosargsOption:
 class InstallcmdOption:
     name = "install_command"
     type = "argv"
-    default = "pip install {opts} {packages}"
+    default = "python -m pip install {opts} {packages}"
     help = "install command for dependencies and package under test."
 
     def postprocess(self, testenv_config, value):
@@ -730,7 +730,7 @@ def tox_addoption(parser):
     parser.add_testenv_attribute(
         name="list_dependencies_command",
         type="argv",
-        default="pip freeze",
+        default="python -m pip freeze",
         help="list dependencies for a virtual environment",
     )
 

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -152,8 +152,10 @@ def test_install_deps_wildcard(newmocksession):
     assert len(pcalls) == 2
     args = pcalls[-1].args
     assert pcalls[-1].cwd == venv.envconfig.config.toxinidir
-    assert "pip" in str(args[0])
-    assert args[1] == "install"
+
+    assert py.path.local.sysfind("python") == args[0]
+    assert ["-m", "pip"] == args[1:3]
+    assert args[3] == "install"
     args = [arg for arg in args if str(arg).endswith("dep1-1.1.zip")]
     assert len(args) == 1
 
@@ -449,7 +451,8 @@ def test_install_python3(newmocksession):
     venv._install(["hello"], action=action)
     assert len(pcalls) == 1
     args = pcalls[0].args
-    assert "pip" in args[0]
+    assert py.path.local.sysfind("python") == args[0]
+    assert ["-m", "pip"] == args[1:3]
     for _ in args:
         assert "--download-cache" not in args, args
 
@@ -744,8 +747,10 @@ def test_run_install_command(newmocksession):
     venv.run_install_command(packages=["whatever"], action=action)
     pcalls = mocksession._pcalls
     assert len(pcalls) == 1
-    assert "pip" in pcalls[0].args[0]
-    assert "install" in pcalls[0].args
+    args = pcalls[0].args
+    assert py.path.local.sysfind("python") == args[0]
+    assert ["-m", "pip"] == args[1:3]
+    assert "install" in args
     env = pcalls[0].env
     assert env is not None
 


### PR DESCRIPTION
This helps in some cases to bypass the shebang limitation.