### PR TITLE
Documents envlist effect on interpreter lookup

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -68,6 +68,7 @@ Pierre-Luc Tessier Gagné
 Ronald Evers
 Ronny Pfannschmidt
 Selim Belhaouane
+Sorin Sbarnea
 Sridhar Ratnakumar
 Stephen Finucane
 Sviatoslav Sydorenko

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -113,6 +113,10 @@ Global settings are defined under the ``tox`` section as:
         (e.g. ``py27.*`` means **don't** evaluate environments that start with the key ``py27``).
         Skipped environments will be logged at level two verbosity level.
 
+    ``envlist`` is also used to determine the preferrence list of python interpreters. For example
+    ``lint,py{37,36}`` will also tell tox to prefer using python3.7. So when available it will use
+    python3.7 for ``lint`` environment and fallback to python3.6 otherwise.
+
 .. conf:: skip_missing_interpreters ^ config|true|false ^ config
 
     .. versionadded:: 1.7.2


### PR DESCRIPTION
Adds paragraph to tox documentation related to how it determines which python interpreter to use when it creates a new virtualenv.
