### PR TITLE
VSTS build improvements

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -85,8 +85,9 @@ jobs:
     inputs:
       testResultsFiles: '.tox/test-results.*.xml'
       mergeTestResults: true
-      testRunTitle: '$(toxenv)'
+      testRunTitle: '$(agent.os) py$(python.version)'
       platform: linux
+    condition: succeededOrFailed()
 
   - script: 'python -m tox -e coverage'
     displayName: generate coverage.xml
@@ -98,6 +99,7 @@ jobs:
     inputs:
       codeCoverageTool: 'cobertura'
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/.tox/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/.tox/htmlcov'
       failIfCoverageEmpty: true
 
   - script: 'python -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-$(python.version)" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=$(python.version)'
@@ -140,8 +142,9 @@ jobs:
     inputs:
       testResultsFiles: '.tox/test-results.*.xml'
       mergeTestResults: true
-      testRunTitle: '$(toxenv)'
+      testRunTitle: '$(agent.os) py$(python.version)'
       platform: windows
+    condition: succeededOrFailed()
 
   - script: 'python -m tox -e coverage'
     displayName: generate coverage.xml
@@ -150,6 +153,7 @@ jobs:
     inputs:
       codeCoverageTool: 'cobertura'
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/.tox/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/.tox/htmlcov'
       failIfCoverageEmpty: true
 
   - script: 'python -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-$(python.version)" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=$(python.version)'
@@ -180,7 +184,8 @@ jobs:
       testResultsFiles: '.tox/test-results.*.xml'
       mergeTestResults: true
       testRunTitle: '$(toxenv)'
-      platform: windows
+      platform: macos
+    condition: succeededOrFailed()
 
   - script: 'python3 -m tox -e coverage'
     displayName: generate coverage.xml
@@ -189,6 +194,7 @@ jobs:
     inputs:
       codeCoverageTool: 'cobertura'
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/.tox/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/.tox/htmlcov'
       failIfCoverageEmpty: true
 
   - script: 'python3 -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-python3" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=3'

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -104,6 +104,7 @@ jobs:
 
   - script: 'python -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-$(python.version)" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=$(python.version)'
     displayName: upload codecov
+    condition: and(succeeded(), variables['CODECOV_TOKEN'])
 
 - job: windows
   pool:
@@ -158,6 +159,7 @@ jobs:
 
   - script: 'python -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-$(python.version)" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=$(python.version)'
     displayName: upload codecov
+    condition: and(succeeded(), variables['CODECOV_TOKEN'])
 
 - job: macOS
   pool:
@@ -199,6 +201,7 @@ jobs:
 
   - script: 'python3 -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-python3" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=3'
     displayName: upload codecov
+    condition: and(succeeded(), variables['CODECOV_TOKEN'])
 
 - job: publish
   dependsOn:

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands = coverage erase
            coverage combine
            coverage report -m
            coverage xml -o {toxworkdir}/coverage.xml
-           coverage html -o {toxworkdir}/htmlcov
+           coverage html -d {toxworkdir}/htmlcov
            diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
 
 [testenv:codecov]

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ commands = coverage erase
            coverage combine
            coverage report -m
            coverage xml -o {toxworkdir}/coverage.xml
+           coverage html -o {toxworkdir}/htmlcov
            diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
 
 [testenv:codecov]


### PR DESCRIPTION
Improves the VSTS build configuration in a few minor ways:
* skips codecov upload when CODECOV_TOKEN is not set (makes it easier for other people to run the build in their own account)
* fixes test run title to include OS and Python version
* ensures test results are uploaded even if test run fails (non-zero exit code)
* publish HTML code coverage report

The HTML coverage report is specified in tox.ini, so it'll be created for all builds. If you'd prefer, I can switch it to use `{posargs}` and only enable the report when using it in VSTS. Or I can just leave it out - unfortunately, the embedding UI doesn't look so pretty (images/CSS break), but at least this makes it available for download if the simple % number isn't sufficient and codecov is not available.