### PR TITLE
Ability to specify package requirements for the tox run #783

### DIFF
--- a/changelog/783.feature.rst
+++ b/changelog/783.feature.rst
@@ -1,0 +1,1 @@
+Ability to specify package requirements for the tox run via the ``tox.ini`` (``tox`` section under key ``requires`` - PEP-508 style): can be used to specify both plugin requirements or build dependencies. - by :user:`gaborbernat`

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -77,6 +77,17 @@ and will first lookup global tox settings in this section:
     is identified. In a future version of tox, this warning will become an
     error.
 
+.. confval:: requires=LIST
+
+    Specify python packages that need to exist alongside the tox installation for the tox build
+    to be able to start. Use this to specify plugin requirements and build dependencies.
+
+    .. code-block:: ini
+
+        [tox]
+        requires = setuptools >= 30.0.0
+                   py
+
 
 Virtualenv test environment settings
 ------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def main():
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
         setup_requires=["setuptools_scm"],
         install_requires=[
-            "packaging  >= 17.1",
+            "setuptools  >= 30.0.0",
             "pluggy >= 0.3.0, <1",
             "py >= 1.4.17, <2",
             "six >= 1.0.0, <2",

--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -13,8 +13,8 @@ import subprocess
 import sys
 import time
 
+import pkg_resources
 import py
-from packaging.version import InvalidVersion, Version
 
 import tox
 from tox.config import parseconfig
@@ -775,6 +775,7 @@ def get_version_from_filename(basename):
         return None
     version = m.group(1)
     try:
-        return Version(version)
-    except InvalidVersion:
+
+        return pkg_resources.packaging.version.Version(version)
+    except pkg_resources.packaging.version.InvalidVersion:
         return None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2716,3 +2716,25 @@ class TestCommandParser:
         )
         envconfig = config.envconfigs["py36"]
         assert envconfig.commands[0] == ["some", r"hello\world"]
+
+
+def test_plugin_require(newconfig, capsys):
+    inisource = """
+        [tox]
+        requires = tox
+                   name[foo,bar]>=2,<3; python_version>"2.0" and os_name=='a'
+                   b
+    """
+    with pytest.raises(
+        RuntimeError, match="not all requirements satisfied, install them alongside tox"
+    ):
+        newconfig([], inisource)
+
+    out, err = capsys.readouterr()
+    assert err.strip() == "\n".join(
+        [
+            'requirement missing name[bar,foo]<3,>=2; python_version > "2.0" and os_name == "a"',
+            "requirement missing b",
+        ]
+    )
+    assert not out


### PR DESCRIPTION
Done via the ``tox.ini`` (``tox`` section under key ``requires`` - PEP-508
style). Can be used to specify both plugin requirements or build
dependencies until we'll have PEP-517 support.

Using ``pkg_resources.Requirement``. Note tox will refuse to run if
cannot satisfy dependencies. It's the users responsibility to ensure
dependencies are satisfied. ``pkg_resources`` is part of setuptools so
added setuptools as dependency.

Realized pkg_resources contain everything we used from packaging,
dropped packaging as a dependency.
