### PR TITLE
Use POSIX shell rules for creating posargs string on non-Windows platforms

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ Anthon van der Neuth
 Anthony Sottile
 Ashley Whetter
 Asmund Grammeltwedt
+Barney Gale
 Barry Warsaw
 Bartolome Sanchez Salado
 Benoit Pierre

--- a/docs/changelog/1336.bugfix.rst
+++ b/docs/changelog/1336.bugfix.rst
@@ -1,0 +1,2 @@
+tox used Windows shell rules on non-Windows platforms when transforming
+positional arguments to a string - by :user:`barneygale`.

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -15,6 +15,11 @@ from fnmatch import fnmatchcase
 from subprocess import list2cmdline
 from threading import Thread
 
+try:
+    from shlex import quote as shlex_quote
+except ImportError:
+    from pipes import quote as shlex_quote
+
 import importlib_metadata
 import pluggy
 import py
@@ -1674,7 +1679,10 @@ class _ArgvlistReader:
     @classmethod
     def processcommand(cls, reader, command, replace=True):
         posargs = getattr(reader, "posargs", "")
-        posargs_string = list2cmdline([x for x in posargs if x])
+        if sys.platform.startswith("win"):
+            posargs_string = list2cmdline([x for x in posargs if x])
+        else:
+            posargs_string = " ".join([shlex_quote(x) for x in posargs if x])
 
         # Iterate through each word of the command substituting as
         # appropriate to construct the new command string. This

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -15,11 +15,6 @@ from fnmatch import fnmatchcase
 from subprocess import list2cmdline
 from threading import Thread
 
-try:
-    from shlex import quote as shlex_quote
-except ImportError:
-    from pipes import quote as shlex_quote
-
 import importlib_metadata
 import pluggy
 import py
@@ -43,6 +38,12 @@ from tox.util.path import ensure_empty_dir
 from .parallel import ENV_VAR_KEY as PARALLEL_ENV_VAR_KEY
 from .parallel import add_parallel_config, add_parallel_flags
 from .reporter import add_verbosity_commands
+
+try:
+    from shlex import quote as shlex_quote
+except ImportError:
+    from pipes import quote as shlex_quote
+
 
 hookimpl = tox.hookimpl
 """DEPRECATED - REMOVE - this is left for compatibility with plugins importing this from here.

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -730,8 +730,18 @@ class TestIniParser:
                 cmd1 -f {posargs}
         """
         )
+        # The operating system APIs for launching processes differ between
+        # Windows and other OSs. On Windows, the command line is passed as a
+        # string (and not a list of strings). Python uses the MS C runtime
+        # rules for splitting this string into `sys.argv`, and those rules
+        # differ from POSIX shell rules in their treatment of quoted arguments.
+        if sys.platform.startswith("win"):
+            substitutions = ["foo", "'bar", "baz'"]
+        else:
+            substitutions = ["foo", "bar baz"]
+
         reader = SectionReader("section", config._cfg)
-        reader.addsubstitutions(["foo", "'bar", "baz'"])
+        reader.addsubstitutions(substitutions)
         assert reader.getargvlist("key1") == []
         x = reader.getargvlist("key2")
         assert x == [["cmd1", "-f", "foo", "bar baz"]]


### PR DESCRIPTION
`subprocess.list2cmdline()` uses Windows shell rules, which don't apply on Linux/Mac. This patch changes it to use `pipes.quote()` (py2) or `shlex.quote()` (py3)

## Contribution checklist:

(also see [CONTRIBUTING.rst](/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](/docs/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
