### PR TITLE
envconfig.missing_subs is not a setting: should be a private attribute

### DIFF
--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -883,7 +883,7 @@ class TestenvConfig:
         #: set of factors
         self.factors = factors
         self._reader = reader
-        self.missing_subs = []
+        self._missing_subs = []
         """Holds substitutions that could not be resolved.
 
         Pre 2.8.1 missing substitutions crashed with a ConfigError although this would not be a
@@ -1233,7 +1233,7 @@ class ParseIni(object):
                 if env_attr.postprocess:
                     res = env_attr.postprocess(testenv_config=tc, value=res)
             except tox.exception.MissingSubstitution as e:
-                tc.missing_subs.append(e.name)
+                tc._missing_subs.append(e.name)
                 res = e.FLAG
             setattr(tc, env_attr.name, res)
             if atype in ("path", "string", "basepython"):

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -575,11 +575,11 @@ class VirtualEnv(object):
         )
 
     def setupenv(self):
-        if self.envconfig.missing_subs:
+        if self.envconfig._missing_subs:
             self.status = (
                 "unresolvable substitution(s): {}. "
                 "Environment variables are missing or defined recursively.".format(
-                    ",".join(["'{}'".format(m) for m in self.envconfig.missing_subs])
+                    ",".join(["'{}'".format(m) for m in self.envconfig._missing_subs])
                 )
             )
             return

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -556,7 +556,7 @@ class TestIniParser:
     def test_missing_env_sub_populates_missing_subs(self, newconfig):
         config = newconfig("[testenv:foo]\ncommands={env:VAR}")
         print(SectionReader("section", config._cfg).getstring("commands"))
-        assert config.envconfigs["foo"].missing_subs == ["VAR"]
+        assert config.envconfigs["foo"]._missing_subs == ["VAR"]
 
     def test_getstring_environment_substitution_with_default(self, monkeypatch, newconfig):
         monkeypatch.setenv("KEY1", "hello")


### PR DESCRIPTION
Small refactoring to fix an oversight from an earlier bugfix: all non private members in envconfigs are actual configuration settings