### PR TITLE
Update Black URLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/ambv/black
+-   repo: https://github.com/python/black
     rev: 19.3b0
     hooks:
     -   id: black

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ status](https://dev.azure.com/toxdev/tox/_apis/build/status/tox%20ci?branchName=
 [![Documentation
 status](https://readthedocs.org/projects/tox/badge/?version=latest&style=flat-square)](https://tox.readthedocs.io/en/latest/?badge=latest)
 [![Code style:
-black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 <a href="https://tox.readthedocs.io">
     <img src="https://raw.githubusercontent.com/tox-dev/tox/master/docs/_static/img/tox.png"


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project
> created with the community in mind from Day 1. Today we moved it under
> the PSF umbrella. It's now available on GitHub under
> https://github.com/python/black/ . You install and use it just like
> before.

https://twitter.com/llanga/status/1123980466292445190