### PR TITLE
Fix repo file links in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,18 +5,18 @@ much about the checklist - we will help you get started.
 
 ## Contribution checklist:
 
-(also see [CONTRIBUTING.rst](/CONTRIBUTING.rst) for details)
+(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)
 
 - [ ] wrote descriptive pull request text
 - [ ] added/updated test(s)
 - [ ] updated/extended the documentation
 - [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
       in message body
-- [ ] added news fragment in [changelog folder](/docs/changelog)
+- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
   * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
   * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
   * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
   * "sign" fragment with "by :user:`<your username>`"
   * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
-  * also see [examples](/docs/changelog/examples.rst)
+  * also see [examples](../tree/master/docs/changelog/examples.rst)
 - [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)

--- a/docs/changelog/1363.misc.fix-broken-pr-template.rst
+++ b/docs/changelog/1363.misc.fix-broken-pr-template.rst
@@ -1,0 +1,1 @@
+￼Fix relative URLs to files in the repo in ``.github/PULL_REQUEST_TEMPLATE.md`` — by :user:`webknjaz`


### PR DESCRIPTION
Links in the PR template are broken. They start with `/` which effectively creates absolute URI paths relative to `https://github.com`. So `/CONTRIBUTING.rst` points to `https://github.com/CONTRIBUTING.rst`, not to the file view under this repo.

Fixes #1120.

See the broken template below (as rendered when I created this PR):

## Contribution checklist:

(also see [CONTRIBUTING.rst](/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](/docs/changelog/examples.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
