### PR TITLE
fix #1153 by adding an additional test for single digit versions

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Ionel Maries Cristian
 Itxaka Serrano
 Jake Windle
 Jannis Leidel
+Joachim Brandon LeBlanc
 Johannes Christ
 Jon Dufresne
 Josh Smeaton

--- a/docs/changelog/1153.bugfix.rst
+++ b/docs/changelog/1153.bugfix.rst
@@ -1,0 +1,1 @@
+Using ``py2`` and ``py3`` with a specific ``basepython`` will no longer raise a warning unless the major version conflicts - by :user:`demosdemon`.

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -571,7 +571,8 @@ def tox_addoption(parser):
                 proposed_version = "".join(
                     str(i) for i in python_info_for_proposed.version_info[0:2]
                 )
-                if implied_version != proposed_version:
+                # '27'.startswith('2') or '27'.startswith('27')
+                if not proposed_version.startswith(implied_version):
                     # TODO(stephenfin): Raise an exception here in tox 4.0
                     warnings.warn(
                         "conflicting basepython version (set {}, should be {}) for env '{}';"


### PR DESCRIPTION
Fixes #1153 by adding an additional test for single digit py versions

## Contribution checklist:

(also see [CONTRIBUTING.rst](/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](/docs/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
