### PR TITLE
Revert "Do not assume all python installs come with virtualenv"

### DIFF
--- a/changelog/929.feature.rst
+++ b/changelog/929.feature.rst
@@ -1,1 +1,0 @@
-Call virtualenv by invoking directly the virtualenv file (after import resolve) instead of ``-m`` (allows pex packaging tox) - trial accepted. - by :user:`zsimic`

--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -19,7 +19,7 @@ from packaging.version import InvalidVersion, Version
 import tox
 from tox.config import parseconfig
 from tox.result import ResultLog
-from tox.venv import VIRTUALENV_FILE, VirtualEnv
+from tox.venv import VirtualEnv
 
 
 def prepare(args):
@@ -728,7 +728,7 @@ class Session:
     def info_versions(self):
         versions = ["tox-{}".format(tox.__version__)]
         proc = subprocess.Popen(
-            (sys.executable, VIRTUALENV_FILE, "--version"), stdout=subprocess.PIPE
+            (sys.executable, "-m", "virtualenv", "--version"), stdout=subprocess.PIPE
         )
         out, _ = proc.communicate()
         versions.append("virtualenv-{}".format(out.decode("UTF-8").strip()))

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -7,16 +7,10 @@ import sys
 import warnings
 
 import py
-import virtualenv
 
 import tox
 
 from .config import DepConfig
-
-# Use virtualenv that comes with tox, don't assume other installed pythons have virtualenv
-VIRTUALENV_FILE = virtualenv.__file__
-if VIRTUALENV_FILE.endswith(".pyc"):
-    VIRTUALENV_FILE = VIRTUALENV_FILE[:-1]
 
 
 class CreationConfig:
@@ -476,7 +470,7 @@ def prepend_shebang_interpreter(args):
 @tox.hookimpl
 def tox_testenv_create(venv, action):
     config_interpreter = venv.getsupportedinterpreter()
-    args = [sys.executable, VIRTUALENV_FILE]
+    args = [sys.executable, "-m", "virtualenv"]
     if venv.envconfig.sitepackages:
         args.append("--system-site-packages")
     if venv.envconfig.alwayscopy:

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -68,7 +68,7 @@ def test_create(mocksession, newconfig):
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
     args = pcalls[0].args
-    assert str(args[1]).endswith("virtualenv.py")
+    assert "virtualenv" == str(args[2])
     if not tox.INFO.IS_WIN:
         # realpath is needed for stuff like the debian symlinks
         our_sys_path = py.path.local(sys.executable).realpath()
@@ -443,7 +443,7 @@ def test_install_python3(newmocksession):
     pcalls = mocksession._pcalls
     assert len(pcalls) == 1
     args = pcalls[0].args
-    assert str(args[1]).endswith("virtualenv.py")
+    assert str(args[2]) == "virtualenv"
     pcalls[:] = []
     action = mocksession.newaction(venv, "hello")
     venv._install(["hello"], action=action)

--- a/tests/test_z_cmdline.py
+++ b/tests/test_z_cmdline.py
@@ -687,7 +687,7 @@ def test_alwayscopy(initproj, cmd):
     )
     result = cmd("-vv")
     assert not result.ret
-    assert "virtualenv.py --always-copy" in result.out
+    assert "virtualenv --always-copy" in result.out
 
 
 def test_alwayscopy_default(initproj, cmd):
@@ -702,7 +702,7 @@ def test_alwayscopy_default(initproj, cmd):
     )
     result = cmd("-vv")
     assert not result.ret
-    assert "virtualenv.py --always-copy" not in result.out
+    assert "virtualenv --always-copy" not in result.out
 
 
 def test_empty_activity_ignored(initproj, cmd):

--- a/tox.ini
+++ b/tox.ini
@@ -126,7 +126,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 line_length = 99
 known_first_party = tox
-known_third_party = apiclient,git,httplib2,oauth2client,packaging,pkg_resources,pluggy,py,pytest,setuptools,six,virtualenv
+known_third_party = apiclient,git,httplib2,oauth2client,packaging,pkg_resources,pluggy,py,pytest,setuptools,six
 
 [testenv:release]
 description = do a release, required posarg of the version number


### PR DESCRIPTION
Reverts tox-dev/tox#929. @zsimic following general consensus let's first validate this with a tox plugin.