### PR TITLE
Move to importlib-metadata for performance improvements

### DIFF
--- a/docs/changelog/1324.feature.rst
+++ b/docs/changelog/1324.feature.rst
@@ -1,0 +1,1 @@
+Replace ``pkg_resources`` with ``importlib_metadata`` for speed - by :user:`asottile`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,8 +38,9 @@ classifiers =
 packages = find:
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 install_requires =
-    setuptools  >= 30.0.0
-    pluggy >= 0.3.0, <1
+    importlib-metadata
+    packaging
+    pluggy >= 0.12.0, <1
     py >= 1.4.17, <2
     six >= 1.0.0, <2
     virtualenv >= 14.0.0

--- a/src/tox/package/builder/isolated.py
+++ b/src/tox/package/builder/isolated.py
@@ -3,8 +3,9 @@ from __future__ import unicode_literals
 import json
 from collections import namedtuple
 
-import pkg_resources
 import six
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 from tox import reporter
 from tox.config import DepConfig, get_py_project_toml
@@ -31,11 +32,11 @@ def build(config, session):
 
     build_requires = get_build_requires(build_info, package_venv, config.setupdir)
     # we need to filter out requirements already specified in pyproject.toml or user deps
-    base_build_deps = {pkg_resources.Requirement(r.name).key for r in package_venv.envconfig.deps}
+    base_build_deps = {canonicalize_name(r.name) for r in package_venv.envconfig.deps}
     build_requires_dep = [
         DepConfig(r, None)
         for r in build_requires
-        if pkg_resources.Requirement(r).key not in base_build_deps
+        if canonicalize_name(Requirement(r).name) not in base_build_deps
     ]
     if build_requires_dep:
         with package_venv.new_action("build_requires", package_venv.envconfig.envdir) as action:

--- a/src/tox/package/local.py
+++ b/src/tox/package/local.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-import pkg_resources
+import packaging.version
 import py
 
 import tox
@@ -58,7 +58,6 @@ def get_version_from_filename(basename):
         return None
     version = m.group(1)
     try:
-
-        return pkg_resources.packaging.version.Version(version)
-    except pkg_resources.packaging.version.InvalidVersion:
+        return packaging.version.Version(version)
+    except packaging.version.InvalidVersion:
         return None

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -7,7 +7,6 @@ import sys
 from itertools import chain
 
 import py
-from pkg_resources import to_filename
 
 import tox
 from tox import reporter
@@ -324,7 +323,7 @@ class VirtualEnv(object):
             sys_path = json.loads(out)
         except ValueError:
             sys_path = []
-        egg_info_fname = ".".join((to_filename(name), "egg-info"))
+        egg_info_fname = ".".join((name.replace("-", "_"), "egg-info"))
         for d in reversed(sys_path):
             egg_info = py.path.local(d).join(egg_info_fname)
             if egg_info.check():

--- a/tests/unit/session/test_provision.py
+++ b/tests/unit/session/test_provision.py
@@ -95,7 +95,7 @@ def test_provision_bad_requires(newconfig, capsys, monkeypatch):
         """,
         )
     out, err = capsys.readouterr()
-    assert "ERROR: failed to parse RequirementParseError" in out
+    assert "ERROR: failed to parse InvalidRequirement" in out
     assert not err
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -139,7 +139,7 @@ include_trailing_comma = True
 force_grid_wrap = 0
 line_length = 99
 known_first_party = tox,tests
-known_third_party = apiclient,docutils,filelock,flaky,freezegun,git,httplib2,oauth2client,packaging,pathlib2,pkg_resources,pluggy,py,pytest,setuptools,six,sphinx,toml
+known_third_party = apiclient,docutils,filelock,flaky,freezegun,git,httplib2,importlib_metadata,oauth2client,packaging,pathlib2,pluggy,py,pytest,setuptools,six,sphinx,toml
 
 [testenv:release]
 description = do a release, required posarg of the version number


### PR DESCRIPTION
### setup

(with ~some amount of pip requirements installed -- I used https://github.com/Yelp/paasta as it installs a bunch of things and I know they all build on my machine)

```console
$ pip freeze -l | wc -l
165
```

I used "best of 5" when picking the outputs below -- the version `0.0.0` is because I didn't have `setuptools-scm` when I built the dist -- just ignore that ;)

### before

```console
$ time tox --version
3.12.1 imported from /tmp/paasta/.tox/py/lib/python3.6/site-packages/tox/__init__.py

real	0m0.298s
user	0m0.270s
sys	0m0.029s
```

### after

```console
$ time tox --version
0.0.0 imported from /tmp/paasta/.tox/py/lib/python3.6/site-packages/tox/__init__.py

real	0m0.208s
user	0m0.200s
sys	0m0.008s
```

### savings

~90ms -- so somewhere between 30-40%

## Contribution checklist:

(also see [CONTRIBUTING.rst](/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](/docs/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
