### PR TITLE
Correctly fail `tox --notest` when setup fails

### DIFF
--- a/docs/changelog/1097.bugfix.rst
+++ b/docs/changelog/1097.bugfix.rst
@@ -1,0 +1,1 @@
+Correctly fail ``tox --notest`` when setup fails.

--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -608,7 +608,7 @@ class Session:
         envlog.set_installed(packages)
 
     def runtestenv(self, venv, redirect=False):
-        if self.config.option.notest:
+        if venv.status == 0 and self.config.option.notest:
             venv.status = "skipped tests"
         else:
             if venv.status:

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -737,6 +737,22 @@ def test_notest(initproj, cmd):
     assert re.match(r".*py26\W+reusing.*", result.out, re.DOTALL)
 
 
+def test_notest_setup_py_error(initproj, cmd):
+    initproj(
+        "example123",
+        filedefs={
+            "setup.py": """\
+                from setuptools import setup
+                setup(name='x', install_requires=['fakefakefakefakefakefake']),
+            """,
+            "tox.ini": "",
+        },
+    )
+    result = cmd("--notest")
+    assert result.ret
+    assert re.search("ERROR:.*InvocationError", result.out)
+
+
 def test_PYC(initproj, cmd, monkeypatch):
     initproj("example123", filedefs={"tox.ini": ""})
     monkeypatch.setenv("PYTHONDOWNWRITEBYTECODE", 1)


### PR DESCRIPTION
Resolves #1097 