### PR TITLE
move to improved Azure template

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
       py34:
         image: [linux, windows, macOs]
       dev: null
-      package_description: null 
+      package_description: null
     coverage:
       with_toxenv: 'coverage' # generate .tox/.coverage, .tox/coverage.xml after test run
       for_envs: [py37, py36, py35, py34, py27]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,8 +32,6 @@ jobs:
       package_description: null
       dev: null
       py37:
-        before:
-        - script: py.exe -0
         image: [linux, windows, macOs]
       py36:
         image: [linux, windows, macOs]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,4 @@
 name: $(BuildDefinitionName)_$(Date:yyyyMMdd)$(Rev:.rr)
-
 resources:
   repositories:
   - repository: tox
@@ -26,41 +25,31 @@ variables:
 jobs:
 - template: run-tox-env.yml@tox
   parameters:
+    tox_version: ''
     jobs:
-      check:
-        py: '3.7'
-        toxenvs:
-        - fix_lint
-        - docs
-        - package_description
-      windows:
-        coverage: 'coverage'
-        toxenvs:
-        - py37
-        - py36
-        - py35
-        - py34
-        - py27
-      linux:
-        coverage: 'coverage'
-        toxenvs:
-        - py38
-        - py37
-        - py36
-        - py35
-        - py34
-        - py27
-      macOs:
-        coverage: 'coverage'
-        toxenvs:
-        - py37
-        - py27
+      fix_lint: null
+      docs: null
+      package_description: null
+      dev: null
+      py37:
+        before:
+        - script: py.exe -0
+        image: [linux, windows, macOs]
+      py36:
+        image: [linux, windows, macOs]
+      py35:
+        image: [linux, windows, macOs]
+      py34:
+        image: [linux, windows, macOs]
+      py27:
+        image: [linux, windows, macOs]
+    env:
+    - key: [py27, py34, py35, py36, py37]
+      coverage: 'coverage'
+
 - template: merge-coverage.yml@tox
   parameters:
-    dependsOn:
-    - windows
-    - linux
-    - macOs
+    dependsOn: [py27, py34, py35, py36, py37]
 
 - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
   - template: publish-pypi.yml@tox

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,9 +29,9 @@ jobs:
     jobs:
       fix_lint: null
       docs: null
-      package_description: null
-      dev: null
       py37:
+        image: [linux, windows, macOs]
+      py27:
         image: [linux, windows, macOs]
       py36:
         image: [linux, windows, macOs]
@@ -39,21 +39,15 @@ jobs:
         image: [linux, windows, macOs]
       py34:
         image: [linux, windows, macOs]
-      py27:
-        image: [linux, windows, macOs]
-    env:
-    - key: [py27, py34, py35, py36, py37]
-      coverage: 'coverage'
-
-- template: merge-coverage.yml@tox
-  parameters:
-    dependsOn: [py27, py34, py35, py36, py37]
+      dev: null
+      package_description: null 
+    coverage:
+      with_toxenv: 'coverage' # generate .tox/.coverage, .tox/coverage.xml after test run
+      for_envs: [py37, py36, py35, py34, py27]
 
 - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
   - template: publish-pypi.yml@tox
     parameters:
     - external_feed: 'toxdev'
     - pypi_remote: 'pypi-toxdev'
-    - dependsOn:
-      - check
-      - report_coverage
+    - dependsOn: [fix_lint, docs, package_description, dev, report_coverage]

--- a/docs/changelog/1290.feature.rst
+++ b/docs/changelog/1290.feature.rst
@@ -1,1 +1,18 @@
-Improve python discovery by also checking if the the ``python`` executable on PATH is correct version.
+Improve python discovery and add architecture support:
+ - UNIX:
+
+   - First, check if the tox host Python matches.
+   - Second, check if the the canonical name (e.g. ``python3.7``, ``python3``) matches or the base python is an absolute path, use that.
+   - Third, check if the the canonical name without version matches (e.g. ``python``, ``pypy``) matches.
+
+ - Windows:
+
+   - First, check if the tox host Python matches.
+   - Second, use the ``py.exe`` to list registered interpreters and any of those match.
+   - Third, check if the the canonical name (e.g. ``python3.7``, ``python3``) matches or the base python is an absolute path, use that.
+   - Fourth, check if the the canonical name without version matches (e.g. ``python``, ``pypy``) matches.
+   - Finally, check for known locations (``c:\python{major}{minor}\python.exe``).
+
+
+tox environment configuration generation is now done in parallel (to alleviate the slowdown due to extra
+checks).

