### PR TITLE
tests: tox.ini: remove changedir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,14 +20,12 @@ setenv = PIP_DISABLE_VERSION_CHECK = 1
 passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
 deps =
 extras = testing
-changedir = {toxinidir}/tests
 commands = pytest {posargs:--cov="{envsitepackagesdir}/tox" --cov-config="{toxinidir}/tox.ini"  --timeout=180 . -n {env:PYTEST_XDIST_PROC_NR:auto}}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
 basepython = python3.7
 extras = docs
-changedir = {toxinidir}
 commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
            python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
 
@@ -35,7 +33,6 @@ commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_ou
 description = check that the long description is valid
 basepython = python3.7
 deps = readme-renderer >= 21.0
-changedir = {toxinidir}
 skip_install = true
 extras =
 commands = python setup.py check -r -s
@@ -51,7 +48,6 @@ passenv = {[testenv]passenv}
 extras = lint
 deps = pre-commit == 1.10.3
 skip_install = True
-changedir = {toxinidir}
 commands = pre-commit run --all-files --show-diff-on-failure
            python -c 'import pathlib; print("hint: run \{\} install to add checks as pre-commit hook".format(pathlib.Path(r"{envdir}") / "bin" / "pre-commit"))'
 
@@ -66,7 +62,6 @@ skip_install = True
 passenv = {[testenv]passenv}
           DIFF_AGAINST
 setenv = COVERAGE_FILE={toxworkdir}/.coverage
-changedir = {toxinidir}
 commands = coverage erase
            coverage combine
            coverage report -m
@@ -80,7 +75,6 @@ passenv = {[testenv]passenv}
           CODECOV_TOKEN
 deps = codecov
 skip_install = True
-changedir = {toxinidir}
 commands = codecov --file "{toxworkdir}/coverage.xml" {posargs}
 
 [testenv:exit_code]
@@ -89,7 +83,6 @@ commands = codecov --file "{toxworkdir}/coverage.xml" {posargs}
 basepython = python3.7
 description = commands with several exit codes
 skip_install = True
-changedir = {toxinidir}
 commands = python3.7 -c "import sys; sys.exit(139)"
 
 [testenv:X]
@@ -172,6 +165,5 @@ deps = {[testenv]deps}
 # required to make looponfail reload on every source code change
 usedevelop = True
 basepython = python3.7
-changedir = {toxinidir}
 commands = python -m pip list --format=columns
            python -c 'import sys; print(sys.executable)'


### PR DESCRIPTION
For "testenv" is allows to copy and paste paths from fails tests more
easily, and for others it will use the default.