### PR TITLE
Bugfix: Do the same transformation to egg-info dirs that pkg_resources does

### DIFF
--- a/docs/changelog/1051.bugfix.rst
+++ b/docs/changelog/1051.bugfix.rst
@@ -1,0 +1,4 @@
+Do the same transformation to egg_info dirs that pkg_resources does. This makes
+it possible for hyphenated names to use the develop-inst-noop optimization (cf.
+#910), which previously only worked with non-hyphenated egg names - by
+:user:`hashbrowncipher`.

--- a/src/tox/_pytestplugin.py
+++ b/src/tox/_pytestplugin.py
@@ -284,7 +284,7 @@ def initproj(tmpdir):
         if not src_root:
             src_root = "."
         if isinstance(nameversion, six.string_types):
-            parts = nameversion.split(str("-"))
+            parts = nameversion.rsplit(str("-"), 1)
             if len(parts) == 1:
                 parts.append("0.1")
             name, version = parts

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -8,6 +8,7 @@ import warnings
 from itertools import chain
 
 import py
+from pkg_resources import to_filename
 
 import tox
 
@@ -295,7 +296,7 @@ class VirtualEnv(object):
             sys_path = json.loads(out)
         except ValueError:
             sys_path = []
-        egg_info_fname = ".".join((name, "egg-info"))
+        egg_info_fname = ".".join((to_filename(name), "egg-info"))
         for d in reversed(sys_path):
             egg_info = py.path.local(d).join(egg_info_fname)
             if egg_info.check():

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -528,10 +528,12 @@ def test_usedevelop_mixed(initproj, cmd):
     assert "sdist-make" in result.out
 
 
+@pytest.mark.parametrize("skipsdist", [False, True])
 @pytest.mark.parametrize("src_root", [".", "src"])
-def test_test_usedevelop(cmd, initproj, src_root, monkeypatch):
+def test_test_usedevelop(cmd, initproj, src_root, skipsdist, monkeypatch):
+    name = "example123-spameggs"
     base = initproj(
-        "example123-0.5",
+        (name, "0.5"),
         src_root=src_root,
         filedefs={
             "tests": {
@@ -546,8 +548,12 @@ def test_test_usedevelop(cmd, initproj, src_root, monkeypatch):
             changedir=tests
             commands=
                 pytest --basetemp={envtmpdir} --junitxml=junit-{envname}.xml []
-            deps=pytest
-        """,
+            deps=pytest"""
+            + """
+            skipsdist={}
+        """.format(
+                skipsdist
+            ),
         },
     )
     result = cmd("-v")
@@ -567,76 +573,7 @@ def test_test_usedevelop(cmd, initproj, src_root, monkeypatch):
 
     # see that things work with a different CWD
     monkeypatch.chdir(base.dirname)
-    result = cmd("-c", "example123/tox.ini")
-    assert not result.ret
-    assert "develop-inst-noop" in result.out
-    assert re.match(
-        r".*\W+1\W+passed.*" r"summary.*" r"python:\W+commands\W+succeeded.*",
-        result.out,
-        re.DOTALL,
-    )
-    monkeypatch.chdir(base)
-
-    # see that tests can also fail and retcode is correct
-    testfile = py.path.local("tests").join("test_hello.py")
-    assert testfile.check()
-    testfile.write("def test_fail(): assert 0")
-    result = cmd()
-    assert result.ret, "{}\n{}".format(result.err, result.out)
-    assert "develop-inst-noop" in result.out
-    assert re.match(
-        r".*\W+1\W+failed.*" r"summary.*" r"python:\W+commands\W+failed.*", result.out, re.DOTALL
-    )
-
-    # test develop is called if setup.py changes
-    setup_py = py.path.local("setup.py")
-    setup_py.write(setup_py.read() + " ")
-    result = cmd()
-    assert result.ret, "{}\n{}".format(result.err, result.out)
-    assert "develop-inst-nodeps" in result.out
-
-
-@pytest.mark.parametrize("src_root", [".", "src"])
-def test_test_usedevelop_skipsdist(cmd, initproj, src_root, monkeypatch):
-    base = initproj(
-        "example123-spameggs-0.5",
-        src_root=src_root,
-        filedefs={
-            "tests": {
-                "test_hello.py": """
-                def test_hello(pytestconfig):
-                    pass
-            """
-            },
-            "tox.ini": """
-            [testenv]
-            usedevelop=True
-            skipsdist=True
-            changedir=tests
-            commands=
-                pytest --basetemp={envtmpdir} --junitxml=junit-{envname}.xml []
-            deps=pytest
-        """,
-        },
-    )
-    result = cmd("-v")
-    assert not result.ret
-    assert re.match(
-        r".*generated\W+xml\W+file.*junit-python\.xml" r".*\W+1\W+passed.*", result.out, re.DOTALL
-    )
-    assert "sdist-make" not in result.out
-    result = cmd("-epython")
-    assert not result.ret
-    assert "develop-inst-noop" in result.out
-    assert re.match(
-        r".*\W+1\W+passed.*" r"summary.*" r"python:\W+commands\W+succeeded.*",
-        result.out,
-        re.DOTALL,
-    )
-
-    # see that things work with a different CWD
-    monkeypatch.chdir(base.dirname)
-    result = cmd("-c", "example123-spameggs/tox.ini")
+    result = cmd("-c", "{}/tox.ini".format(name))
     assert not result.ret
     assert "develop-inst-noop" in result.out
     assert re.match(


### PR DESCRIPTION
I noticed that my hyphenated project name is not using the `develop-inst-noop` action, instead using the `develop-inst-nodeps` (cf. #910). This is because it uses a hyphenated project name, and tox was looking at the mtime of a nonexistent `myproject-name.egg-info` directory, when distutils/setuptools instead create a directory called `myproject_name.egg-info`. I don't know why they behave this way.

I've added a test for this behavior, and also made it so that initproj can take hyphenated strings for project names. Then, to fix the failing test, I added a call to `to_filename`, the function which `pkg_resources` uses for the same transformation.