--- a/docs/changelog/1290.feature.rst
+++ b/docs/changelog/1290.feature.rst
@@ -1,0 +1,1 @@
+Improve python discovery by also checking if the the ``python`` executable on PATH is correct version.

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -8,10 +8,12 @@ import re
 import shlex
 import string
 import sys
+import traceback
 import warnings
 from collections import OrderedDict
 from fnmatch import fnmatchcase
 from subprocess import list2cmdline
+from threading import Thread
 
 import pkg_resources
 import pluggy
@@ -28,6 +30,7 @@ from tox.reporter import (
     using,
     verbosity1,
 )
+from tox.util.path import ensure_empty_dir
 
 from .parallel import ENV_VAR_KEY as PARALLEL_ENV_VAR_KEY
 from .parallel import add_parallel_config, add_parallel_flags
@@ -1036,6 +1039,9 @@ class ParseIni(object):
         config.sdistsrc = reader.getpath("sdistsrc", None)
         config.setupdir = reader.getpath("setupdir", "{toxinidir}")
         config.logdir = config.toxworkdir.join("log")
+        within_parallel = PARALLEL_ENV_VAR_KEY in os.environ
+        if not within_parallel:
+            ensure_empty_dir(config.logdir)
 
         # determine indexserver dictionary
         config.indexserver = {"default": IndexServerConfig("default")}
@@ -1084,6 +1090,16 @@ class ParseIni(object):
                 known_factors.update(env.split("-"))
 
         # configure testenvs
+        to_do = []
+        failures = {}
+        cur_self = self
+
+        def run(name, section, subs, config):
+            try:
+                config.envconfigs[name] = cur_self.make_envconfig(name, section, subs, config)
+            except Exception as exception:
+                failures[name] = (exception, traceback.format_exc())
+
         for name in all_envs:
             section = "{}{}".format(testenvprefix, name)
             factors = set(name.split("-"))
@@ -1094,7 +1110,21 @@ class ParseIni(object):
                     tox.PYTHON.PY_FACTORS_RE.match(factor) for factor in factors - known_factors
                 )
             ):
