### PR TITLE
better base python version conflict detection

### DIFF
--- a/changelog/908.bugfix.rst
+++ b/changelog/908.bugfix.rst
@@ -1,0 +1,1 @@
+instead of assuming the Python version from the base python name ask the interpreter to reveal the version for the ``ignore_basepython_conflict`` flag - by :user:`gaborbernat`

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -80,13 +80,19 @@ and will first lookup global tox settings in this section:
 
     .. versionadded:: 3.1.0
 
-    If ``True``, :confval:`basepython` settings that conflict with the Python
-    variant for environments using default factors, such as ``py27`` or
-    ``py35``, will be ignored. This allows you to configure
-    :confval:`basepython` in the global testenv without affecting these
-    factors. If ``False``, the default, a warning will be emitted if a conflict
-    is identified. In a future version of tox, this warning will become an
-    error.
+    tox allows setting the python version for an environment via the :confval:`basepython`
+    setting. If that's not set tox can set a default value from the environment name (
+    e.g. ``py37`` implies Python 3.7). Matching up the python version with the environment
+    name has became expected at this point, leading to surprises when some configs don't
+    do so. To help with sanity of users a warning will be emitted whenever the environment
+    name version does not matches up with this expectation. In a future version of tox,
+    this warning will become an error.
+
+    Furthermore, we allow hard enforcing this rule (and bypassing the warning) by setting
+    this flag to ``True``. In such cases we ignore the :confval:`basepython` and instead
+    always use the base python implied from the Python name. This allows you to
+    configure :confval:`basepython` in the global testenv without affecting environments
+    that have implied base python versions.
 
 .. confval:: requires=LIST
 

--- a/src/tox/config.py
+++ b/src/tox/config.py
@@ -21,7 +21,7 @@ import toml
 
 import tox
 from tox.constants import INFO
-from tox.interpreters import Interpreters
+from tox.interpreters import Interpreters, NoInterpreterInfo
 
 hookimpl = tox.hookimpl
 """DEPRECATED - REMOVE - this is left for compatibility with plugins importing this from here.
@@ -532,35 +532,40 @@ def tox_addoption(parser):
     )
 
     def basepython_default(testenv_config, value):
-        """Configure a sane interpreter for the environment.
+        """either user set or proposed from the factor name
 
-        If the environment contains a default factor, this will always be the
-        interpreter associated with that factor overriding anything manually
-        set.
+        in both cases we check that the factor name implied python version and the resolved
+        python interpreter version match up; if they don't we warn, unless ignore base
+        python conflict is set in which case the factor name implied version if forced
         """
         for factor in testenv_config.factors:
-            match = tox.PYTHON.PY_FACTORS_RE.match(factor)
-            if match:
-                base_exe = tox.PYTHON.PY_FACTORS_MAP[match.group(1)]
-                version = ".".join(match.group(2) or "")
-                default = "{}{}".format(base_exe, version)
+            if factor in tox.PYTHON.DEFAULT_FACTORS:
+                implied_python = tox.PYTHON.DEFAULT_FACTORS[factor]
+                break
+        else:
+            implied_python, factor = None, None
 
-                if value is None or testenv_config.config.ignore_basepython_conflict:
-                    return default
+        if testenv_config.config.ignore_basepython_conflict and implied_python is not None:
+            return implied_python
 
-                if str(value) != default:
+        proposed_python = (implied_python or sys.executable) if value is None else str(value)
+        if implied_python is not None and implied_python != proposed_python:
+            testenv_config.basepython = proposed_python
+            implied_version = tox.PYTHON.PY_FACTORS_RE.match(factor).group(2)
+            python_info_for_proposed = testenv_config.python_info
+            if not isinstance(python_info_for_proposed, NoInterpreterInfo):
+                proposed_version = "".join(
+                    str(i) for i in python_info_for_proposed.version_info[0:2]
+                )
+                if implied_version != proposed_version:
                     # TODO(stephenfin): Raise an exception here in tox 4.0
                     warnings.warn(
-                        "Conflicting basepython for environment '{}'; resolve conflict "
-                        "or configure ignore_basepython_conflict".format(
-                            testenv_config.envname, str(value), default
+                        "conflicting basepython version (set {}, should be {}) for env '{}';"
+                        "resolve conflict or set ignore_basepython_conflict".format(
+                            proposed_version, implied_version, testenv_config.envname
                         )
                     )
-
-        if value is None:
-            return sys.executable
-
-        return str(value)
+        return proposed_python
 
     parser.add_testenv_attribute(
         name="basepython",

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,7 @@ commands = echo {posargs}
 [flake8]
 max-complexity = 22
 max-line-length = 99
-ignore = E203, W503
+ignore = E203, W503, C901
 
 [coverage:run]
 branch = true


### PR DESCRIPTION
Instead of assuming the Python version from the base python name ask the interpreter to reveal the version for the ``ignore_basepython_conflict`` flag.

Resolves #908.