### PR TITLE
Fix over-precise float formatting on Python 3

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,6 @@
-Alexander Schepanovski
 Alex Grönholm
 Alexander Loechel
+Alexander Schepanovski
 Alexandre Conrad
 Allan Feldman
 Andrii Soldatenko
@@ -47,6 +47,7 @@ Lukasz Rogalski
 Manuel Jacob
 Marc Abramowitz
 Marc Schlaich
+Marius Gedminas
 Mariusz Rusiniak
 Mark Hirota
 Matt Good
@@ -65,8 +66,8 @@ Pierre-Luc Tessier Gagné
 Ronald Evers
 Ronny Pfannschmidt
 Selim Belhaouane
-Stephen Finucane
 Sridhar Ratnakumar
+Stephen Finucane
 Sviatoslav Sydorenko
 Tim Laurence
 Ville Skyttä

--- a/docs/changelog/1241.bugfix.rst
+++ b/docs/changelog/1241.bugfix.rst
@@ -1,0 +1,1 @@
+Do not print timings with more than 3 decimal digits on Python 3 - by :user:`mgedmin`.

--- a/src/tox/util/spinner.py
+++ b/src/tox/util/spinner.py
@@ -167,7 +167,7 @@ def td_human_readable(delta):
             period_value, seconds = divmod(seconds, period_seconds)
             if period_name == "second":
                 ms = delta.total_seconds() - int(delta.total_seconds())
-                period_value += round(ms, 3)
-            has_s = "s" if period_value > 1 else ""
+                period_value = round(period_value + ms, 3)
+            has_s = "s" if period_value != 1 else ""
             texts.append("{} {}{}".format(period_value, period_name, has_s))
     return ", ".join(texts)

--- a/tests/unit/util/test_spinner.py
+++ b/tests/unit/util/test_spinner.py
@@ -4,7 +4,9 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import time
+import datetime
 
+import pytest
 from freezegun import freeze_time
 
 from tox.util import spinner
@@ -70,9 +72,9 @@ def test_spinner_report(capfd, monkeypatch):
     lines = out.split(os.linesep)
     del lines[0]
     expected = [
-        "\r{}✔ OK ok in 0.0 second".format(spin.CLEAR_LINE),
-        "\r{}✖ FAIL fail in 0.0 second".format(spin.CLEAR_LINE),
-        "\r{}⚠ SKIP skip in 0.0 second".format(spin.CLEAR_LINE),
+        "\r{}✔ OK ok in 0.0 seconds".format(spin.CLEAR_LINE),
+        "\r{}✖ FAIL fail in 0.0 seconds".format(spin.CLEAR_LINE),
+        "\r{}⚠ SKIP skip in 0.0 seconds".format(spin.CLEAR_LINE),
         "\r{}".format(spin.CLEAR_LINE),
     ]
     assert lines == expected
@@ -106,3 +108,17 @@ def test_spinner_stdout_not_unicode(capfd, monkeypatch):
     out, err = capfd.readouterr()
     assert not err
     assert all(f in out for f in spin.frames)
+
+
+@pytest.mark.parametrize('seconds, expected', [
+    (0, '0.0 seconds'),
+    (1.0, '1.0 second'),
+    (4.0, '4.0 seconds'),
+    (4.130, '4.13 seconds'),
+    (4.137, '4.137 seconds'),
+    (42.12345, '42.123 seconds'),
+    (61, '1 minute, 1.0 second'),
+])
+def test_td_human_readable(seconds, expected):
+    dt = datetime.timedelta(seconds=seconds)
+    assert spinner.td_human_readable(dt) == expected

--- a/tests/unit/util/test_spinner.py
+++ b/tests/unit/util/test_spinner.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
+import datetime
 import os
 import sys
 import time
-import datetime
 
 import pytest
 from freezegun import freeze_time
@@ -110,15 +110,18 @@ def test_spinner_stdout_not_unicode(capfd, monkeypatch):
     assert all(f in out for f in spin.frames)
 
 
-@pytest.mark.parametrize('seconds, expected', [
-    (0, '0.0 seconds'),
-    (1.0, '1.0 second'),
-    (4.0, '4.0 seconds'),
-    (4.130, '4.13 seconds'),
-    (4.137, '4.137 seconds'),
-    (42.12345, '42.123 seconds'),
-    (61, '1 minute, 1.0 second'),
-])
+@pytest.mark.parametrize(
+    "seconds, expected",
+    [
+        (0, "0.0 seconds"),
+        (1.0, "1.0 second"),
+        (4.0, "4.0 seconds"),
+        (4.130, "4.13 seconds"),
+        (4.137, "4.137 seconds"),
+        (42.12345, "42.123 seconds"),
+        (61, "1 minute, 1.0 second"),
+    ],
+)
 def test_td_human_readable(seconds, expected):
     dt = datetime.timedelta(seconds=seconds)
     assert spinner.td_human_readable(dt) == expected


### PR DESCRIPTION
Sometimes tox would tell me things like

    ✔ OK py27 in 4.1370000000000005 seconds
    ✔ OK py36 in 14.5 seconds
    ✔ OK py37 in 15.029 seconds
    ✔ OK py35 in 17.519 seconds
    ✔ OK py34 in 18.85 seconds

the almost-rounded-to-3-decimals value was both funny and sad, but mostly irritating.

This was happening because on Python 3 float.\_\_str\_\_ was changed to be more precise, and now

    >>> print(4 + 0.137)
    4.1370000000000005

We can avoid the problem if we round the result of the addition instead of adding a rounded number to the integer number of seconds:

    >>> print(4.137)
    4.137

I've also corrected the plural logic because "0.5 second" is wrong:
https://ell.stackexchange.com/questions/7817/singular-or-plural-for-seconds

## Contribution checklist:

(also see [CONTRIBUTING.rst](/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] ~~updated/extended the documentation~~ -- not applicable, I think
- [ ] ~~added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body~~ -- I've filed no issue and found no existing issue for this
- [x] added news fragment in [changelog folder](/docs/changelog) -- 
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](/docs/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
