### PR TITLE
Make windows interpreter lookup precedence more like posix

### DIFF
--- a/docs/changelog/1087.bugfix.rst
+++ b/docs/changelog/1087.bugfix.rst
@@ -1,0 +1,1 @@
+On windows, check ``sys.executable`` before others for interpreter version lookup.  This matches what happens on non-windows.

--- a/src/tox/interpreters.py
+++ b/src/tox/interpreters.py
@@ -144,26 +144,25 @@ else:
 
     @tox.hookimpl
     def tox_get_python_executable(envconfig):
-        name = envconfig.basepython
-        p = py.path.local.sysfind(name)
+        if envconfig.basepython == "python{}.{}".format(*sys.version_info[0:2]):
+            return sys.executable
+        p = py.path.local.sysfind(envconfig.basepython)
         if p:
             return p
 
         # Is this a standard PythonX.Y name?
-        m = re.match(r"python(\d)(?:\.(\d))?", name)
+        m = re.match(r"python(\d)(?:\.(\d))?", envconfig.basepython)
         groups = [g for g in m.groups() if g] if m else []
         if m:
             # The standard names are in predictable places.
             actual = r"c:\python{}\python.exe".format("".join(groups))
         else:
 
-            actual = win32map.get(name, None)
+            actual = win32map.get(envconfig.basepython, None)
         if actual:
             actual = py.path.local(actual)
             if actual.check():
                 return actual
-        if name == "python{}.{}".format(*sys.version_info[0:2]):
-            return sys.executable
         # Use py.exe to determine location - PEP-514 & PEP-397
         if m:
             return locate_via_py(*groups)


### PR DESCRIPTION
Notably:
- check the current `sys.executable` first

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] _(n/a)_ added/updated test(s) 
- [x] _(n/a)_ updated/extended the documentation
- [x] _(n/a)_ added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) in message body (n/a)
- [x] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
