### PR TITLE
Fix typo

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include CONTRIBUTORS
 include LICENSE
 include setup.py
 include tox.ini
-graft doc
+graft docs
 graft tests
 
 global-exclude __pycache__


### PR DESCRIPTION
## Thanks for contributing a pull request!
You are welcome :-) I hope its not a complete mess.

While investigating a broken build ( https://travis-ci.org/zopefoundation/Products.OFSP/jobs/487391552#L510 )  due to a failed installation of tox 3.6.0, I grepped the tox source code for "doc" without "s" and found "graft doc" in manifest.in.

As there is no "doc" directory, this must be a typo, right?

The official docs (https://docs.python.org/2/distutils/sourcedist.html#commands) are not 100% clear about whether graft also makes usw of explicit or implicit globbing.

Best


If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](/docs/changelog/examples.rst)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)