### PR TITLE
Add environment variable to disable parallel spinner for CI tools

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -60,6 +60,7 @@ Mikhail Kyshtymov
 Monty Taylor
 Morgan Fainberg
 Nick Douma
+Nick Prendergast
 Oliver Bestwalter
 Paweł Adamczak
 Philip Thiem

--- a/docs/changelog/1184.feature.rst
+++ b/docs/changelog/1184.feature.rst
@@ -1,0 +1,1 @@
+Adding ```TOX_PARALLEL_NO_SPINNER``` environment variable to disable the spinner in parallel mode for the purposes of clean output when using CI tools - by :user:`zeroshift`

--- a/src/tox/session/commands/help.py
+++ b/src/tox/session/commands/help.py
@@ -11,3 +11,4 @@ def show_help(config):
         "passed into test command environments"
     )
     reporter.line("PY_COLORS: 0 disable colorized output, 1 enable (default)")
+    reporter.line("TOX_PARALLEL_NO_SPINNER: 1 disable spinner for CI, 0 enable (default)")

--- a/src/tox/session/commands/run/parallel.py
+++ b/src/tox/session/commands/run/parallel.py
@@ -13,6 +13,7 @@ from tox.util.spinner import Spinner
 def run_parallel(config, venv_dict):
     """here we'll just start parallel sub-processes"""
     live_out = config.option.parallel_live
+    disable_spinner = bool(os.environ.get("TOX_PARALLEL_NO_SPINNER") == "1")
     args = [sys.executable, MAIN_FILE] + config.args
     try:
         position = args.index("--")
@@ -25,7 +26,9 @@ def run_parallel(config, venv_dict):
     semaphore = Semaphore(max_parallel)
     finished = Event()
 
-    show_progress = not live_out and reporter.verbosity() > reporter.Verbosity.QUIET
+    show_progress = (
+        not disable_spinner and not live_out and reporter.verbosity() > reporter.Verbosity.QUIET
+    )
 
     with Spinner(enabled=show_progress) as spinner:
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1164,6 +1164,17 @@ class TestConfigTestEnv:
         assert "A1" in env.passenv
         assert "A2" in env.passenv
 
+    def test_no_spinner(self, newconfig, monkeypatch):
+        monkeypatch.setenv("TOX_PARALLEL_NO_SPINNER", "1")
+        config = newconfig(
+            """
+            [testenv]
+            passenv = TOX_PARALLEL_NO_SPINNER
+        """
+        )
+        env = config.envconfigs["python"]
+        assert "TOX_PARALLEL_NO_SPINNER" in env.passenv
+
     def test_changedir_override(self, newconfig):
         config = newconfig(
             """

--- a/tests/unit/session/test_parallel.py
+++ b/tests/unit/session/test_parallel.py
@@ -189,3 +189,28 @@ parallel_show_output = True
     assert "stderr env" not in result.out, result.output()
     assert "stdout always" in result.out, result.output()
     assert "stderr always" in result.out, result.output()
+
+
+def test_parallel_no_spinner(cmd, initproj, monkeypatch):
+    monkeypatch.setenv(str("TOX_PARALLEL_NO_SPINNER"), str("1"))
+    initproj(
+        "pkg123-0.7",
+        filedefs={
+            "tox.ini": """
+            [tox]
+            envlist = a, b
+            isolated_build = true
+            [testenv]
+            commands=python -c "import sys; print(sys.executable)"
+            [testenv:b]
+            depends = a
+        """,
+            "pyproject.toml": """
+            [build-system]
+            requires = ["setuptools >= 35.0.2"]
+            build-backend = 'setuptools.build_meta'
+                        """,
+        },
+    )
+    result = cmd("--parallel", "all")
+    result.assert_success()


### PR DESCRIPTION
Adding TOX_PARALLEL_NO_SPINNER environment variable to disable the spinner for parallel runs. The purpose is to avoid issues with the spinner causing excess logging in CI tools such as Jenkins.

Closes #1184