### PR TITLE
Jenkins 2.0 renamed "slave" to "agent"

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1399,7 +1399,7 @@ v1.0
   for test commands (thanks Chris Rose)
 - fix `#22 <https://github.com/tox-dev/tox/issues/22>`_: require virtualenv-1.6.1, obsoleting virtualenv5 (thanks Jannis Leidel)
   and making things work with pypy-1.5 and python3 more seamlessly
-- toxbootstrap.py (used by jenkins build slaves) now follows the latest release of virtualenv
+- toxbootstrap.py (used by jenkins build agents) now follows the latest release of virtualenv
 - fix `#20 <https://github.com/tox-dev/tox/issues/20>`_: document format of URLs for specifying dependencies
 - fix `#19 <https://github.com/tox-dev/tox/issues/19>`_: substitute Hudson for Jenkins everywhere following the renaming
   of the project.  NOTE: if you used the special [tox:hudson]

--- a/docs/example/jenkins.rst
+++ b/docs/example/jenkins.rst
@@ -6,7 +6,7 @@ Using Jenkins multi-configuration jobs
 
 The Jenkins_ continuous integration server allows to define "jobs" with
 "build steps" which can be test invocations.  If you :doc:`install <../install>` ``tox`` on your
-default Python installation on each Jenkins slave, you can easily create
+default Python installation on each Jenkins agent, you can easily create
 a Jenkins multi-configuration job that will drive your tox runs from the CI-server side,
 using these steps:
 
@@ -42,7 +42,7 @@ for example with ``pytest`` it is done like this:
 
 
 
-**zero-installation** for slaves
+**zero-installation** for agents
 -------------------------------------------------------------
 
 .. note::
@@ -51,7 +51,7 @@ for example with ``pytest`` it is done like this:
     has been removed.  Please file an issue if you'd like to
     see it back.
 
-If you manage many Jenkins slaves and want to use the latest officially
+If you manage many Jenkins agents and want to use the latest officially
 released tox (or latest development version) and want to skip manually
 installing ``tox`` then substitute the above **Python build step** code
 with this:


### PR DESCRIPTION
See e.g. https://issues.jenkins-ci.org/browse/JENKINS-42816