### PR TITLE
[WIP] "requires" config improvements

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -120,8 +120,12 @@ Global settings are defined under the ``tox`` section as:
     .. code-block:: ini
 
         [tox]
-        requires = setuptools >= 30.0.0
-                   py
+        requires = tox-venv
+                   setuptools >= 30.0.0
+
+    .. note:: tox does **not** install those required packages for you. tox only checks if the
+              requirements are satisfied and crashes early with an helpful error rather then later
+              in the process.
 
 .. conf:: isolated_build ^ true|false ^ false
 

--- a/src/tox/config.py
+++ b/src/tox/config.py
@@ -1084,19 +1084,18 @@ class ParseIni(object):
 
     @staticmethod
     def ensure_requires_satisfied(specified):
-        fail = False
+        missing_requirements = []
         for s in specified:
             try:
                 pkg_resources.get_distribution(s)
             except pkg_resources.RequirementParseError:
                 raise
             except Exception:
-                fail = True
-                print(
-                    "requirement missing {}".format(pkg_resources.Requirement(s)), file=sys.stderr
-                )
-        if fail:
-            raise RuntimeError("not all requirements satisfied, install them alongside tox")
+                missing_requirements.append(str(pkg_resources.Requirement(s)))
+        if missing_requirements:
+            raise tox.exception.MissingRequirement(
+                "Packages {} need to be installed alongside tox in {}".format(", ".join(missing_requirements), sys.executable)
+            )
 
     def _list_section_factors(self, section):
         factors = set()

--- a/src/tox/config.py
+++ b/src/tox/config.py
@@ -1094,7 +1094,9 @@ class ParseIni(object):
                 missing_requirements.append(str(pkg_resources.Requirement(s)))
         if missing_requirements:
             raise tox.exception.MissingRequirement(
-                "Packages {} need to be installed alongside tox in {}".format(", ".join(missing_requirements), sys.executable)
+                "Packages {} need to be installed alongside tox in {}".format(
+                    ", ".join(missing_requirements), sys.executable
+                )
             )
 
     def _list_section_factors(self, section):

--- a/src/tox/exception.py
+++ b/src/tox/exception.py
@@ -80,6 +80,10 @@ class MissingDependency(Error):
     """A dependency could not be found or determined."""
 
 
+class MissingRequirement(Error):
+    """A requirement defined in :config:`require` is not met."""
+
+
 class MinVersionError(Error):
     """The installed tox version is lower than requested minversion."""
 

--- a/src/tox/interpreters.py
+++ b/src/tox/interpreters.py
@@ -151,6 +151,7 @@ else:
             # The standard names are in predictable places.
             actual = r"c:\python{}\python.exe".format("".join(groups))
         else:
+
             actual = win32map.get(name, None)
         if actual:
             actual = py.path.local(actual)

--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -51,7 +51,7 @@ def main(args):
         raise SystemExit(retcode)
     except KeyboardInterrupt:
         raise SystemExit(2)
-    except tox.exception.MinVersionError as e:
+    except (tox.exception.MinVersionError, tox.exception.MissingRequirement) as e:
         r = Reporter(None)
         r.error(str(e))
         raise SystemExit(1)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2656,7 +2656,7 @@ def test_plugin_require(newconfig):
 
     assert exc_info.value.args[0] == (
         r'Packages name[bar,foo]<3,>=2; python_version > "2.0" and os_name == "a", b '
-        r'need to be installed alongside tox in {}'.format(sys.executable)
+        r"need to be installed alongside tox in {}".format(sys.executable)
     )
 
 


### PR DESCRIPTION
If requirements are not satisfied the error is now represented by a custom exception and appropriately caught to make the error look like what it is: a misconfiguration of the environment rather than an error in tox.

so this:

```console
tox
ERROR: MissingRequirement: Packages tox-venv, tox-travis need to be installed alongside tox in [...]/bin/python
```

rather than:

```console
tox                                 (git)-[generic-project/master:613bf7ce2c38+! ]
requirement missing tox-venv
requirement missing tox-travis
Traceback (most recent call last):
  File "[...]/bin/tox", line 11, in <module>
    sys.exit(cmdline())
  File "[...]/lib/python3.7/site-packages/tox/session.py", line 41, in cmdline
    main(args)
  File "[...]/lib/python3.7/site-packages/tox/session.py", line 46, in main
    config = prepare(args)
  File "[...]/lib/python3.7/site-packages/tox/session.py", line 28, in prepare
    config = parseconfig(args)
  File "[...]/lib/python3.7/site-packages/tox/config.py", line 232, in parseconfig
    ParseIni(config, config_file, content)
  File "[...]/lib/python3.7/site-packages/tox/config.py", line 982, in __init__
    self.ensure_requires_satisfied(reader.getlist("requires"))
  File "[...]/lib/python3.7/site-packages/tox/config.py", line 1099, in ensure_requires_satisfied
    raise RuntimeError("not all requirements satisfied, install them alongside tox")
RuntimeError: not all requirements satisfied, install them alongside tox
```

The docs give explicit info now also, that require is not doing what you might expect if you draw an analogy to the require options in `setuptools.setup()`.

Marked this wip as I am not sure whether we really need a new exception or how to deal in general with our internal exceptions. I feel we should catch them all on the upper level and output a friendly error rather than a traceback (but maybe this should be tackled in another PR).
