### PR TITLE
Fix `commands_pre`/`commands_post` documentation.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,7 @@ Anthony Sottile
 Asmund Grammeltwedt
 Barry Warsaw
 Bartolome Sanchez Salado
+Benoit Pierre
 Bernat Gabor
 Bruno Oliveira
 Carl Meyer

--- a/docs/changelog/1071.doc.rst
+++ b/docs/changelog/1071.doc.rst
@@ -1,0 +1,1 @@
+Mention the minimum version required for ``commands_pre``/``commands_post`` support.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -228,10 +228,14 @@ Complete list of settings that you can put into ``testenv*`` sections:
 
 .. conf:: commands_pre ^ ARGVLIST
 
+    .. versionadded:: 3.4
+
     Commands to run before running the :conf:`commands`.
     All evaluation and configuration logic applies from :conf:`commands`.
 
 .. conf:: commands_post ^ ARGVLIST
+
+    .. versionadded:: 3.4
 
     Commands to run after running the :conf:`commands`. Execute regardless of the outcome of
     both :conf:`commands` and :conf:`commands_pre`.


### PR DESCRIPTION
Mention the minimum version required.
