### PR TITLE
Wipe git dependency repositories if they exist on dep install

### DIFF
--- a/changelog/503.bugfix.rst
+++ b/changelog/503.bugfix.rst
@@ -1,0 +1,1 @@
+add ``--exists-action w`` to default pip flags to handle better VCS dependencies (`pip documentation on this <https://pip.pypa.io/en/latest/reference/pip/#exists-action-option>`_) - by :user:`gaborbernat`

--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -721,7 +721,7 @@ def test_installpkg_no_upgrade(tmpdir, newmocksession):
     mocksession.installpkg(venv, pkg)
     pcalls = mocksession._pcalls
     assert len(pcalls) == 1
-    assert "-U" not in pcalls[0].args
+    assert pcalls[0].args[1:-1] == ["-m", "pip", "install", "--exists-action", "w"]
 
 
 def test_installpkg_upgrade(newmocksession, tmpdir):


### PR DESCRIPTION
add ``--exists-action w`` to default pip flags to handle better VCS
dependencies, which may prompt a question about how to handle it

pip documentation on this
https://pip.pypa.io/en/latest/reference/pip/#exists-action-option

Resolves #503.