### PR TITLE
add --nodeps command line option

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -162,7 +162,11 @@ Here is a simple overview, with tox-specific bits:
 
    Or to only run tests in a particular test module on Python 3.6::
 
-    $ tox -e py36 -- testing/test_config.py
+    $ tox -e py36 -- tests/unit/test_config.py
+
+   Or to only run a single specific test with more verbosity::
+
+    $ tox -e py36 -- -s -v -k test_notest tests/unit/test_config.py
 
    You can also use the dev environment:
 

--- a/changelog/410.feature.rst
+++ b/changelog/410.feature.rst
@@ -1,0 +1,1 @@
+add ``--nodeps`` command line option to enable skipping dependency installation (ignore deps=...) - by :user:`janhn`

--- a/src/tox/config.py
+++ b/src/tox/config.py
@@ -407,6 +407,9 @@ def tox_addoption(parser):
         help="work against specified environments (ALL selects all).",
     )
     parser.add_argument(
+        "--nodeps", action="store_true", dest="nodeps", help="skip dependency installation."
+    )
+    parser.add_argument(
         "--notest", action="store_true", dest="notest", help="skip invoking test commands."
     )
     parser.add_argument(

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -217,10 +217,11 @@ class VirtualEnv(object):
             self.just_created = True
         except tox.exception.UnsupportedInterpreter as exception:
             return exception
-        try:
-            self.hook.tox_testenv_install_deps(action=action, venv=self)
-        except tox.exception.InvocationError as exception:
-            return "could not install deps {}; v = {!r}".format(self.envconfig.deps, exception)
+        if not self.session.config.option.nodeps:
+            try:
+                self.hook.tox_testenv_install_deps(action=action, venv=self)
+            except tox.exception.InvocationError as exception:
+                return "could not install deps {}; v = {!r}".format(self.envconfig.deps, exception)
 
     def _getliveconfig(self):
         base_resolved_python_path = self.envconfig.python_info.executable

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1781,6 +1781,12 @@ class TestConfigTestEnv:
 
 
 class TestGlobalOptions:
+    def test_nodeps(self, newconfig):
+        config = newconfig([], "")
+        assert not config.option.nodeps
+        config = newconfig(["--nodeps"], "")
+        assert config.option.nodeps
+
     def test_notest(self, newconfig):
         config = newconfig([], "")
         assert not config.option.notest

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -688,6 +688,26 @@ def test_test_piphelp(initproj, cmd):
     assert not result.ret
 
 
+def test_nodeps(initproj, cmd):
+    initproj(
+        "example123",
+        filedefs={
+            "tox.ini": """
+        # content of: tox.ini
+        [testenv]
+        deps=qweqwe123
+    """
+        },
+    )
+    result = cmd("-v")
+    assert result.ret
+    assert result.outlines[-1].startswith("ERROR:   python: could not install deps [qweqwe123];")
+    result = cmd("-v", "--nodeps")
+    assert not result.ret
+    pattern = re.compile("python installed: example123==0.1")
+    assert any(pattern.match(line) for line in result.outlines), result.outlines
+
+
 def test_notest(initproj, cmd):
     initproj(
         "example123",


### PR DESCRIPTION
Kindly asking for a review of suggested changes to implement #410.

Tests have been run as suggested in the contributing guide, with and without the change to verify that no failures are being introduced.

```
=========================== short test summary info ============================
SKIP [1] tests/integration/test_package_int.py:38: flit is Python 3 only
SKIP [1] tests/unit/test_interpreters.py:30: non posix test
XFAIL unit/test_config.py::TestConfigTestEnv::()::test_regression_test_issue_706[envlist0]
  reproduce bug 706
XFAIL unit/test_config.py::TestCmdInvocation::()::test_colon_symbol_in_directory_name
  Upstream bug. See #203

============== 452 passed, 2 skipped, 2 xfailed in 100.44 seconds ==============
``` 