### PR TITLE
Turn GH widget from watch to star

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -59,5 +59,6 @@ Ronny Pfannschmidt
 Selim Belhaouane
 Stephen Finucane
 Sridhar Ratnakumar
+Sviatoslav Sydorenko
 Ville Skyttä
 anatoly techtonik

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,6 +62,7 @@ html_theme_options = {
     "github_repo": "tox",
     "description": "standardise testing in Python",
     "github_banner": "true",
+    "github_type": "star",
     "travis_button": "true",
     "badge_branch": "master",
     "fixed_sidebar": "false",


### PR DESCRIPTION
This PR switches GitHub widget in docs from Watch to Star.

Fixes #925

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by @superuser."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
