### PR TITLE
Used relative paths instead of absolute URLs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,18 +5,18 @@ much about the checklist - we will help you get started.
 
 ## Contribution checklist:
 
-(also see [CONTRIBUTING.rst](https://github.com/tox-dev/tox/tree/master/CONTRIBUTING.rst) for details)
+(also see [CONTRIBUTING.rst](/CONTRIBUTING.rst) for details)
 
 - [ ] wrote descriptive pull request text
 - [ ] added/updated test(s)
 - [ ] updated/extended the documentation
 - [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
       in message body
-- [ ] added news fragment in [changelog folder](https://github.com/tox-dev/tox/tree/master/docs/changelog)
+- [ ] added news fragment in [changelog folder](/docs/changelog)
   * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
   * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
   * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
   * "sign" fragment with "by @<your username>"
   * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
-  * also see [examples](https://github.com/tox-dev/tox/tree/master/changelog/examples.rst)
+  * also see [examples](/docs/changelog/examples.rst)
 - [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)

--- a/docs/changelog/1120.doc.rst
+++ b/docs/changelog/1120.doc.rst
@@ -1,0 +1,2 @@
+Set to PULL_REQUEST_TEMPLATE.md use relative instead of absolute URLs - by :user:`evandrocoan`
+Fixed PULL_REQUEST_TEMPLATE.md path for changelog/examples.rst to docs/changelog/examples.rst - by :user:`evandrocoan`


### PR DESCRIPTION
Also fixed .github/PULL_REQUEST_TEMPLATE.md path for changelog/examples.rst to docs/changelog/examples.rst