### PR TITLE
pytest: use -ra by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -115,7 +115,7 @@ source = src/tox
          .tox/pypy*/site-packages/tox
 
 [pytest]
-addopts = -rsxX --showlocals
+addopts = -ra --showlocals
 rsyncdirs = tests tox
 looponfailroots = tox tests
 norecursedirs = .hg .tox


### PR DESCRIPTION
Let's see failing tests in the summary, ok?  ("f")

[ci skip]
[build skip]