### PR TITLE
Improve accuracy of _alwayscopy_not_supported()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     setup_requires=["setuptools-scm>2, <4"],  # readthedocs needs it
     extras_require={
         "testing": [
-            "distro",
             "pytest >= 3.0.0, <4",
             "pytest-cov >= 2.5.1, <3",
             "pytest-mock >= 1.10.0, <2",

--- a/tox.ini
+++ b/tox.ini
@@ -145,7 +145,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 line_length = 99
 known_first_party = tox,tests
-known_third_party = apiclient,distro,docutils,filelock,git,httplib2,oauth2client,packaging,pkg_resources,pluggy,py,pytest,setuptools,six,sphinx,toml
+known_third_party = apiclient,docutils,filelock,git,httplib2,oauth2client,packaging,pkg_resources,pluggy,py,pytest,setuptools,six,sphinx,toml
 
 [testenv:release]
 description = do a release, required posarg of the version number


### PR DESCRIPTION
Previously, this function checked against a whitelist of OSes that were
known to be a problem. This did include Fedora, which also fails this
test. Rather than chasing endless edge cases, test for this feature
programmatically.