### PR TITLE
inject the built package as a environment variable

### DIFF
--- a/docs/changelog/1081.feature.rst
+++ b/docs/changelog/1081.feature.rst
@@ -1,0 +1,1 @@
+if the packaging phase successfully builds a package set it as environment variable under ``TOX_PACKAGE`` (useful to make assertions on the built package itself, instead of just how it ends up after installation) - by :user:`gaborbernat`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -896,6 +896,7 @@ tox will inject the following environment variables that you can use to test tha
 - ``TOX_WORK_DIR`` env var is set to the tox work directory
 - ``TOX_ENV_NAME`` is set to the current running tox environment name
 - ``TOX_ENV_DIR`` is set to the current tox environments working dir.
+- ``TOX_PACKAGE`` the packaging phases outcome path (useful to inspect and make assertion of the built package itself).
 
 :note: this applies for all tox envs (isolated packaging too) and all external
  commands called (e.g. install command - pip).

--- a/src/tox/session.py
+++ b/src/tox/session.py
@@ -577,6 +577,7 @@ class Session:
                     venv.package = self.hook.tox_package(session=self, venv=venv)
                     if not venv.package:
                         return 2
+                    venv.envconfig.setenv[str("TOX_PACKAGE")] = str(venv.package)
         if self.config.option.sdistonly:
             return
         for venv in self.venvlist:

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -104,3 +104,19 @@ def test_make_sdist(initproj):
     _, sdist_new = get_package(Session(config))
     assert sdist_new == sdist
     assert sdist_new.stat().size > 10
+
+
+def test_package_inject(initproj, cmd, monkeypatch, tmp_path):
+    monkeypatch.delenv(str("PYTHONPATH"), raising=False)
+    initproj(
+        "example123-0.5",
+        filedefs={
+            "tox.ini": """
+            [testenv:py]
+            passenv = PYTHONPATH
+            commands = python -c 'import os; assert os.path.exists(os.environ["TOX_PACKAGE"])'
+        """
+        },
+    )
+    result = cmd("-q")
+    assert result.session.getvenv("py").envconfig.setenv.get("TOX_PACKAGE")


### PR DESCRIPTION
When trying to fix https://github.com/pypa/virtualenv/pull/909 I realized there's no easy parallel safe way to run tests/inspect the package generated during the packaging phase. This allows this by exposing the installed raw package. This will allow users to write tests (aka that look into the sdist) that assert expectations of the package.