### PR TITLE
Fix missing error for `tox -e unknown` when tox.ini declares envlist.

### DIFF
--- a/docs/changelog/1160.bugfix.rst
+++ b/docs/changelog/1160.bugfix.rst
@@ -1,0 +1,1 @@
+Fix missing error for ``tox -e unknown`` when tox.ini declares ``envlist``. - by :user:`medmunds`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1053,7 +1053,7 @@ class ParseIni(object):
         # factors stated in config envlist
         stated_envlist = reader.getstring("envlist", replace=False)
         if stated_envlist:
-            for env in config.envlist:
+            for env in _split_env(stated_envlist):
                 known_factors.update(env.split("-"))
 
         # configure testenvs

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2147,6 +2147,15 @@ class TestGlobalOptions:
         env = config.envconfigs["py"]
         assert str(env.basepython) == sys.executable
 
+    def test_no_implicit_venv_from_cli_with_envlist(self, newconfig):
+        # See issue 1160.
+        inisource = """
+            [tox]
+            envlist = stated-factors
+        """
+        config = newconfig(["-etypo-factor"], inisource)
+        assert "typo-factor" not in config.envconfigs
+
     def test_correct_basepython_chosen_from_default_factors(self, newconfig):
         envlist = list(tox.PYTHON.DEFAULT_FACTORS.keys())
         config = newconfig([], "[tox]\nenvlist={}".format(", ".join(envlist)))

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -281,11 +281,15 @@ def test_unknown_environment(cmd, initproj):
 
 
 def test_unknown_environment_with_envlist(cmd, initproj):
-    initproj("pkg123", filedefs={
-        "tox.ini": """
+    initproj(
+        "pkg123",
+        filedefs={
+            "tox.ini": """
             [tox]
             envlist = py{36,37}-django{20,21}
-        """})
+        """
+        },
+    )
     result = cmd("-e", "py36-djagno21")
     assert result.ret, "{}\n{}".format(result.err, result.out)
     assert result.out == "ERROR: unknown environment 'py36-djagno21'\n"

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -280,6 +280,17 @@ def test_unknown_environment(cmd, initproj):
     assert result.out == "ERROR: unknown environment 'qpwoei'\n"
 
 
+def test_unknown_environment_with_envlist(cmd, initproj):
+    initproj("pkg123", filedefs={
+        "tox.ini": """
+            [tox]
+            envlist = py{36,37}-django{20,21}
+        """})
+    result = cmd("-e", "py36-djagno21")
+    assert result.ret, "{}\n{}".format(result.err, result.out)
+    assert result.out == "ERROR: unknown environment 'py36-djagno21'\n"
+
+
 def test_minimal_setup_py_empty(cmd, initproj):
     initproj(
         "pkg123-0.7",


### PR DESCRIPTION
Fix tox 3.7.0 injection where "unknown environment" error is not raised when the command line (or TOXENV) requests unknown factors and tox.ini includes an envlist.

Fixes #1160.

## Contribution checklist:

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- N/A updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](/docs/changelog)
- N/A added yourself to `CONTRIBUTORS` (preserving alphabetical order)
