### PR TITLE
allow creation of jython envs

### DIFF
--- a/docs/changelog/1073.bugfix.rst
+++ b/docs/changelog/1073.bugfix.rst
@@ -1,0 +1,1 @@
+change the way we acquire interpreter information to make it compatible with ``jython`` interpreter, note to create jython envs one needs ``virtualenv > 16.0`` which will be released later :user:`gaborbernat`

--- a/tests/integration/test_jython_env_create.py
+++ b/tests/integration/test_jython_env_create.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+# TODO
+@pytest.mark.skip(reason="needs jython and dev cut of virtualenv")
+def test_jython_create(initproj, cmd):
+    initproj(
+        "py_jython-0.1",
+        filedefs={
+            "tox.ini": """
+                        [tox]
+                        skipsdist = true
+                        envlist = jython
+                        commands = python -c 'import sys; print(sys.executable)'
+                    """
+        },
+    )
+    result = cmd("--notest", "-vvv")
+    assert not result.ret, "{}\n{}".format(result.err, result.out)

--- a/tests/unit/test_interpreters.py
+++ b/tests/unit/test_interpreters.py
@@ -14,9 +14,7 @@ from tox.interpreters import (
     InterpreterInfo,
     Interpreters,
     NoInterpreterInfo,
-    pyinfo,
     run_and_get_interpreter_info,
-    sitepackagesdir,
     tox_get_python_executable,
 )
 
@@ -160,29 +158,6 @@ class TestInterpreters:
         info = interpreters.get_info(envconfig)
         s = interpreters.get_sitepackagesdir(info, "")
         assert s
-
-
-def test_pyinfo(monkeypatch):
-    monkeypatch.setattr(sys, "version_info", [42, 4242])
-    monkeypatch.setattr(sys, "platform", "an unladen swallow")
-    result = pyinfo()
-    assert len(result) == 2
-    assert result["version_info"] == (42, 4242)
-    assert result["sysplatform"] == "an unladen swallow"
-
-
-def test_sitepackagesdir(monkeypatch):
-    import distutils.sysconfig as sysconfig
-
-    test_envdir = "holy grail"
-    test_dir = "Now go away or I will taunt you a second time."
-
-    def dummy_get_python_lib(prefix):
-        assert prefix is test_envdir
-        return test_dir
-
-    monkeypatch.setattr(sysconfig, "get_python_lib", dummy_get_python_lib)
-    assert sitepackagesdir(test_envdir) == {"dir": test_dir}
 
 
 def test_exec_failed():


### PR DESCRIPTION
The logic used to get the interpreter information was error prone to
warnings at interpreter start, which made impossible to create a jython
environment.