### PR TITLE
Create azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,234 @@
+name: $(BuildDefinitionName)_$(Date:yyyyMMdd)$(Rev:.rr)
+
+variables:
+  "System.PreferGit": true
+
+trigger:
+  branches:
+    include:
+    - master
+    - refs/tags/*
+
+jobs:
+- job: lint
+  pool:
+    vmImage: 'Ubuntu 16.04'
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: setup python
+    inputs:
+      versionSpec: '3.7'
+
+  - script: 'python -m pip install -U tox'
+    displayName: install tox
+
+  - script: 'tox -e fix-lint'
+    displayName: run tox
+
+- job: docs
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    maxParallel: 2
+    matrix:
+      readthedocs:
+        toxenv: 'docs'
+      packageDescription:
+        toxenv: 'package-description'
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: setup python
+    inputs:
+      versionSpec: '3.7'
+
+  - script: 'python -m pip install -U tox'
+    displayName: install tox
+
+  - script: 'tox -e $(toxenv)'
+    displayName: run tox
+
+- job: linux
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    maxParallel: 4
+    matrix:
+      python27:
+        python.version: '2.7'
+      python34:
+        python.version: '3.4'
+      python35:
+        python.version: '3.5'
+      python36:
+        python.version: '3.6'
+      python37:
+        python.version: '3.7'
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: setup python$(python.version)
+    inputs:
+      versionSpec: '$(python.version)'
+
+  - script: 'python -m pip install -U tox'
+    displayName: install tox
+
+  - script: 'python -m tox -e py --notest'
+    displayName: acquire env dependencies
+
+  - script: 'python -m tox -e py'
+    displayName: run tests
+
+  - task: PublishTestResults@2
+    displayName: publish test results
+    inputs:
+      testResultsFiles: '.tox/test-results.*.xml'
+      mergeTestResults: true
+      testRunTitle: '$(agent.os) py$(python.version)'
+      platform: linux
+    condition: succeededOrFailed()
+
+  - script: 'python -m tox -e coverage'
+    displayName: generate coverage.xml
+
+  - script: 'ls . -Ra'
+    displayName: show
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'cobertura'
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/.tox/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/.tox/htmlcov'
+      failIfCoverageEmpty: true
+
+  - script: 'python -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-$(python.version)" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=$(python.version)'
+    displayName: upload codecov
+    condition: and(succeeded(), variables['CODECOV_TOKEN'])
+
+- job: windows
+  pool:
+    vmImage: 'vs2017-win2016'
+  strategy:
+    maxParallel: 4
+    matrix:
+      python27:
+        python.version: '2.7'
+      python34:
+        python.version: '3.4'
+      python35:
+        python.version: '3.5'
+      python36:
+        python.version: '3.6'
+      python37:
+        python.version: '3.7'
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: setup python$(python.version)
+    inputs:
+      versionSpec: '$(python.version)'
+
+  - script: 'python -m pip install -U tox'
+    displayName: install tox
+
+  - script: 'python -m tox -e py --notest'
+    displayName: acquire env dependencies
+
+  - script: 'python -m tox -e py'
+    displayName: run tests
+
+  - task: PublishTestResults@2
+    displayName: publish test results
+    inputs:
+      testResultsFiles: '.tox/test-results.*.xml'
+      mergeTestResults: true
+      testRunTitle: '$(agent.os) py$(python.version)'
+      platform: windows
+    condition: succeededOrFailed()
+
+  - script: 'python -m tox -e coverage'
+    displayName: generate coverage.xml
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'cobertura'
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/.tox/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/.tox/htmlcov'
+      failIfCoverageEmpty: true
+
+  - script: 'python -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-$(python.version)" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=$(python.version)'
+    displayName: upload codecov
+    condition: and(succeeded(), variables['CODECOV_TOKEN'])
+
+- job: macOS
+  pool:
+    vmImage: 'macOS 10.13'
+  strategy:
+    maxParallel: 1
+    matrix:
+      python:
+        toxenv: 'py3'
+
+  steps:
+  - script: 'python3 -m pip install -U tox'
+    displayName: install tox
+
+  - script: 'python3 -m tox -e $(toxenv) --notest'
+    displayName: acquire env dependencies
+
+  - script: 'python3 -m tox -e $(toxenv)'
+    displayName: run tests
+
+  - task: PublishTestResults@2
+    displayName: publish test results
+    inputs:
+      testResultsFiles: '.tox/test-results.*.xml'
+      mergeTestResults: true
+      testRunTitle: '$(toxenv)'
+      platform: macos
+    condition: succeededOrFailed()
+
+  - script: 'python3 -m tox -e coverage'
+    displayName: generate coverage.xml
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'cobertura'
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/.tox/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/.tox/htmlcov'
+      failIfCoverageEmpty: true
+
+  - script: 'python3 -m tox -e codecov -- -t $(CODECOV_TOKEN) --required -n "$(agent.os)-python3" --build "$(Build.DefinitionName)" --env OS=$(agent.os) python=3'
+    displayName: upload codecov
+    condition: and(succeeded(), variables['CODECOV_TOKEN'])
+
+- job: publish
+  dependsOn:
+  - macOS
+  - linux
+  - windows
+  - lint
+  - docs
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+  pool:
+    vmImage: 'Ubuntu 16.04'
+  strategy:
+    maxParallel: 1
+    matrix:
+      python37:
+        python.version: '3.7'
+
+  steps:
+  - task: UsePythonVersion@0
+    displayName: setup python$(python.version)
+    inputs:
+      versionSpec: '$(python.version)'
+
+  - task: PyPIPublisher@0
+    displayName: Package and publish to PyPI
+    inputs:
+      pypiConnection: pypi-conn
+      packageDirectory: '$(System.DefaultWorkingDirectory)'
+      alsoPublishWheel: true


### PR DESCRIPTION
This addresses #975 by creating a file named azure-pipelines.yml.  This is the official filename for Azure Pipelines CI.  This file is a duplicate of .vsts-ci.yml.  Once this file is merged to master, we can point Azure Pipelines at it to begin using it instead of .vsts-ci.yml.  Then, we can delete .vsts-ci.yml.  Thanks for considering this PR!