### PR TITLE
improve our own devenv in tox.ini

### DIFF
--- a/docs/example/devenv.rst
+++ b/docs/example/devenv.rst
@@ -38,7 +38,7 @@ In it we state:
   develop``, as opposed to building and installing its source distribution using
   ``setup.py install``.
 
-The development environment will reside in `toxworkdir` (default is `.tox`) just
+The development environment will reside in ``toxworkdir`` (default is ``.tox``) just
 like the other tox environments.
 
 We can configure a lot more, if we want to. For example, we can add the

--- a/docs/example/devenv.rst
+++ b/docs/example/devenv.rst
@@ -12,7 +12,7 @@ mismatched development environments.
 
 Here are some examples illustrating how to set up a project's development
 environment using tox. For illustration purposes, let us call the development
-environment ``devenv``.
+environment ``dev``.
 
 
 Example 1: Basic scenario
@@ -22,32 +22,33 @@ Step 1 - Configure the development environment
 ----------------------------------------------
 
 First, we prepare the tox configuration for our development environment by
-defining a ``[testenv:devenv]`` section in the project's ``tox.ini``
+defining a ``[testenv:dev]`` section in the project's ``tox.ini``
 configuration file:
 
 .. code-block:: ini
 
-    [testenv:devenv]
-    envdir = devenv
+    [testenv:dev]
     basepython = python2.7
     usedevelop = True
 
 In it we state:
 
-- what directory to locate the environment in,
 - what Python executable to use in the environment,
 - that our project should be installed into the environment using ``setup.py
   develop``, as opposed to building and installing its source distribution using
   ``setup.py install``.
 
-Actually, we can configure a lot more, and these are only the required settings.
-For example, we can add the following to our configuration, telling tox not to
-reuse ``commands`` or ``deps`` settings from the base ``[testenv]``
+The development environment will reside in `toxworkdir` (default is `.tox`) just
+like the other tox environments.
+
+We can configure a lot more, if we want to. For example, we can add the
+following to our configuration, telling tox not to reuse ``commands`` or
+``deps`` settings from the base ``[testenv]``
 configuration:
 
 .. code-block:: ini
 
-    [testenv:devenv]
+    [testenv:dev]
     commands =
     deps =
 
@@ -55,12 +56,12 @@ configuration:
 Step 2 - Create the development environment
 -------------------------------------------
 
-Once the ``[testenv:devenv]`` configuration section has been defined, we create
+Once the ``[testenv:dev]`` configuration section has been defined, we create
 the actual development environment by running the following:
 
 .. code-block:: shell
 
-    tox -e devenv
+    tox -e dev
 
 This creates the environment at the path specified by the environment's
 ``envdir`` configuration value.
@@ -71,7 +72,6 @@ Example 2: A more complex scenario
 
 Let us say we want our project development environment to:
 
-- be located in the ``devenv`` directory,
 - use Python executable ``python2.7``,
 - pull packages from ``requirements.txt``, located in the same directory as
   ``tox.ini``.
@@ -80,8 +80,7 @@ Here is an example configuration for the described scenario:
 
 .. code-block:: ini
 
-    [testenv:devenv]
-    envdir = devenv
+    [testenv:dev]
     basepython = python2.7
     usedevelop = True
     deps = -rrequirements.txt

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,11 +1,11 @@
-import sys
-
 import os
+import re
+import sys
+from textwrap import dedent
+
 import py
 import pytest
-import re
 from pluggy import PluginManager
