### PR TITLE
🔥 Cut comments off dependency lines

### DIFF
--- a/docs/changelog/1262.feature.rst
+++ b/docs/changelog/1262.feature.rst
@@ -1,1 +1,1 @@
-Allow having inline comments in dependency lists in ``tox.ini`` — by :user:`webknjaz`
+Allow having inline comments in :conf:`deps` — by :user:`webknjaz`

--- a/docs/changelog/1262.feature.rst
+++ b/docs/changelog/1262.feature.rst
@@ -1,0 +1,1 @@
+Allow having inline comments in dependency lists in ``tox.ini`` — by :user:`webknjaz`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -360,6 +360,20 @@ Complete list of settings that you can put into ``testenv*`` sections:
     (Experimentally introduced in 1.6.1) all installer commands are executed
     using the ``{toxinidir}`` as the current working directory.
 
+    .. note::
+
+        .. versionadded:: 3.9.0
+
+        As of tox v3.9.0 deps entries having inline comments are
+        supported. During post-processing stage, tox cuts off any
+        substring starting with any number of whitespaces followed by
+        a ``#`` character.
+
+        For example, if a dependency is ``octomachinery==0.0.13  # pyup:
+        < 0.1.0 # disable feature updates`` it will be turned into just
+        ``octomachinery==0.0.13`` which later will be used in the ``pip
+        install`` command.
+
 .. conf:: platform ^ REGEX
 
     .. versionadded:: 2.0

--- a/docs/example/package.rst
+++ b/docs/example/package.rst
@@ -4,13 +4,12 @@ packaging
 Although one can use tox to develop and test applications one of its most popular
 usage is to help library creators. Libraries need first to be packaged, so then
 they can be installed inside a virtual environment for testing. To help with this
-tox implements `PEP-517 <https://www.python.org/dev/peps/pep-0517/>`_ and
-`PEP-518 <https://www.python.org/dev/peps/pep-0518/>`_. This means that by default
+tox implements PEP-517_ and PEP-518_. This means that by default
 tox will build source distribution out of source trees. Before running test commands
 ``pip`` is used to install the source distribution inside the build environment.
 
-To create a source distribution there are multiple tools out there and with ``PEP-517``
-and ``PEP-518`` you can easily use your favorite one with tox. Historically tox
+To create a source distribution there are multiple tools out there and with PEP-517_ and PEP-518_
+you can easily use your favorite one with tox. Historically tox
 only supported ``setuptools``, and always used the tox host environment to build
 a source distribution from the source tree. This is still the default behavior.
 To opt out of this behaviour you need to set isolated builds to true.
@@ -37,7 +36,7 @@ build requirements.
 
 flit
 ----
-`flit <https://flit.readthedocs.io/en/latest/>`_ requires ``Python 3``, however the generated source
+flit_ requires ``Python 3``, however the generated source
 distribution can be installed under ``python 2``. Furthermore it does not require a ``setup.py``
 file as that information is also added to the ``pyproject.toml`` file.
 
@@ -68,7 +67,7 @@ file as that information is also added to the ``pyproject.toml`` file.
 
 poetry
 ------
-`poetry <https://poetry.eustace.io/>`_ requires ``Python 3``, however the generated source
+poetry_ requires ``Python 3``, however the generated source
 distribution can be installed under ``python 2``. Furthermore it does not require a ``setup.py``
 file as that information is also added to the ``pyproject.toml`` file.
 
@@ -95,3 +94,5 @@ file as that information is also added to the ``pyproject.toml`` file.
    # so unless this is python 3 you can require a given python version for the packaging
    # environment via the basepython key
    basepython = python3
+
+.. include:: ../links.rst

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -9,6 +9,7 @@
 .. _`nose`: https://pypi.org/project/nose
 .. _`Holger Krekel`: https://twitter.com/hpk42
 .. _`pytest-xdist`: https://pypi.org/project/pytest-xdist
+.. _ConfigParser: https://docs.python.org/3/library/configparser.html
 
 .. _`easy_install`: http://peak.telecommunity.com/DevCenter/EasyInstall
 .. _pip: https://pypi.org/project/pip
@@ -18,7 +19,13 @@
 .. _discover: https://pypi.org/project/discover
 .. _unittest2: https://pypi.org/project/unittest2
 .. _mock: https://pypi.org/project/mock/
+.. _flit: https://flit.readthedocs.io/en/latest/
+.. _poetry: https://poetry.eustace.io/
 .. _pypy: https://pypy.org
 
 .. _`Python Packaging Guide`: https://packaging.python.org/tutorials/packaging-projects/
 .. _`tox.ini`: :doc:configfile
+
+.. _`PEP-508`: https://www.python.org/dev/peps/pep-0508/
+.. _`PEP-517`: https://www.python.org/dev/peps/pep-0517/
+.. _`PEP-518`: https://www.python.org/dev/peps/pep-0518/

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,8 +64,9 @@ testing =
     pytest-xdist >= 1.22.2, <2
     pytest-randomly >= 1.2.3, <2
     psutil >= 5.6.1, < 6; python_version != "3.4"
+    flaky >= 3.4.0, < 4
 docs =
-    sphinx >= 1.8.0, < 2
+    sphinx >= 2.0.0, < 3
     towncrier >= 18.5.0
     pygments-github-lexers >= 0.0.5
     sphinxcontrib-autoprogram >= 0.1.5

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -179,7 +179,7 @@ class DepOption:
 
     @staticmethod
     def _cut_off_dep_comment(name):
