### PR TITLE
do not build sdist if skip install specified for target envs

### DIFF
--- a/changelog/974.feature.rst
+++ b/changelog/974.feature.rst
@@ -1,0 +1,1 @@
+do not build sdist if skip install is specified for the envs to be run - by :user:`gaborbernat`

--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -522,9 +522,10 @@ class Session:
             self.report.info("skipping sdist step")
         else:
             for venv in self.venvlist:
-                venv.package = self.hook.tox_package(session=self, venv=venv)
-                if not venv.package:
-                    return 2
+                if not venv.envconfig.skip_install:
+                    venv.package = self.hook.tox_package(session=self, venv=venv)
+                    if not venv.package:
+                        return 2
         if self.config.option.sdistonly:
             return
         for venv in self.venvlist:

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -102,3 +102,41 @@ def test_tox_parallel_build_safe(initproj, cmd, mock_venv):
         basename = path.basename
         assert basename.startswith(base)
         assert uuid.UUID(basename[len(base) :], version=4)
+
+
+def test_skip_sdist(cmd, initproj):
+    initproj(
+        "pkg123-0.7",
+        filedefs={
+            "tests": {"test_hello.py": "def test_hello(): pass"},
+            "setup.py": """
+            syntax error
+        """,
+            "tox.ini": """
+            [tox]
+            skipsdist=True
+            [testenv]
+            commands=python -c "print('done')"
+        """,
+        },
+    )
+    result = cmd()
+    assert result.ret == 0
+
+
+def test_skip_install_skip_package(cmd, initproj, mock_venv):
+    initproj(
+        "pkg123-0.7",
+        filedefs={
+            "setup.py": """raise RuntimeError""",
+            "tox.ini": """
+            [tox]
+            envlist = py
+
+            [testenv]
+            skip_install = true
+        """,
+        },
+    )
+    result = cmd("--notest")
+    assert result.ret == 0

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -302,26 +302,6 @@ def test_unknown_environment(cmd, initproj):
     assert result.out == "ERROR: unknown environment 'qpwoei'\n"
 
 
-def test_skip_sdist(cmd, initproj):
-    initproj(
-        "pkg123-0.7",
-        filedefs={
-            "tests": {"test_hello.py": "def test_hello(): pass"},
-            "setup.py": """
-            syntax error
-        """,
-            "tox.ini": """
-            [tox]
-            skipsdist=True
-            [testenv]
-            commands=python -c "print('done')"
-        """,
-        },
-    )
-    result = cmd()
-    assert result.ret == 0
-
-
 def test_minimal_setup_py_empty(cmd, initproj):
     initproj(
         "pkg123-0.7",


### PR DESCRIPTION
in this case we'll not test the sdist either way, so might as well bystep the work of producing it
