### PR TITLE
Fix for --result-json with --parallel

### DIFF
--- a/docs/changelog/1184.feature.rst
+++ b/docs/changelog/1184.feature.rst
@@ -1,1 +1,1 @@
-Adding ```TOX_PARALLEL_NO_SPINNER``` environment variable to disable the spinner in parallel mode for the purposes of clean output when using CI tools - by :user:`zeroshift`
+Adding ``TOX_PARALLEL_NO_SPINNER`` environment variable to disable the spinner in parallel mode for the purposes of clean output when using CI tools - by :user:`zeroshift`

--- a/docs/changelog/1295.bugfix.rst
+++ b/docs/changelog/1295.bugfix.rst
@@ -1,1 +1,1 @@
-When using ``--parallel`` with ``--result-json`` the test results are now included the same way as with serial runs - by @fschulze
+When using ``--parallel`` with ``--result-json`` the test results are now included the same way as with serial runs - by :user:`fschulze`

--- a/docs/changelog/1295.bugfix.rst
+++ b/docs/changelog/1295.bugfix.rst
@@ -1,0 +1,1 @@
+When using ``--parallel`` with ``--result-json`` the test results are now included the same way as with serial runs - by @fschulze

--- a/src/tox/constants.py
+++ b/src/tox/constants.py
@@ -86,3 +86,5 @@ VERSION_QUERY_SCRIPT = os.path.join(_HELP_DIR, "get_version.py")
 SITE_PACKAGE_QUERY_SCRIPT = os.path.join(_HELP_DIR, "get_site_package_dir.py")
 BUILD_REQUIRE_SCRIPT = os.path.join(_HELP_DIR, "build_requires.py")
 BUILD_ISOLATED = os.path.join(_HELP_DIR, "build_isolated.py")
+PARALLEL_RESULT_JSON_PREFIX = ".tox-result"
+PARALLEL_RESULT_JSON_SUFFIX = ".json"

--- a/src/tox/session/commands/run/parallel.py
+++ b/src/tox/session/commands/run/parallel.py
@@ -42,6 +42,9 @@ def run_parallel(config, venv_dict):
                 if hasattr(tox_env, "package"):
                     args_sub.insert(position, str(tox_env.package))
                     args_sub.insert(position, "--installpkg")
+                if tox_env.get_result_json_path():
+                    result_json_index = args_sub.index("--result-json")
+                    args_sub[result_json_index + 1] = "{}".format(tox_env.get_result_json_path())
                 with tox_env.new_action("parallel {}".format(tox_env.name)) as action:
 
                     def collect_process(process):

--- a/src/tox/util/lock.py
+++ b/src/tox/util/lock.py
@@ -36,6 +36,6 @@ def get_unique_file(path, prefix, suffix):
                 max_value = max(max_value, int(candidate.basename[len(prefix) : -len(suffix)]))
             except ValueError:
                 continue
-        winner = path.join("{}{}.log".format(prefix, max_value + 1))
+        winner = path.join("{}{}{}".format(prefix, max_value + 1, suffix))
         winner.ensure(dir=0)
         return winner

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -13,7 +13,9 @@ import tox
 from tox import reporter
 from tox.action import Action
 from tox.config.parallel import ENV_VAR_KEY as PARALLEL_ENV_VAR_KEY
+from tox.constants import PARALLEL_RESULT_JSON_PREFIX, PARALLEL_RESULT_JSON_SUFFIX
 from tox.package.local import resolve_package
+from tox.util.lock import get_unique_file
 from tox.util.path import ensure_empty_dir
 
 from .config import DepConfig
@@ -113,6 +115,7 @@ class VirtualEnv(object):
         self.popen = popen
         self._actions = []
         self.env_log = env_log
+        self._result_json_path = None
 
     def new_action(self, msg, *args):
         config = self.envconfig.config
@@ -129,6 +132,14 @@ class VirtualEnv(object):
             self.popen,
             self.envconfig.envpython,
         )
+
+    def get_result_json_path(self):
+        if self._result_json_path is None:
+            if self.envconfig.config.option.resultjson:
+                self._result_json_path = get_unique_file(
+                    self.path, PARALLEL_RESULT_JSON_PREFIX, PARALLEL_RESULT_JSON_SUFFIX
+                )
+        return self._result_json_path
 
     @property
     def hook(self):

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -500,7 +500,7 @@ def test_result_json(cmd, initproj, example123):
         assert isinstance(pyinfo["version_info"], list)
         assert pyinfo["version"]
         assert pyinfo["executable"]
-    assert "wrote json report at: {}".format(json_path) == result.outlines[-1]
+    assert "write json report at: {}".format(json_path) == result.outlines[-1]
 
 
 def test_developz(initproj, cmd):


### PR DESCRIPTION
Fix #1295 

When using ``--parallel`` with ``--result-json`` the test results are now included the same way as with serial runs.

This is accomplished by generating json result output for each individual run and at the end copy the data into the main json result output.

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] ~~updated/extended the documentation~~
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if pr has no issue: consider creating one first or change it to the pr number after creating the pr
  * "sign" fragment with "by @<your username>"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](/docs/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
