### PR TITLE
Clarify that extras are not installed if skip_install is False

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -485,7 +485,8 @@ Complete list of settings that you can put into ``testenv*`` sections:
 
     A list of "extras" to be installed with the sdist or develop install.
     For example, ``extras = testing`` is equivalent to ``[testing]`` in a
-    ``pip install`` command.
+    ``pip install`` command. These are not installed if ``skip_install`` is
+    ``false``.
 
 .. conf:: description ^ SINGLE-LINE-TEXT ^ no description
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -486,7 +486,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
     A list of "extras" to be installed with the sdist or develop install.
     For example, ``extras = testing`` is equivalent to ``[testing]`` in a
     ``pip install`` command. These are not installed if ``skip_install`` is
-    ``false``.
+    ``true``.
 
 .. conf:: description ^ SINGLE-LINE-TEXT ^ no description
 


### PR DESCRIPTION
When `skip_install` is `False`, then any dependencies listed using `extras` are not installed.


## Contribution checklist:

(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)

- [ x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
