### PR TITLE
Fix small typo where the word contraints was spelled as contrains

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,6 @@
+Alexander Schepanovski
 Alex Grönholm
 Alexander Loechel
-Alexander Schepanovski
 Alexandre Conrad
 Allan Feldman
 Andrii Soldatenko
@@ -57,9 +57,9 @@ Pierre-Luc Tessier Gagné
 Ronald Evers
 Ronny Pfannschmidt
 Selim Belhaouane
-Sridhar Ratnakumar
 Stephen Finucane
+Sridhar Ratnakumar
 Sviatoslav Sydorenko
 Ville Skyttä
-anatoly techtonik
 Xander Johnson
+anatoly techtonik

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,6 @@
-Alexander Schepanovski
 Alex Grönholm
 Alexander Loechel
+Alexander Schepanovski
 Alexandre Conrad
 Allan Feldman
 Andrii Soldatenko
@@ -57,8 +57,9 @@ Pierre-Luc Tessier Gagné
 Ronald Evers
 Ronny Pfannschmidt
 Selim Belhaouane
-Stephen Finucane
 Sridhar Ratnakumar
+Stephen Finucane
 Sviatoslav Sydorenko
 Ville Skyttä
 anatoly techtonik
+Xander Johnson

--- a/docs/changelog/1061.doc.rst
+++ b/docs/changelog/1061.doc.rst
@@ -1,0 +1,1 @@
+change the spelling of a single word from contrains to the proper word, constraintsj - by :user:`metasyn`

--- a/docs/changelog/1061.doc.rst
+++ b/docs/changelog/1061.doc.rst
@@ -1,1 +1,1 @@
-change the spelling of a single word from contrains to the proper word, constraintsj - by :user:`metasyn`
+change the spelling of a single word from contrains to the proper word, constraints - by :user:`metasyn`

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -148,7 +148,7 @@ or
     deps = -rrequirements.txt -cconstraints.txt
 
 All installation commands are executed using ``{toxinidir}`` (the directory where ``tox.ini`` resides) as the current working directory.
-Therefore, the underlying ``pip`` installation will assume ``requirements.txt`` or ``constraints.txt`` to exist at ``{toxinidir}/requirements.txt`` or ``{toxinidir}/contrains.txt``.
+Therefore, the underlying ``pip`` installation will assume ``requirements.txt`` or ``constraints.txt`` to exist at ``{toxinidir}/requirements.txt`` or ``{toxinidir}/constraints.txt``.
 
 This is actually a side effect that all elements of the dependency list is directly passed to ``pip``.
 


### PR DESCRIPTION
Single word typo  - very small PR. 