### PR TITLE
Add bounds for importlib-metadata / packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,8 +38,8 @@ classifiers =
 packages = find:
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 install_requires =
-    importlib-metadata
-    packaging
+    importlib-metadata >= 0.12, <1
+    packaging >= 14
     pluggy >= 0.12.0, <1
     py >= 1.4.17, <2
     six >= 1.0.0, <2


### PR DESCRIPTION
`packaging` uses calver so I don't have a reasonable upper bound for it -- I ran the testsuite with the oldest version of packaging on pypi and it passes so I put a lower bound there