### PR TITLE
show config now shows all config, filter-able, contains host tox python and package versions

### DIFF
--- a/docs/changelog/1298.feature.rst
+++ b/docs/changelog/1298.feature.rst
@@ -1,0 +1,11 @@
+``--showconfig`` overhaul:
+
+- now fully generated via the config parser, so anyone can load it by using the built-in python config parser
+- the ``tox`` section contains all configuration data from config
+- the ``tox`` section contains a ``host_python`` key detailing the path of the host python
+- the ``tox:version`` section contains the versions of all packages tox depends on with their version
+- passing ``-l`` now allows only listing default target envs
+- allows showing config for a given set of tox environments only via the ``-e`` cli flag or the ``TOXENV`` environment
+  variable, in this case the ``tox`` and ``tox:version`` section is only shown if at least one verbosity flag is passed
+
+this should help inspecting the options.

--- a/src/tox/session/commands/show_config.py
+++ b/src/tox/session/commands/show_config.py
@@ -1,31 +1,77 @@
-import subprocess
 import sys
+from collections import OrderedDict
 
-from tox import reporter as report
-from tox.version import __version__
+from six import StringIO
+from six.moves import configparser
+
+from tox import reporter
+
+DO_NOT_SHOW_CONFIG_ATTRIBUTES = (
+    "interpreters",
+    "envconfigs",
+    "envlist",
+    "pluginmanager",
+    "envlist_explicit",
+)
 
 
 def show_config(config):
