### PR TITLE
Fix typo in configuration documentation

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -67,7 +67,7 @@ Global settings are defined under the ``tox`` section as:
 
 .. conf:: sdistsrc ^ PATH ^ {toxworkdir}/dist
 
-   Do not build the package, but instead use teh latest package available under this path.
+   Do not build the package, but instead use the latest package available under this path.
    You can override it via the command line flag ``--installpkg``.
 
 .. conf:: distshare ^ PATH ^ {homedir}/.tox/distshare


### PR DESCRIPTION
While reading the online documentation I've noticed there is a typo which is fixed by this PR

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [X] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
