### PR TITLE
-eALL should also include environment from envlist

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@ Eugene Yunak
 Fernando L. Pereira
 Florian Preinstorfer
 Florian Schulze
+Gonéri Le Bouder
 Hazal Ozturk
 Henk-Jaap Wagenaar
 Ian Stapleton Cordasco

--- a/docs/changelog/1155.bugix.rst
+++ b/docs/changelog/1155.bugix.rst
@@ -1,0 +1,1 @@
+The ``-eALL`` command line argument now expands the ``envlist`` key and includes all its environment.

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2065,7 +2065,7 @@ class TestGlobalOptions:
         config = newconfig([], "")
         assert not config.sdistsrc
 
-    def test_env_selection(self, newconfig, monkeypatch):
+    def test_env_selection_with_section_name(self, newconfig, monkeypatch):
         inisource = """
             [tox]
             envlist = py36
@@ -2090,6 +2090,18 @@ class TestGlobalOptions:
         assert config.envlist == ["py36", "py35", "py27"]
         config = newconfig(["-espam"], inisource)
         assert config.envlist == ["spam"]
+
+    def test_env_selection_expanded_envlist(self, newconfig, monkeypatch):
+        inisource = """
+            [tox]
+            envlist = py{36,35,27}
+            [testenv:py36]
+            basepython=python3.6
+        """
+        config = newconfig([], inisource)
+        assert config.envlist == ["py36", "py35", "py27"]
+        config = newconfig(["-eALL"], inisource)
+        assert config.envlist == ["py36", "py35", "py27"]
 
     def test_py_venv(self, newconfig):
         config = newconfig(["-epy"], "")


### PR DESCRIPTION
According to the `--help` output, `-eALL` should work against specified
environments (ALL selects all). However, the environments from the
envlist key were ignored if they were not associated with a section.

For instance, with:
```
[tox]
envlist = py{a,b}
```

No environment was selected, and the default `python` was used instead.
With this patch, `tox` with test both `a` and `b`.