### PR TITLE
tests: pytest: use testpaths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -132,7 +132,7 @@ source = src/tox
 addopts = -ra --showlocals
 rsyncdirs = tests tox
 looponfailroots = tox tests
-norecursedirs = .hg .tox
+testpaths = tests
 xfail_strict = True
 
 [isort]


### PR DESCRIPTION
Removes then unnecessary norecursedirs.