### PR TITLE
Parallel arg bug, remove broken arg cleanup code

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -68,6 +68,7 @@ Selim Belhaouane
 Stephen Finucane
 Sridhar Ratnakumar
 Sviatoslav Sydorenko
+Tim Laurence
 Ville Skyttä
 Xander Johnson
 anatoly techtonik

--- a/docs/changelog/1192.bugfix.rst
+++ b/docs/changelog/1192.bugfix.rst
@@ -1,1 +1,1 @@
-Fix for difference in output between ``--parallel`` and ``-p`` when using ``posargs`` - by :user:`timdaman`
+Removed code that sometimes caused a difference in results between ``--parallel`` and ``-p`` when using ``posargs`` - by :user:`timdaman`

--- a/docs/changelog/1192.bugfix.rst
+++ b/docs/changelog/1192.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for difference in output between ``--parallel`` and ``-p`` when using ``posargs`` - by :user:`timdaman`

--- a/src/tox/session/commands/run/parallel.py
+++ b/src/tox/session/commands/run/parallel.py
@@ -17,12 +17,6 @@ def run_parallel(config, venv_dict):
         position = args.index("--")
     except ValueError:
         position = len(args)
-    try:
-        parallel_at = args[0:position].index("--parallel")
-        del args[parallel_at]
-        position -= 1
-    except ValueError:
-        pass
 
     max_parallel = config.option.parallel
     if max_parallel is None:

--- a/tests/unit/package/test_package_parallel.py
+++ b/tests/unit/package/test_package_parallel.py
@@ -7,7 +7,9 @@ import pytest
 from tox.session.commands.run import sequential
 
 
-@pytest.mark.skipif(platform.python_implementation() == "pypy", reason="this is flaky on pypy")
+@pytest.mark.skipif(
+    platform.python_implementation().lower() == "pypy", reason="this is flaky on pypy"
+)
 def test_tox_parallel_build_safe(initproj, cmd, mock_venv, monkeypatch):
     initproj(
         "env_var_test",


### PR DESCRIPTION
This resolves issue #1192 where the argument to --parallel was sometimes being passed as a `posarg`

Fixes: #1192 