### PR TITLE
Docs fix: move depends and parallel_show_output into the right section

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -160,25 +160,6 @@ Global settings are defined under the ``tox`` section as:
     Name of the virtual environment used to create a source distribution from the
     source tree.
 
-.. conf:: parallel_show_output ^ bool ^ false
-
-    .. versionadded:: 3.7.0
-
-    If set to True the content of the output will always be shown when running in parallel mode.
-
-.. conf:: depends ^ comma separated values
-
-    .. versionadded:: 3.7.0
-
-    tox environments this depends on. tox will try to run all dependent environments before running this
-    environment. Format is same as :conf:`envlist` (allows factor usage).
-
-    .. warning::
-
-       ``depends`` does not pull in dependencies into the run target, for example if you select ``py27,py36,coverage``
-       via the ``-e`` tox will only run those three (even if ``coverage`` may specify as ``depends`` other targets too -
-       such as ``py27, py35, py36, py37``).
-
 
 Jenkins override
 ++++++++++++++++
@@ -542,6 +523,25 @@ Complete list of settings that you can put into ``testenv*`` sections:
     A short description of the environment, this will be used to explain
     the environment to the user upon listing environments for the command
     line with any level of verbosity higher than zero.
+
+.. conf:: parallel_show_output ^ bool ^ false
+
+    .. versionadded:: 3.7.0
+
+    If set to True the content of the output will always be shown when running in parallel mode.
+
+.. conf:: depends ^ comma separated values
+
+    .. versionadded:: 3.7.0
+
+    tox environments this depends on. tox will try to run all dependent environments before running this
+    environment. Format is same as :conf:`envlist` (allows factor usage).
+
+    .. warning::
+
+       ``depends`` does not pull in dependencies into the run target, for example if you select ``py27,py36,coverage``
+       via the ``-e`` tox will only run those three (even if ``coverage`` may specify as ``depends`` other targets too -
+       such as ``py27, py35, py36, py37``).
 
 Substitutions
 -------------


### PR DESCRIPTION
`depends` and `parallel_show_output` are not global settings, they're per-environment settings.  I think they got listed in the global settings section by accident.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] ~~added/updated test(s)~~ – not applicable
- [x] updated/extended the documentation
- [ ] ~~added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) in message body~~ – not applicable
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog) -- is this needed for this trivial docs fix?
<!--
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog/examples.rst)
-->
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order) -- I _think_ I'm already there from before
