### PR TITLE
Fix #1236 typos in isolated.py build method

### DIFF
--- a/docs/changelog/1236.bugfix.rst
+++ b/docs/changelog/1236.bugfix.rst
@@ -1,0 +1,1 @@
+fix typos in isolated.py that made it impossible to install package with requirements in pyproject.toml - by :user:`unmade`

--- a/src/tox/package/builder/isolated.py
+++ b/src/tox/package/builder/isolated.py
@@ -38,9 +38,9 @@ def build(config, session):
         if pkg_resources.Requirement(r).key not in base_build_deps
     ]
     if build_requires_dep:
-        with package_venv.newaction("build_requires", package_venv.envconfig.envdir) as action:
+        with package_venv.new_action("build_requires", package_venv.envconfig.envdir) as action:
             package_venv.run_install_command(packages=build_requires_dep, action=action)
-        package_venv.finishvenv(package_venv)
+        package_venv.finishvenv()
     return perform_isolated_build(build_info, package_venv, config.distdir, config.setupdir)
 
 

--- a/tests/integration/test_package_int.py
+++ b/tests/integration/test_package_int.py
@@ -53,6 +53,9 @@ def test_package_flit(initproj, cmd):
                     author = "Happy Harry"
                     author-email = "happy@harry.com"
                     home-page = "https://github.com/happy-harry/is"
+                    requires = [
+                        "tox",
+                    ]
                     """,
             ".gitignore": ".tox",
         },

--- a/tests/integration/test_provision_int.py
+++ b/tests/integration/test_provision_int.py
@@ -9,6 +9,10 @@ from pathlib2 import Path
 from tox.util.main import MAIN_FILE
 
 
+@pytest.mark.skipif(
+    "sys.platform == 'win32' and sys.version_info < (3,)",
+    reason="does not run on windows with py2",
+)
 def test_provision_missing(initproj, cmd):
     initproj(
         "pkg123-0.7",


### PR DESCRIPTION
Hi, there!

There are typos in [tox/package/builder/isolated.py](https://github.com/tox-dev/tox/blob/master/src/tox/package/builder/isolated.py#L41) making it **impossible** to install package with requirements in pyproject.toml

I've been using tox (3.7.0) with flit as a build backend. After upgrading to tox 3.8 I keep getting an error whenever try to run tox. 

It seems like during refactoring there have been made some typos. I made two commits:

1. first commit with failing test, so you can see how to reproduce bug
2. second commit fixes typos
