### PR TITLE
Add short name to --skip-missing-interpreters as -s

### DIFF
--- a/docs/changelog/1119.feature.rst
+++ b/docs/changelog/1119.feature.rst
@@ -1,0 +1,1 @@
+Added command line shortcut ``-s`` for ``--skip-missing-interpreters`` - by :user:`evandrocoan`

--- a/src/tox/config.py
+++ b/src/tox/config.py
@@ -809,6 +809,7 @@ def cli_skip_missing_interpreter(parser):
             setattr(namespace, self.dest, value)
 
     parser.add_argument(
+        "-s",
         "--skip-missing-interpreters",
         default="config",
         metavar="val",


### PR DESCRIPTION
Related to:
1. https://github.com/tox-dev/tox/issues/672 --result-json does not respect --skip-missing-interpreters-option