### PR TITLE
Don't clean up unique directory names via --parallel--safe-build

### DIFF
--- a/changelog/849.bug.rst
+++ b/changelog/849.bug.rst
@@ -1,0 +1,1 @@
+``--parallel--safe-build`` no longer cleans up its folders (``distdir``, ``distshare``, ``log``). - by :user:`gaborbernat`

--- a/doc/example/jenkins.rst
+++ b/doc/example/jenkins.rst
@@ -193,7 +193,8 @@ Running tox environments in parallel
 
 Jenkins has parallel stages allowing you to run commands in parallel, however tox package
 building it is not parallel safe. Use the ``--parallel--safe-build`` flag to enable parallel safe
-builds. Here's a generic stage definition demonstrating this:
+builds (this will generate unique folder names for ``distdir``, ``ditshare`` and ``log``.
+Here's a generic stage definition demonstrating how to use this inside Jenkins:
 
 .. code-block:: groovy
 

--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -42,12 +42,7 @@ def cmdline(args=None):
 def main(args):
     try:
         config = prepare(args)
-        try:
-            retcode = Session(config).runcommand()
-        finally:
-            if config.option.parallel_safe_build:
-                for folder in ("distdir", "distshare", "logdir"):
-                    getattr(config, folder).remove(ignore_errors=True)
+        retcode = Session(config).runcommand()
         if retcode is None:
             retcode = 0
         raise SystemExit(retcode)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,6 @@
 import re
 import uuid
 
-import py
 import pytest
 
 from tox.exception import MissingDependency, MissingDirectory
@@ -103,5 +102,3 @@ def test_tox_parallel_build_safe(initproj, cmd, mock_venv):
         basename = path.basename
         assert basename.startswith(base)
         assert uuid.UUID(basename[len(base) :], version=4)
-        assert not path.exists()
-        assert not py.path.local(path.dirname).join(base[:-1]).exists()


### PR DESCRIPTION
This can cause race conditions and inside Jenkins the expectation is the user will cleanup either way at the end.