-from textwrap import dedent
 
 import tox
 from tox.config import (

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,11 +1,11 @@
-import os
-import re
 import sys
-from textwrap import dedent
 
+import os
 import py
 import pytest
+import re
 from pluggy import PluginManager
+from textwrap import dedent
 
 import tox
 from tox.config import (
@@ -70,22 +70,22 @@ class TestVenvConfig:
         config = newconfig(
             [],
             """
-            [testenv:devenv]
-            envdir = devenv
+            [testenv:dev]
+            envdir = dev
         """,
         )
-        envconfig = config.envconfigs["devenv"]
-        assert envconfig.envdir == tmpdir.join("devenv")
+        envconfig = config.envconfigs["dev"]
+        assert envconfig.envdir == tmpdir.join("dev")
 
     def test_envdir_set_manually_with_substitutions(self, newconfig):
         config = newconfig(
             [],
             """
-            [testenv:devenv]
+            [testenv:dev]
             envdir = {toxworkdir}/foobar
         """,
         )
-        envconfig = config.envconfigs["devenv"]
+        envconfig = config.envconfigs["dev"]
         assert envconfig.envdir == config.toxworkdir.join("foobar")
 
     def test_force_dep_version(self, initproj):

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -1,12 +1,12 @@
+import sys
+
 import json
 import os
 import platform
-import re
-import subprocess
-import sys
-
 import py
 import pytest
+import re
+import subprocess
 
 import tox
 from tox._pytestplugin import ReportExpectMock
@@ -509,7 +509,7 @@ def test_usedevelop_mixed(initproj, cmd):
         "example123",
         filedefs={
             "tox.ini": """
-            [testenv:devenv]
+            [testenv:dev]
             usedevelop=True
             [testenv:nondev]
             usedevelop=False
@@ -517,8 +517,8 @@ def test_usedevelop_mixed(initproj, cmd):
         },
     )
 
-    # running only 'devenv' should not do sdist
-    result = cmd("-vv", "-e", "devenv")
+    # running only 'dev' should not do sdist
+    result = cmd("-vv", "-e", "dev")
     assert not result.ret
     assert "sdist-make" not in result.out
 

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -1,12 +1,12 @@
-import sys
-
 import json
 import os
 import platform
-import py
-import pytest
 import re
 import subprocess
+import sys
+
+import py
+import pytest
 
 import tox
 from tox._pytestplugin import ReportExpectMock

--- a/tox.ini
+++ b/tox.ini
@@ -165,14 +165,12 @@ deps = gitpython >= 2.1.10
        oauth2client >= 4.1.2
 commands = python {toxinidir}/tasks/notify.py
 
-[testenv:dev]
-description = generate a DEV environment
+[testenv:devenv]
+description = create '{toxworkdir}/devenv' with all dependencies for development
 extras = testing, docs
 deps = {[testenv]deps}
        {[testenv:release]deps}
        {[testenv:notify]deps}
-# required to make looponfail reload on every source code change
 usedevelop = True
-basepython = python3.7
 commands = python -m pip list --format=columns
-           python -c 'import sys; print(sys.executable)'
+           python -c 'import sys; print("devenv at: %s" % sys.exec_prefix)'

--- a/tox.ini
+++ b/tox.ini
@@ -165,12 +165,12 @@ deps = gitpython >= 2.1.10
        oauth2client >= 4.1.2
 commands = python {toxinidir}/tasks/notify.py
 
-[testenv:devenv]
-description = create '{toxworkdir}/devenv' with all dependencies for development
+[testenv:dev]
+description = dev environment with all deps at {envdir}
 extras = testing, docs
 deps = {[testenv]deps}
        {[testenv:release]deps}
        {[testenv:notify]deps}
 usedevelop = True
 commands = python -m pip list --format=columns
-           python -c 'import sys; print("devenv at: %s" % sys.exec_prefix)'
+           python -c "print('{envpython}')"


### PR DESCRIPTION
* fix devenv != recommendation in our own documentation
* remove forced Python3.7 base (not necessary)
* remove ancient comment that makes only sense in a limited context
* improve description (contains path to devenv now)

see: https://tox.readthedocs.io/en/latest/example/devenv.html

[//]: # (rtdbot-start)

URL of RTD document: https://tox.readthedocs.io/en/improve-devenv/ ![Documentation Status](https://readthedocs.org/projects/tox/badge/?version=improve-devenv)

[//]: # (rtdbot-end)
