### PR TITLE
Fix testsuite and honor environment markers in requires

### DIFF
--- a/docs/changelog/1380.bugfix.rst
+++ b/docs/changelog/1380.bugfix.rst
@@ -1,0 +1,1 @@
+Honor environment markers in ``requires`` list - by :user:`asottile`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1165,6 +1165,9 @@ class ParseIni(object):
             # noinspection PyBroadException
             try:
                 package = requirements.Requirement(require)
+                # check if the package even applies
+                if package.marker and not package.marker.evaluate({"extra": ""}):
+                    continue
                 package_name = canonicalize_name(package.name)
                 if package_name not in exists:
                     deps.append(DepConfig(require, None))

--- a/tests/integration/test_provision_int.py
+++ b/tests/integration/test_provision_int.py
@@ -23,7 +23,8 @@ def test_provision_missing(initproj, cmd):
                 minversion = 3.7.0
                 requires =
                     setuptools == 40.6.3
-                    pyparsing!=2.4.1,!=2.4.1.1;python_version=="3.4"
+                    # remove when 2.4.2 is released or python3.4 is dropped
+                    pyparsing!=2.4.1,!=2.4.1.1
                 [testenv]
                 commands=python -c "import sys; print(sys.executable); raise SystemExit(1)"
             """

--- a/tests/unit/session/test_provision.py
+++ b/tests/unit/session/test_provision.py
@@ -24,10 +24,10 @@ def test_provision_min_version_is_requires(newconfig, next_tox_major):
     with pytest.raises(MissingRequirement) as context:
         newconfig(
             [],
-            """
+            """\
             [tox]
             minversion = {}
-        """.format(
+            """.format(
                 next_tox_major
             ),
         )
@@ -45,10 +45,10 @@ def test_provision_min_version_is_requires(newconfig, next_tox_major):
 def test_provision_tox_change_name(newconfig):
     config = newconfig(
         [],
-        """
+        """\
         [tox]
         provision_tox_env = magic
-    """,
+        """,
     )
     assert config.provision_tox_env == "magic"
 
@@ -58,12 +58,12 @@ def test_provision_basepython_global_only(newconfig, next_tox_major):
     with pytest.raises(MissingRequirement) as context:
         newconfig(
             [],
-            """
+            """\
             [tox]
             minversion = {}
             [testenv]
             basepython = what
-        """.format(
+            """.format(
                 next_tox_major
             ),
         )
@@ -77,12 +77,12 @@ def test_provision_basepython_local(newconfig, next_tox_major):
     with pytest.raises(MissingRequirement) as context:
         newconfig(
             [],
-            """
+            """\
             [tox]
             minversion = {}
             [testenv:.tox]
             basepython = what
-        """.format(
+            """.format(
                 next_tox_major
             ),
         )
@@ -95,10 +95,10 @@ def test_provision_bad_requires(newconfig, capsys, monkeypatch):
     with pytest.raises(BadRequirement):
         newconfig(
             [],
-            """
+            """\
             [tox]
             requires = sad >sds d ok
-        """,
+            """,
         )
     out, err = capsys.readouterr()
     assert "ERROR: failed to parse InvalidRequirement" in out
@@ -208,7 +208,7 @@ def test_provision_non_canonical_dep(
     initproj(
         "w-0.1",
         {
-            "tox.ini": """
+            "tox.ini": """\
             [tox]
             envlist = py
             requires =
@@ -228,6 +228,21 @@ def test_provision_non_canonical_dep(
     monkeypatch.setenv(str("PIP_FIND_LINKS"), str(find_links))
 
     result = cmd("-a", "-v", "-v")
+    result.assert_success(is_run_test_env=False)
+
+
+def test_provision_requirement_with_environment_marker(cmd, initproj):
+    initproj(
+        "proj",
+        {
+            "tox.ini": """\
+            [tox]
+            requires =
+                package-that-does-not-exist;python_version=="1.0"
+            """
+        },
+    )
+    result = cmd("-e", "py", "-vv")
     result.assert_success(is_run_test_env=False)
 
 


### PR DESCRIPTION
accidentally broken in #1380

I also made tox support environment specifiers in the `requires` section

unfortunately, I still can't use that in the testsuite itself because tox tries to install tox which goes to public pypi and ends up with the current version which doesn't support environment specifiers 🤦‍♂. 
 instead of trying to move around the testing code for the `tox` wheel, I opted for a comment with clean up instructions 🤷‍♂ 