-        return re.sub(r'\s+#.*', '', name).strip()
+        return re.sub(r"\s+#.*", "", name).strip()
 
     @classmethod
     def _is_same_dep(cls, dep1, dep2):

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -158,6 +158,7 @@ class DepOption:
                     name_start = "{} ".format(option)
                     if name.startswith(name_start):
                         name = "{}={}".format(option, name[len(option) :].strip())
+            name = self._cut_off_dep_comment(name)
             name = self._replace_forced_dep(name, config)
             deps.append(DepConfig(name, ixserver))
         return deps
@@ -175,6 +176,10 @@ class DepOption:
             if self._is_same_dep(forced_dep, name):
                 return forced_dep
         return name
+
+    @staticmethod
+    def _cut_off_dep_comment(name):
+        return re.sub(r'\s+#.*', '', name).strip()
 
     @classmethod
     def _is_same_dep(cls, dep1, dep2):

--- a/tests/integration/test_parallel_interrupt.py
+++ b/tests/integration/test_parallel_interrupt.py
@@ -6,11 +6,13 @@ import sys
 from datetime import datetime
 
 import pytest
+from flaky import flaky
 from pathlib2 import Path
 
 from tox.util.main import MAIN_FILE
 
 
+@flaky(max_runs=3)
 @pytest.mark.skipif(
     "sys.platform == 'win32'", reason="triggering SIGINT reliably on Windows is hard"
 )

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -144,6 +144,7 @@ class TestVenvConfig:
                 -r requirements.txt
                 yapf>=0.25.0,<0.27  # pyup: < 0.27 # disable updates
                 --index-url https://pypi.org/simple
+                pywin32 >=1.0 ; sys_platform == '#my-magic-platform' or sys_platform == 'your-#-platform' # so what now 
                 -fhttps://pypi.org/packages
                 --global-option=foo
                 -v dep1
@@ -154,6 +155,7 @@ class TestVenvConfig:
             "-rrequirements.txt",
             "yapf>=0.25.0,<0.27",
             "--index-url=https://pypi.org/simple",
+            "pywin32 >=1.0 ; sys_platform == '#my-magic-platform' or sys_platform == 'your-#-platform'",
             "-fhttps://pypi.org/packages",
             "--global-option=foo",
             "-v dep1",

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -142,6 +142,7 @@ class TestVenvConfig:
             [testenv]
             deps =
                 -r requirements.txt
+                yapf>=0.25.0,<0.27  # pyup: < 0.27 # disable updates
                 --index-url https://pypi.org/simple
                 -fhttps://pypi.org/packages
                 --global-option=foo
@@ -151,6 +152,7 @@ class TestVenvConfig:
         )  # note that those last two are invalid
         expected_deps = [
             "-rrequirements.txt",
+            "yapf>=0.25.0,<0.27",
             "--index-url=https://pypi.org/simple",
             "-fhttps://pypi.org/packages",
             "--global-option=foo",

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -144,7 +144,7 @@ class TestVenvConfig:
                 -r requirements.txt
                 yapf>=0.25.0,<0.27  # pyup: < 0.27 # disable updates
                 --index-url https://pypi.org/simple
-                pywin32 >=1.0 ; sys_platform == '#my-magic-platform' or sys_platform == 'your-#-platform' # so what now 
+                pywin32 >=1.0 ; sys_platform == '#my-magic-platform' # so what now
                 -fhttps://pypi.org/packages
                 --global-option=foo
                 -v dep1
@@ -155,7 +155,7 @@ class TestVenvConfig:
             "-rrequirements.txt",
             "yapf>=0.25.0,<0.27",
             "--index-url=https://pypi.org/simple",
-            "pywin32 >=1.0 ; sys_platform == '#my-magic-platform' or sys_platform == 'your-#-platform'",
+            "pywin32 >=1.0 ; sys_platform == '#my-magic-platform'",
             "-fhttps://pypi.org/packages",
             "--global-option=foo",
             "-v dep1",

--- a/tests/unit/package/test_package_parallel.py
+++ b/tests/unit/package/test_package_parallel.py
@@ -1,16 +1,13 @@
 import os
-import platform
 import traceback
 
 import py
-import pytest
+from flaky import flaky
 
 from tox.session.commands.run import sequential
 
 
-@pytest.mark.skipif(
-    platform.python_implementation().lower() == "pypy", reason="this is flaky on pypy"
-)
+@flaky(max_runs=3)
 def test_tox_parallel_build_safe(initproj, cmd, mock_venv, monkeypatch):
     initproj(
         "env_var_test",

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,7 @@ source = src/tox
          *\src\tox
 
 [pytest]
-addopts = -ra --showlocals
+addopts = -ra --showlocals --no-success-flaky-report
 rsyncdirs = tests tox
 looponfailroots = tox tests
 testpaths = tests
@@ -136,7 +136,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 line_length = 99
 known_first_party = tox,tests
-known_third_party = apiclient,docutils,filelock,freezegun,git,httplib2,oauth2client,packaging,pathlib2,pkg_resources,pluggy,py,pytest,setuptools,six,sphinx,toml
+known_third_party = apiclient,docutils,filelock,flaky,freezegun,git,httplib2,oauth2client,packaging,pathlib2,pkg_resources,pluggy,py,pytest,setuptools,six,sphinx,toml
 
 [testenv:release]
 description = do a release, required posarg of the version number


### PR DESCRIPTION
This enables users to have inline comments in deps lines in `tox.ini`. In particular, this allows having pyup bot integration.

Ref: https://github.com/pyupio/dparse/issues/34
Ref: https://github.com/ansible/molecule/issues/1973

Fixes #1260

## Contribution checklist:

(also see [CONTRIBUTING.rst](/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](/docs/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
