### PR TITLE
New VSTS YAML syntax and the 'Ubuntu 16.04' pool

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -6,10 +6,10 @@ trigger:
     - master
     - refs/tags/*
 
-phases:
-- phase: lint
-  queue:
-    name: 'Hosted Linux Preview'
+jobs:
+- job: lint
+  pool:
+    vmImage: 'Ubuntu 16.04'
 
   steps:
   - task: UsePythonVersion@0
@@ -25,10 +25,11 @@ phases:
 
 
 
-- phase: docs
-  queue:
-    name: 'Hosted Linux Preview'
-    parallel: 2
+- job: docs
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    maxParallel: 2
     matrix:
       readthedocs:
         toxenv: 'docs'
@@ -47,10 +48,11 @@ phases:
   - script: 'tox -e $(toxenv)'
     displayName: run tox
 
-- phase: linux
-  queue:
-    name: 'Hosted Linux Preview'
-    parallel: 4
+- job: linux
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    maxParallel: 4
     matrix:
       python27:
         python.version: '2.7'
@@ -101,10 +103,11 @@ phases:
   - script: 'python -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-$(python.version)" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=$(python.version)'
     displayName: upload codecov
 
-- phase: windows
-  queue:
-    name: 'Hosted VS2017'
-    parallel: 4
+- job: windows
+  pool:
+    vmImage: 'vs2017-win2016'
+  strategy:
+    maxParallel: 4
     matrix:
       python27:
         python.version: '2.7'
@@ -152,10 +155,11 @@ phases:
   - script: 'python -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-$(python.version)" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=$(python.version)'
     displayName: upload codecov
 
-- phase: macOS
-  queue:
-    name: 'Hosted macOS Preview'
-    parallel: 1
+- job: macOS
+  pool:
+    vmImage: 'macOS 10.13'
+  strategy:
+    maxParallel: 1
     matrix:
       python:
         toxenv: 'py3'
@@ -190,7 +194,7 @@ phases:
   - script: 'python3 -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-python3" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=3'
     displayName: upload codecov
 
-- phase: publish
+- job: publish
   dependsOn:
   - macOs
   - linux
@@ -198,10 +202,12 @@ phases:
   - lint
   - docs
   condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
-  queue:
-    name: 'Hosted Linux Preview'
-    parallel: 1
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    maxParallel: 1
     matrix:
+    
       python37:
         python.version: '3.7'
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -207,7 +207,6 @@ jobs:
   strategy:
     maxParallel: 1
     matrix:
-    
       python37:
         python.version: '3.7'
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Chris Jerdonek
 Chris Rose
 Clark Boylan
 Cyril Roelandt
+David Staheli
 Ederag
 Eli Collins
 Eugene Yunak

--- a/changelog/955.misc.rst
+++ b/changelog/955.misc.rst
@@ -1,1 +1,1 @@
-Updated the VSTS build YAML to use the latest syntax - by @davidstaheli.
+Updated the VSTS build YAML to use the latest jobs and pools syntax - by :user:`davidstaheli`

--- a/changelog/955.misc.rst
+++ b/changelog/955.misc.rst
@@ -1,0 +1,1 @@
+Updated the VSTS build YAML to use the latest syntax - by @davidstaheli.


### PR DESCRIPTION
This PR addresses #955 by updating the VSTS build YAML for the latest supported syntax:
- "phases" are now "jobs"
- "queue" is now "pool"
- pool names are specified as "vmImage" values
- pool names are updated to use the pools with the fastest performance
