### PR TITLE
[RFC/WIP] _getdict: turn escaped newlines into real ones

### DIFF
--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1432,6 +1432,8 @@ class SectionReader:
         for line in value.split(sep):
             if line.strip():
                 name, rest = line.split("=", 1)
+                # Turn escaped newlines into real newlines.
+                rest = rest.strip().replace("\\n", "\n")
                 d[name.strip()] = rest.strip()
 
         return d


### PR DESCRIPTION
This is meant for `getdict_setenv` only, so should be moved maybe (or
driven through an argument).

It is meant to support passing literal newlines to e.g. pytest's `-o
filterwarnings=` value (which expects a list of values separated by
newlines).