### PR TITLE
Added Python 3.7 to trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ def main():
         ]
         + [
             ("Programming Language :: Python :: {}".format(x))
-            for x in "2 2.7 3 3.4 3.5 3.6".split()
+            for x in "2 2.7 3 3.4 3.5 3.6 3.7".split()
         ],
     )
 


### PR DESCRIPTION
Without this classifier, recent pip versions reject the installation of tox.

```
$ pipenv install --dev tox
Installing tox...
Requirement already satisfied: tox in /home/markus/.venvs/project-SqLSqFAd/lib/python3.7/site-packages (3.0.0)
Requirement already satisfied: py>=1.4.17 in /home/markus/.venvs/project-SqLSqFAd/lib/python3.7/site-packages (from tox) (1.6.0)
Requirement already satisfied: virtualenv>=1.11.2 in /home/markus/.venvs/project-SqLSqFAd/lib/python3.7/site-packages (from tox) (16.0.0)
Requirement already satisfied: six in /home/markus/.venvs/project-SqLSqFAd/lib/python3.7/site-packages (from tox) (1.11.0)
Requirement already satisfied: pluggy<1.0,>=0.3.0 in /home/markus/.venvs/project-SqLSqFAd/lib/python3.7/site-packages (from tox) (0.7.1)

Adding tox to Pipfile's [dev-packages]...
Pipfile.lock (5032b4) out of date, updating to (ebc581)...
Locking [dev-packages] dependencies...

Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
  You can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.
  Hint: try $ pipenv lock --pre if it is a pre-release dependency.
Could not find a version that matches tox==3.0.0,==3.3.0 (from -r /tmp/pipenv-t76kavjb-requirements/pipenv-eqtmjp7r-constraints.txt (line 5))
Tried: 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.4.1, 1.4.2, 1.4.3, 1.5.0, 1.6.0, 1.6.1, 1.7.0, 1.7.1, 1.7.2, 1.8.0, 1.8.1, 1.9.0, 1.9.1, 1.9.2, 2.0.0, 2.0.0, 2.0.1, 2.0.1, 2.0.2, 2.0.2, 2.1.0, 2.1.0, 2.1.1, 2.1.1, 2.2.0, 2.2.0, 2.2.1, 2.2.1, 2.3.0, 2.3.0, 2.3.1, 2.3.1, 2.3.2, 2.3.2, 2.4.0, 2.4.0, 2.4.1, 2.4.1, 2.5.0, 2.5.0, 2.6.0, 2.6.0, 2.7.0, 2.7.0, 2.8.0, 2.8.0, 2.8.1, 2.8.1, 2.8.2, 2.8.2, 2.9.0, 2.9.0, 2.9.1, 2.9.1, 3.0.0, 3.0.0, 3.1.0, 3.1.0, 3.1.1, 3.1.1, 3.1.2, 3.1.2, 3.1.3, 3.1.3, 3.2.0, 3.2.0, 3.2.1, 3.2.1, 3.3.0, 3.3.0
Skipped pre-versions: 2.8.0rc1, 2.8.0rc1, 2.8.0rc2, 2.8.0rc2, 2.9.0rc1, 2.9.0rc1, 3.0.0rc1, 3.0.0rc1, 3.0.0rc2, 3.0.0rc2, 3.0.0rc3, 3.0.0rc3, 3.0.0rc4, 3.0.0rc4
There are incompatible versions in the resolved dependencies.
```

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)