### PR TITLE
do not allow setting the ``TOXENV`` or the ``-e` flag to override the listed default environment variables, these show up under extra

### DIFF
--- a/docs/changelog/720.bugfix.rst
+++ b/docs/changelog/720.bugfix.rst
@@ -1,0 +1,1 @@
+fix for ``tox -l`` command: do not allow setting the ``TOXENV`` or the ``-e`` flag to override the listed default environment variables, they still show up under extra if non defined target - by :user:`gaborbernat`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1058,7 +1058,7 @@ class ParseIni(object):
         self.handle_provision(config, reader)
 
         self.parse_build_isolation(config, reader)
-        config.envlist, all_envs = self._getenvdata(reader, config)
+        config.envlist, all_envs, config.envlist_default = self._getenvdata(reader, config)
 
         # factors used in config or predefined
         known_factors = self._list_section_factors("testenv")
@@ -1243,7 +1243,7 @@ class ParseIni(object):
         if config.isolated_build is True and package_env in env_list:
             msg = "isolated_build_env {} cannot be part of envlist".format(package_env)
             raise tox.exception.ConfigError(msg)
-        return env_list, all_envs
+        return env_list, all_envs, _split_env(from_config)
 
 
 def _split_env(env):

--- a/src/tox/session/commands/show_env.py
+++ b/src/tox/session/commands/show_env.py
@@ -5,7 +5,7 @@ from tox import reporter as report
 
 def show_envs(config, all_envs=False, description=False):
     env_conf = config.envconfigs  # this contains all environments
-    default = config.envlist  # this only the defaults
+    default = config.envlist_default  # this only the defaults
     ignore = {config.isolated_build_env, config.provision_tox_env}.union(default)
     extra = [e for e in env_conf if e not in ignore] if all_envs else []
 

--- a/tests/unit/session/test_list_env.py
+++ b/tests/unit/session/test_list_env.py
@@ -20,6 +20,18 @@ def test_listenvs(cmd, initproj, monkeypatch):
         """
         },
     )
+
+    result = cmd("-l")
+    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs"]
+
+    result = cmd("-l", "-e", "py")
+    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs"]
+
+    monkeypatch.setenv(str("TOXENV"), str("py"))
+    result = cmd("-l")
+    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs"]
+
+    monkeypatch.setenv(str("TOXENV"), str("py36"))
     result = cmd("-l")
     assert result.outlines == ["py36", "py27", "py34", "pypi", "docs"]
 
@@ -60,7 +72,7 @@ def test_listenvs_verbose_description(cmd, initproj):
     assert result.outlines[2:] == expected
 
 
-def test_listenvs_all(cmd, initproj):
+def test_listenvs_all(cmd, initproj, monkeypatch):
     initproj(
         "listenvs_all",
         filedefs={
@@ -79,6 +91,17 @@ def test_listenvs_all(cmd, initproj):
     result = cmd("-a")
     expected = ["py36", "py27", "py34", "pypi", "docs", "notincluded"]
     assert result.outlines == expected
+
+    result = cmd("-a", "-e", "py")
+    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs", "py", "notincluded"]
+
+    monkeypatch.setenv(str("TOXENV"), str("py"))
+    result = cmd("-a")
+    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs", "py", "notincluded"]
+
+    monkeypatch.setenv(str("TOXENV"), str("py36"))
+    result = cmd("-a")
+    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs", "notincluded"]
 
 
 def test_listenvs_all_verbose_description(cmd, initproj):


### PR DESCRIPTION
Resolves #720.