### PR TITLE
Un-hardcode the supported factors again

### DIFF
--- a/docs/changelog/1374.feature.rst
+++ b/docs/changelog/1374.feature.rst
@@ -1,0 +1,1 @@
+Add support for minor versions with multiple digits ``tox -e py310` works for ``python3.10`` - by :user:`asottile`

--- a/docs/changelog/1377.fix.rst
+++ b/docs/changelog/1377.fix.rst
@@ -1,0 +1,1 @@
+Fix regression failing to detect future and past ``py##`` factors  - by :user:`asottile`

--- a/src/tox/constants.py
+++ b/src/tox/constants.py
@@ -9,36 +9,11 @@ import sys
 _THIS_FILE = os.path.realpath(os.path.abspath(__file__))
 
 
-def _construct_default_factors(cpython_versions, pypy_versions, other_interpreters):
-    default_factors = {"py": sys.executable, "py2": "python2", "py3": "python3"}
-    default_factors.update(
-        {
-            "py{}{}".format(major, minor): "python{}.{}".format(major, minor)
-            for major, minor in cpython_versions
-        }
-    )
-    default_factors.update({exc: exc for exc in ["pypy", "pypy2", "pypy3"]})
-    default_factors.update(
-        {
-            "pypy{}{}".format(major, minor): "pypy{}.{}".format(major, minor)
-            for major, minor in pypy_versions
-        }
-    )
-    default_factors.update({interpreter: interpreter for interpreter in other_interpreters})
-    return default_factors
-
-
 class PYTHON:
-    PY_FACTORS_RE = re.compile("^(?!py$)(py|pypy|jython)([2-9][0-9]?)?$")
-    CPYTHON_VERSION_TUPLES = [(2, 7), (3, 4), (3, 5), (3, 6), (3, 7), (3, 8)]
-    PYPY_VERSION_TUPLES = [(2, 7), (3, 5)]
-    OTHER_PYTHON_INTERPRETERS = ["jython"]
-    DEFAULT_FACTORS = _construct_default_factors(
-        CPYTHON_VERSION_TUPLES, PYPY_VERSION_TUPLES, OTHER_PYTHON_INTERPRETERS
-    )
-    CURRENT_RELEASE_ENV = "py36"
+    PY_FACTORS_RE = re.compile("^(?!py$)(py|pypy|jython)([2-9][0-9]?[0-9]?)?$")
+    CURRENT_RELEASE_ENV = "py37"
     """Should hold currently released py -> for easy updating"""
-    QUICKSTART_PY_ENVS = ["py27", "py34", "py35", CURRENT_RELEASE_ENV, "pypy", "jython"]
+    QUICKSTART_PY_ENVS = ["py27", "py35", "py36", CURRENT_RELEASE_ENV, "pypy", "jython"]
     """For choices in tox-quickstart"""
 
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2194,26 +2194,24 @@ class TestGlobalOptions:
         assert "typo-factor" not in config.envconfigs
 
     def test_correct_basepython_chosen_from_default_factors(self, newconfig):
-        envlist = list(tox.PYTHON.DEFAULT_FACTORS.keys())
-        config = newconfig([], "[tox]\nenvlist={}".format(", ".join(envlist)))
-        assert config.envlist == envlist
+        envs = {
+            "py": sys.executable,
+            "py2": "python2",
+            "py3": "python3",
+            "py27": "python2.7",
+            "py36": "python3.6",
+            "py310": "python3.10",
+            "pypy": "pypy",
+            "pypy2": "pypy2",
+            "pypy3": "pypy3",
+            "pypy36": "pypy3.6",
+            "jython": "jython",
+        }
+        config = newconfig([], "[tox]\nenvlist={}".format(", ".join(envs)))
+        assert set(config.envlist) == set(envs)
         for name in config.envlist:
             basepython = config.envconfigs[name].basepython
-            if name == "jython":
-                assert basepython == "jython"
-            elif name in ("pypy2", "pypy3"):
-                assert basepython == "pypy" + name[-1]
-            elif name in ("py2", "py3"):
-                assert basepython == "python" + name[-1]
-            elif name == "pypy":
-                assert basepython == name
-            elif name == "py":
-                assert "python" in basepython or "pypy" in basepython
-            elif "pypy" in name:
-                assert basepython == "pypy{}.{}".format(name[-2], name[-1])
-            else:
-                assert name.startswith("py")
-                assert basepython == "python{}.{}".format(name[2], name[3])
+            assert basepython == envs[name]
 
     def test_envlist_expansion(self, newconfig):
         inisource = """

--- a/tests/unit/interpreters/test_interpreters.py
+++ b/tests/unit/interpreters/test_interpreters.py
@@ -46,7 +46,7 @@ def test_tox_get_python_executable():
 
     p = tox_get_python_executable(envconfig)
     assert p == py.path.local(sys.executable)
-    for major, minor in tox.PYTHON.CPYTHON_VERSION_TUPLES:
+    for major, minor in [(2, 7), (3, 5), (3, 6), (3, 7), (3, 8)]:
         name = "python{}.{}".format(major, minor)
         if tox.INFO.IS_WIN:
             pydir = "python{}{}".format(major, minor)

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -164,24 +164,29 @@ def test_unknown_interpreter_and_env(cmd, initproj):
         "interp123-0.5",
         filedefs={
             "tests": {"test_hello.py": "def test_hello(): pass"},
-            "tox.ini": """
-            [testenv:python]
-            basepython=xyz_unknown_interpreter
-            [testenv]
-            changedir=tests
-            skip_install = true
-        """,
+            "tox.ini": """\
+                [testenv:python]
+                basepython=xyz_unknown_interpreter
+                [testenv]
+                changedir=tests
+                skip_install = true
+            """,
         },
     )
     result = cmd()
     result.assert_fail()
-    assert any(
-        "ERROR: InterpreterNotFound: xyz_unknown_interpreter" == l for l in result.outlines
-    ), result.outlines
+    assert "ERROR: InterpreterNotFound: xyz_unknown_interpreter" in result.outlines
 
     result = cmd("-exyz")
     result.assert_fail()
     assert result.out == "ERROR: unknown environment 'xyz'\n"
+
+
+def test_unknown_interpreter_factor(cmd, initproj):
+    initproj("py21", filedefs={"tox.ini": "[testenv]\nskip_install=true"})
+    result = cmd("-e", "py21")
+    result.assert_fail()
+    assert "ERROR: InterpreterNotFound: python2.1" in result.outlines
 
 
 def test_unknown_interpreter(cmd, initproj):


### PR DESCRIPTION
Resolves #1374 

This also fixes some other things which regressed in #983 -- notably this

```console
$ tox -e py21 --notest && .tox/py21/bin/python --version
py21 create: /tmp/tox/.tox/py21
py21 installdeps: pip == 19.1.1
py21 inst: /tmp/tox/.tox/.tmp/package/1/tox-3.13.3.dev7+g84c4c8d.tar.gz
py21 installed: apipkg==1.5,atomicwrites==1.3.0,attrs==19.1.0,coverage==4.5.3,execnet==1.6.1,filelock==3.0.12,flaky==3.6.0,freezegun==0.3.12,importlib-metadata==0.18,more-itertools==7.2.0,packaging==19.0,pathlib2==2.3.4,pluggy==0.12.0,psutil==5.6.3,py==1.8.0,pyparsing==2.4.1.1,pytest==5.0.1,pytest-cov==2.7.1,pytest-forked==1.0.2,pytest-mock==1.10.4,pytest-randomly==1.2.3,pytest-xdist==1.29.0,python-dateutil==2.8.0,six==1.12.0,toml==0.10.0,tox==3.13.3.dev7+g84c4c8d,virtualenv==16.7.1,wcwidth==0.1.7,zipp==0.5.2
_______________________________________________________________________ summary ________________________________________________________________________
  py21: skipped tests
  congratulations :)
Python 3.6.8
```

restored behaviour:

```console
$ .tox/py36/bin/tox -e py21 --notest
py21 create: /tmp/tox/.tox/py21
SKIPPED: InterpreterNotFound: python2.1
_______________________________________________________________________ summary ________________________________________________________________________
SKIPPED:  py21: InterpreterNotFound: python2.1
  congratulations :)
```