-    info_versions()
-    report.keyvalue("config-file:", config.option.configfile)
-    report.keyvalue("toxinipath: ", config.toxinipath)
-    report.keyvalue("toxinidir:  ", config.toxinidir)
-    report.keyvalue("toxworkdir: ", config.toxworkdir)
-    report.keyvalue("setupdir:   ", config.setupdir)
-    report.keyvalue("distshare:  ", config.distshare)
-    report.keyvalue("skipsdist:  ", config.skipsdist)
-    report.line("")
-    for envconfig in config.envconfigs.values():
-        report.line("[testenv:{}]".format(envconfig.envname), bold=True)
-        for attr in config._parser._testenv_attr:
-            report.line("  {:<15} = {}".format(attr.name, getattr(envconfig, attr.name)))
+    parser = configparser.ConfigParser()
+
+    if not config.envlist_explicit or reporter.verbosity() >= reporter.Verbosity.INFO:
+        tox_info(config, parser)
+        version_info(parser)
+    tox_envs_info(config, parser)
+
+    content = StringIO()
+    parser.write(content)
+    value = content.getvalue().rstrip()
+    reporter.verbosity0(value)
 
 
-def info_versions():
-    versions = ["tox-{}".format(__version__)]
-    proc = subprocess.Popen(
-        (sys.executable, "-m", "virtualenv", "--version"), stdout=subprocess.PIPE
+def tox_envs_info(config, parser):
+    if config.envlist_explicit:
+        env_list = config.envlist
+    elif config.option.listenvs:
+        env_list = config.envlist_default
+    else:
+        env_list = list(config.envconfigs.keys())
+    for name in env_list:
+        env_config = config.envconfigs[name]
+        values = OrderedDict(
+            (attr.name, str(getattr(env_config, attr.name)))
+            for attr in config._parser._testenv_attr
+        )
+        section = "testenv:{}".format(name)
+        set_section(parser, section, values)
+
+
+def tox_info(config, parser):
+    info = OrderedDict(
+        (i, str(getattr(config, i)))
+        for i in sorted(dir(config))
+        if not i.startswith("_") and i not in DO_NOT_SHOW_CONFIG_ATTRIBUTES
     )
-    out, _ = proc.communicate()
-    versions.append("virtualenv-{}".format(out.decode("UTF-8").strip()))
-    report.keyvalue("tool-versions:", " ".join(versions))
+    info["host_python"] = sys.executable
+    set_section(parser, "tox", info)
+
+
+def version_info(parser):
+    import pkg_resources
+
+    versions = OrderedDict()
+    visited = set()
+    to_visit = {"tox"}
+    while to_visit:
+        current = to_visit.pop()
+        visited.add(current)
+        current_dist = pkg_resources.get_distribution(current)
+        to_visit.update(i.name for i in current_dist.requires() if i.name not in visited)
+        versions[current] = current_dist.version
+    set_section(parser, "tox:versions", versions)
+
+
+def set_section(parser, section, values):
+    parser.add_section(section)
+    for key, value in values.items():
+        parser.set(section, key, value)

--- a/tests/unit/session/test_show_config.py
+++ b/tests/unit/session/test_show_config.py
@@ -1,0 +1,117 @@
+import py
+import pytest
+from six import StringIO
+from six.moves import configparser
+
+
+def load_config(args, cmd):
+    result = cmd(*args)
+    result.assert_success(is_run_test_env=False)
+    parser = configparser.ConfigParser()
+    output = StringIO(result.out)
+    parser.readfp(output)
+    return parser
+
+
+def test_showconfig_with_force_dep_version(cmd, initproj):
+    initproj(
+        "force_dep_version",
+        filedefs={
+            "tox.ini": """
+        [tox]
+
+        [testenv]
+        deps=
+            dep1==2.3
+            dep2
+        """
+        },
+    )
+    parser = load_config(("--showconfig",), cmd)
+    assert parser.get("testenv:python", "deps") == "[dep1==2.3, dep2]"
+
+    parser = load_config(("--showconfig", "--force-dep=dep1", "--force-dep=dep2==5.0"), cmd)
+    assert parser.get("testenv:python", "deps") == "[dep1, dep2==5.0]"
+
+
+@pytest.fixture()
+def setup_mixed_conf(initproj):
+    initproj(
+        "force_dep_version",
+        filedefs={
+            "tox.ini": """
+            [tox]
+            envlist = py37,py27,pypi,docs
+
+            [testenv:notincluded]
+            changedir = whatever
+
+            [testenv:docs]
+            changedir = docs
+            """
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (
+            ["--showconfig"],
+            [
+                "tox",
+                "tox:versions",
+                "testenv:py37",
+                "testenv:py27",
+                "testenv:pypi",
+                "testenv:docs",
+                "testenv:notincluded",
+            ],
+        ),
+        (
+            ["--showconfig", "-l"],
+            [
+                "tox",
+                "tox:versions",
+                "testenv:py37",
+                "testenv:py27",
+                "testenv:pypi",
+                "testenv:docs",
+            ],
+        ),
+        (["--showconfig", "-e", "py37,py36"], ["testenv:py37", "testenv:py36"]),
+    ],
+    ids=["all", "default_only", "-e"],
+)
+def test_showconfig(cmd, setup_mixed_conf, args, expected):
+    parser = load_config(args, cmd)
+    found_sections = parser.sections()
+    assert found_sections == expected
+
+
+def test_config_specific_ini(tmpdir, cmd):
+    ini = tmpdir.ensure("hello.ini")
+    output = load_config(("-c", ini, "--showconfig"), cmd)
+    assert output.get("tox", "toxinipath") == ini
+
+
+def test_override_workdir(cmd, initproj):
+    baddir = "badworkdir-123"
+    gooddir = "overridden-234"
+    initproj(
+        "overrideworkdir-0.5",
+        filedefs={
+            "tox.ini": """
+        [tox]
+        toxworkdir={}
+        """.format(
+                baddir
+            )
+        },
+    )
+    result = cmd("--workdir", gooddir, "--showconfig")
+    assert not result.ret
+    assert gooddir in result.out
+    assert baddir not in result.out
+    assert py.path.local(gooddir).check()
+    assert not py.path.local(baddir).check()

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv = PIP_DISABLE_VERSION_CHECK = 1
          COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
          VIRTUALENV_NO_DOWNLOAD = 1
 passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE PYTEST_*
-deps = pip == 19.0.3
+deps = pip == 19.1.1
 extras = testing
 commands = pytest \
            --cov "{envsitepackagesdir}/tox" \


### PR DESCRIPTION
``--showconfig`` overhaul:

 - now fully generated via the config parser, so anyone can load it by using the built-in python config parser
- the ``tox`` section contains all configuration data from config
- the ``tox`` section contains a ``host_python`` key detailing the path of the host python
- the ``tox:version`` section contains the versions of all packages tox depends on with their version
- passing ``-l`` now allows only listing default target envs
- allows showing config for a given set of tox environments only via the ``-e`` cli flag or the ``TOXENV`` environment variable, in this case the ``tox`` and ``tox:version`` section is only shown if at least one verbosity flag is passed