### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/docs/changelog/1083.misc.rst
+++ b/docs/changelog/1083.misc.rst
@@ -1,0 +1,1 @@
+Include the license file in the wheel distribution - by :user:`jdufresne`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The wheel package format supports including the license file. This is
done using the [metadata] section in the setup.cfg file. For additional
information on this feature, see:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file

Helps project comply with its own license.

> The above copyright notice and this permission notice shall be
> included in all copies or substantial portions of the Software.

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- <s>added/updated test(s)</s> N/A
- <s>updated/extended the documentation</s> N/A
- <s>added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body</s>
- [x] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
