### PR TITLE
Fixed result of tox_get_python_executable not being used to make virtualenvs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,6 +6,7 @@ Allan Feldman
 Andrii Soldatenko
 Anthon van der Neuth
 Anthony Sottile
+Ashley Whetter
 Asmund Grammeltwedt
 Barry Warsaw
 Bartolome Sanchez Salado

--- a/docs/changelog/1301.bugfix.rst
+++ b/docs/changelog/1301.bugfix.rst
@@ -1,0 +1,1 @@
+When creating virtual environments we no longer ask the python to tell its path, but rather use the discovered path.

--- a/src/tox/interpreters.py
+++ b/src/tox/interpreters.py
@@ -67,6 +67,7 @@ def run_and_get_interpreter_info(name, executable):
         result["version_info"] = tuple(result["version_info"])  # fix json dump transformation
         del result["name"]
         del result["version"]
+        result["executable"] = str(executable)
     except ExecFailed as e:
         return NoInterpreterInfo(name, executable=e.executable, out=e.out, err=e.err)
     else:

--- a/src/tox/logs/env.py
+++ b/src/tox/logs/env.py
@@ -20,6 +20,7 @@ class EnvLog(object):
         cmd = [str(python_executable), VERSION_QUERY_SCRIPT]
         result = subprocess.check_output(cmd, universal_newlines=True)
         answer = json.loads(result)
+        answer["executable"] = python_executable
         self.dict["python"] = answer
 
     def get_commandlog(self, name):

--- a/tests/unit/test_interpreters.py
+++ b/tests/unit/test_interpreters.py
@@ -147,7 +147,7 @@ class TestInterpreters:
             "#!{executable}\n"
             "import subprocess\n"
             "import sys\n"
-            "sys.exit(subprocess.call([\"{executable}\"] + sys.argv[1:]))\n"
+            'sys.exit(subprocess.call(["{executable}"] + sys.argv[1:]))\n'
         ).format(executable=sys.executable)
         magic.write_text(wrapper)
         magic.chmod(magic.stat().st_mode | stat.S_IEXEC)


### PR DESCRIPTION
The result of `tox_get_python_executable` hooks are again used to create the virtualenvs.

Fixes #1300 