-                config.envconfigs[name] = self.make_envconfig(name, section, reader._subs, config)
+                thread = Thread(target=run, args=(name, section, reader._subs, config))
+                thread.daemon = True
+                thread.start()
+                to_do.append(thread)
+        for thread in to_do:
+            while thread.is_alive():
+                thread.join(timeout=20)
+        if failures:
+            raise tox.exception.ConfigError(
+                "\n".join(
+                    "{} failed with {} at {}".format(key, exc, trace)
+                    for key, (exc, trace) in failures.items()
+                )
+            )
+
         all_develop = all(
             name in config.envconfigs and config.envconfigs[name].usedevelop
             for name in config.envlist

--- a/src/tox/constants.py
+++ b/src/tox/constants.py
@@ -46,6 +46,7 @@ class INFO:
     DEFAULT_CONFIG_NAME = "tox.ini"
     CONFIG_CANDIDATES = ("pyproject.toml", "tox.ini", "setup.cfg")
     IS_WIN = sys.platform == "win32"
+    IS_PYPY = hasattr(sys, "pypy_version_info")
 
 
 class PIP:

--- a/src/tox/helper/get_version.py
+++ b/src/tox/helper/get_version.py
@@ -5,8 +5,10 @@ import sys
 
 info = {
     "executable": sys.executable,
+    "name": "pypy" if hasattr(sys, "pypy_version_info") else "python",
     "version_info": list(sys.version_info),
     "version": sys.version,
+    "is_64": sys.maxsize > 2 ** 32,
     "sysplatform": sys.platform,
 }
 info_as_dump = json.dumps(info)

--- a/src/tox/interpreters.py
+++ b/src/tox/interpreters.py
@@ -226,6 +226,7 @@ else:
             if spec.name == "python":
                 # The standard names are in predictable places.
                 candidates.append(r"c:\python{}{}\python.exe".format(spec.major, spec.minor))
+        print('candidates', candidates)
         return check_with_path(candidates, spec)
 
     _PY_AVAILABLE = []

--- a/src/tox/interpreters.py
+++ b/src/tox/interpreters.py
@@ -54,7 +54,7 @@ class Interpreters:
         try:
             res = exec_on_interpreter(str(info.executable), SITE_PACKAGE_QUERY_SCRIPT, str(envdir))
         except ExecFailed as e:
-            print("execution failed: {} -- {}".format(e.out, e.err))
+            reporter.verbosity1("execution failed: {} -- {}".format(e.out, e.err))
             return ""
         else:
             return res["dir"]
@@ -226,7 +226,6 @@ else:
             if spec.name == "python":
                 # The standard names are in predictable places.
                 candidates.append(r"c:\python{}{}\python.exe".format(spec.major, spec.minor))
-        print('candidates', candidates)
         return check_with_path(candidates, spec)
 
     _PY_AVAILABLE = []
@@ -273,6 +272,7 @@ def check_with_path(candidates, spec):
         base = path
         if not os.path.isabs(path):
             path = py.path.local.sysfind(path)
+            reporter.verbosity2(("path found", path))
         if path is not None:
             if os.path.exists(str(path)):
                 cur_spec = exe_spec(path, base)

--- a/src/tox/session/__init__.py
+++ b/src/tox/session/__init__.py
@@ -24,7 +24,6 @@ from tox.logs.result import ResultLog
 from tox.reporter import update_default_reporter
 from tox.util import set_os_env_var
 from tox.util.graph import stable_topological_sort
-from tox.util.path import ensure_empty_dir
 from tox.util.stdlib import suppress_output
 from tox.venv import VirtualEnv
 
@@ -62,7 +61,6 @@ def main(args):
     try:
         config = load_config(args)
         config.logdir.ensure(dir=1)
-        ensure_empty_dir(config.logdir)
         with set_os_env_var("TOX_WORK_DIR", config.toxworkdir):
             session = build_session(config)
             exit_code = session.runcommand()

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1773,7 +1773,7 @@ class TestConfigTestEnv:
             deps=
                 {[testing:pytest]deps}
         """
-        with pytest.raises(ValueError):
+        with pytest.raises(tox.exception.ConfigError):
             newconfig([], inisource)
 
     def test_single_value_from_other_secton(self, newconfig, tmpdir):

--- a/tests/unit/session/test_parallel.py
+++ b/tests/unit/session/test_parallel.py
@@ -30,6 +30,7 @@ def test_parallel(cmd, initproj):
     result.assert_success()
 
 
+@flaky(max_runs=3)
 def test_parallel_live(cmd, initproj):
     initproj(
         "pkg123-0.7",

--- a/tests/unit/test_interpreters.py
+++ b/tests/unit/test_interpreters.py
@@ -83,23 +83,19 @@ def test_tox_get_python_executable():
 
 @pytest.mark.skipif(not hasattr(os, "symlink"), reason="no symlink")
 def test_find_alias_on_path(monkeypatch, tmp_path):
-    try:
-        magic = tmp_path / "magic"
-        os.symlink(sys.executable, str(magic))
-    except OSError:
-        pass
-    else:
-        monkeypatch.setenv(
-            str("PATH"),
-            os.pathsep.join(([str(tmp_path)] + os.environ.get(str("PATH"), "").split(os.pathsep))),
-        )
+    magic = tmp_path / "magic{}".format(os.path.splitext(sys.executable)[1])
+    os.symlink(sys.executable, str(magic))
+    monkeypatch.setenv(
+        str("PATH"),
+        os.pathsep.join(([str(tmp_path)] + os.environ.get(str("PATH"), "").split(os.pathsep))),
+    )
 
-        class envconfig:
-            basepython = "magic"
-            envname = "pyxx"
+    class envconfig:
+        basepython = "magic"
+        envname = "pyxx"
 
-        t = tox_get_python_executable(envconfig)
-        assert t == str(magic)
+    t = tox_get_python_executable(envconfig).lower()
+    assert t == str(magic).lower()
 
 
 def test_run_and_get_interpreter_info():

--- a/tests/unit/test_interpreters.py
+++ b/tests/unit/test_interpreters.py
@@ -59,9 +59,9 @@ def test_locate_via_py(monkeypatch):
     monkeypatch.setattr(distutils.spawn, "find_executable", fake_find_exe)
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
     assert locate_via_py("3", "6") == sys.executable
-    assert fake_popen.last_call == ("py", "-3.6", inspect.getsourcefile(get_version))
+    assert fake_popen.last_call == ["py", "-3.6", inspect.getsourcefile(get_version)]
     assert locate_via_py("3") == sys.executable
-    assert fake_popen.last_call == ("py", "-3", inspect.getsourcefile(get_version))
+    assert fake_popen.last_call == ["py", "-3", inspect.getsourcefile(get_version)]
 
 
 def test_tox_get_python_executable():
@@ -97,7 +97,8 @@ def test_tox_get_python_executable():
     for major in (2, 3):
         name = "python{}".format(major)
         if tox.INFO.IS_WIN:
-            if subprocess.call(("py", "-{}".format(major), "-c", "")):
+            error_code = subprocess.call(("py", "-{}".format(major), "-c", ""))
+            if error_code:
                 continue
         elif not py.path.local.sysfind(name):
             continue

--- a/tests/unit/test_interpreters.py
+++ b/tests/unit/test_interpreters.py
@@ -6,6 +6,7 @@ import py
 import pytest
 
 import tox
+from tox import reporter
 from tox._pytestplugin import mark_dont_run_on_posix
 from tox.config import get_plugin_manager
 from tox.interpreters import (
@@ -16,6 +17,7 @@ from tox.interpreters import (
     run_and_get_interpreter_info,
     tox_get_python_executable,
 )
+from tox.reporter import Verbosity
 
 
 @pytest.fixture(name="interpreters")
@@ -81,8 +83,9 @@ def test_tox_get_python_executable():
         assert_version_in_output(exe, str(major))
 
 
-@pytest.mark.skipif(not hasattr(os, "symlink"), reason="no symlink")
+@pytest.mark.skipif("sys.platform == 'win32'", reason="symlink execution unreliable on Windows")
 def test_find_alias_on_path(monkeypatch, tmp_path):
+    reporter.update_default_reporter(Verbosity.DEFAULT, Verbosity.DEBUG)
     magic = tmp_path / "magic{}".format(os.path.splitext(sys.executable)[1])
     os.symlink(sys.executable, str(magic))
     monkeypatch.setenv(

--- a/tests/unit/test_interpreters.py
+++ b/tests/unit/test_interpreters.py
@@ -94,6 +94,9 @@ def test_find_alias_on_path(monkeypatch, tmp_path):
         basepython = "magic"
         envname = "pyxx"
 
+    detected = py.path.local.sysfind("magic")
+    assert detected
+
     t = tox_get_python_executable(envconfig).lower()
     assert t == str(magic).lower()
 

--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -42,7 +42,7 @@ def test_getsupportedinterpreter(monkeypatch, newconfig, mocksession):
         venv.getsupportedinterpreter()
     monkeypatch.undo()
     monkeypatch.setattr(venv.envconfig, "envname", "py1")
-    monkeypatch.setattr(venv.envconfig, "basepython", "notexistingpython")
+    monkeypatch.setattr(venv.envconfig, "basepython", "notexisting")
     with pytest.raises(tox.exception.InterpreterNotFound):
         venv.getsupportedinterpreter()
     monkeypatch.undo()

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv = PIP_DISABLE_VERSION_CHECK = 1
          COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
          VIRTUALENV_NO_DOWNLOAD = 1
 passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE PYTEST_*
-deps =
+deps = pip == 19.0.3
 extras = testing
 commands = pytest \
            --cov "{envsitepackagesdir}/tox" \


### PR DESCRIPTION
The first iteration of the template turned out to be not that flexible when you needed to customize things. This one also has support for inline tox installation (eat our own dog food) and separates the tox host from the target Python (in preparation of python 2 EOL). This separation also proved we can't detect when python is on path... but not python3.5... So fixed that with it.