### PR TITLE
Don't warn when PYTHONPATH is present but empty.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ Johannes Christ
 Jon Dufresne
 Josh Smeaton
 Josh Snyder
+Julian Berman
 Julian Krause
 Jurko Gospodnetić
 Krisztian Fekete

--- a/docs/changelog/1092.misc.rst
+++ b/docs/changelog/1092.misc.rst
@@ -1,0 +1,1 @@
+Don't warn when PYTHONPATH is present but empty - by :user:`Julian`.

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -387,7 +387,7 @@ class VirtualEnv(object):
             os.environ.pop(key, None)
         if "PYTHONPATH" not in self.envconfig.passenv:
             # If PYTHONPATH not explicitly asked for, remove it.
-            if "PYTHONPATH" in os.environ:
+            if os.environ.get("PYTHONPATH"):
                 self.session.report.warning(
                     "Discarding $PYTHONPATH from environment, to override "
                     "specify PYTHONPATH in 'passenv' in your configuration."


### PR DESCRIPTION
Some users (e.g. me :) have an always set [but empty] PYTHONPATH
(for reasons like supporting zsh's typeset -T). Since Python's own
behavior is the same in this case as having the env var unset,
tox shouldn't warn.

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
