### PR TITLE
keep additional environments config order #903

### DIFF
--- a/changelog/903.feature.rst
+++ b/changelog/903.feature.rst
@@ -1,0 +1,1 @@
+skip missing interpreters value from the config file can now be overridden via the ``--skip-missing-interpreters`` cli flag - by :user:`gaborbernat`

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -54,18 +54,18 @@ and will first lookup global tox settings in this section:
     commands = ...  # override [tox] settings for the jenkins context
     # note: for jenkins distshare defaults to ``{toxworkdir}/distshare`` (DEPRECATED)
 
-.. confval:: skip_missing_interpreters=BOOL
+.. confval:: skip_missing_interpreters=config|true|false
 
     .. versionadded:: 1.7.2
 
-    Setting this to ``True`` is equivalent of passing the
-    ``--skip-missing-interpreters`` command line option, and will force ``tox`` to
-    return success even if some of the specified environments were missing. This is
-    useful for some CI systems or running on a developer box, where you might only
-    have a subset of all your supported interpreters installed but don't want to
-    mark the build as failed because of it. As expected, the command line switch
-    always overrides this setting if passed on the invokation.
-    **Default:** ``False``
+    When skip missing interpreters is ``true`` will force ``tox`` to return success even
+    if some of the specified environments were missing. This is useful for some CI
+    systems or running on a developer box, where you might only have a subset of
+    all your supported interpreters installed but don't want to mark the build as
+    failed because of it. As expected, the command line switch always overrides
+    this setting if passed on the invocation. Setting it to ``config``
+    means that the value is read from the config file (default is ``false``).
+    **Default:** ``config``
 
 .. confval:: envlist=CSV
 

--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -470,7 +470,7 @@ class Session:
                 )
             except tox.exception.InterpreterNotFound as e:
                 status = e
-                if self.config.option.skip_missing_interpreters:
+                if self.config.option.skip_missing_interpreters == "true":
                     default_ret_code = 0
             if status:
                 str_status = str(status)
@@ -573,7 +573,7 @@ class Session:
             status = venv.status
             if isinstance(status, tox.exception.InterpreterNotFound):
                 msg = " {}: {}".format(venv.envconfig.envname, str(status))
-                if self.config.option.skip_missing_interpreters:
+                if self.config.option.skip_missing_interpreters == "true":
                     self.report.skip(msg)
                 else:
                     retcode = 1

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1902,20 +1902,48 @@ class TestGlobalOptions:
             newconfig([], inisource)
 
     def test_skip_missing_interpreters_true(self, newconfig):
-        inisource = """
+        ini_source = """
             [tox]
             skip_missing_interpreters = True
         """
-        config = newconfig([], inisource)
-        assert config.option.skip_missing_interpreters
+        config = newconfig([], ini_source)
+        assert config.option.skip_missing_interpreters == "true"
 
     def test_skip_missing_interpreters_false(self, newconfig):
-        inisource = """
+        ini_source = """
             [tox]
             skip_missing_interpreters = False
         """
-        config = newconfig([], inisource)
-        assert not config.option.skip_missing_interpreters
+        config = newconfig([], ini_source)
+        assert config.option.skip_missing_interpreters == "false"
+
+    def test_skip_missing_interpreters_cli_no_arg(self, newconfig):
+        ini_source = """
+            [tox]
+            skip_missing_interpreters = False
+        """
+        config = newconfig(["--skip-missing-interpreters"], ini_source)
+        assert config.option.skip_missing_interpreters == "true"
+
+    def test_skip_missing_interpreters_cli_not_specified(self, newconfig):
+        config = newconfig([], "")
+        assert config.option.skip_missing_interpreters == "false"
+
+    def test_skip_missing_interpreters_cli_overrides_true(self, newconfig):
+        ini_source = """
+                    [tox]
+                    skip_missing_interpreters = False
+                """
+        config = newconfig(["--skip-missing-interpreters", "true"], ini_source)
+        assert config.option.skip_missing_interpreters == "true"
+
+    def test_skip_missing_interpreters_cli_overrides_false(self, newconfig):
+        ini_source = """
+                    [tox]
+                    skip_missing_interpreters = True
+                """
+        config = newconfig(["--skip-missing-interpreters", "false"], ini_source)
+        assert config.option.skip_missing_interpreters == "false"
 
     def test_defaultenv_commandline(self, newconfig):
         config = newconfig(["-epy27"], "")


### PR DESCRIPTION
skip missing interpreters value from the config file can now be overridden via the ``--skip-missing-interpreters`` cli flag
Resolves #903.