### PR TITLE
Fix ResourceWarning: unclosed file in Action

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -53,6 +53,7 @@ Matt Good
 Matt Jeffery
 Mattieu Agopian
 Michael Manganiello
+Mickaël Schoentgen
 Mikhail Kyshtymov
 Monty Taylor
 Morgan Fainberg

--- a/docs/changelog/1179.bugfix.rst
+++ b/docs/changelog/1179.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a ``ResourceWarning: unclosed file`` in ``Action`` - by :user:`BoboTiG`.

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -463,7 +463,8 @@ def test_json(cmd, example123):
     jsonpath = example123.join("res.json")
     result = cmd("--result-json", jsonpath)
     assert result.ret == 1, "{}\n{}".format(result.err, result.out)
-    data = json.load(jsonpath.open("r"))
+    with jsonpath.open("r") as f:
+        data = json.load(f)
     verify_json_report_format(data)
     assert re.match(
         r".*\W+1\W+failed.*" r"summary.*" r"python:\W+commands\W+failed.*", result.out, re.DOTALL


### PR DESCRIPTION
Hello,

Here is a patch to fix an annoying `ResourceWarning: unclosed file` I have on several projects when using tox. I did not find something better, but I am open to suggestions :)

FTR I used this fixture to ensure the fix is working well:
```python
@pytest.fixture(autouse=True)
def no_warnings(recwarn):
    """Fail on warning."""

    yield

    warnings = []
    for warning in recwarn:  # pragma: no cover
        warnings.append("{w.filename}:{w.lineno} {w.message}".format(w=warning))
    assert not warnings
```

When encountering the related error, we could see this kind of warning:
```python
tox/venv.py:545 unclosed file <_io.BufferedReader name='/tmp/pytest-of-tiger-222/pytest-55/popen-gw2/test_config_current_py0/.tox/py36/log/py36-0.log'>
```

I can add the fixture to the PR if you are interested (although it will need more work as there are other warnings while running the tests suite).

## Contribution checklist:

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] added news fragment in [changelog folder](/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)