### PR TITLE
Add quote marks so readers are not tripped up by spaces in their path…

### DIFF
--- a/docs/example/pytest.rst
+++ b/docs/example/pytest.rst
@@ -53,7 +53,7 @@ and the following ``tox.ini`` content:
     changedir = tests
     deps = pytest
     # change pytest tempdir and add posargs from command line
-    commands = pytest --basetemp={envtmpdir} {posargs}
+    commands = pytest --basetemp="{envtmpdir}" {posargs}
 
 you can invoke ``tox`` in the directory where your ``tox.ini`` resides.
 Differently than in the previous example the ``pytest`` command
@@ -75,7 +75,7 @@ to make ``tox`` use this feature:
     deps = pytest-xdist
     changedir = tests
     # use three sub processes
-    commands = pytest --basetemp={envtmpdir}  \
+    commands = pytest --basetemp="{envtmpdir}"  \
                       --confcutdir=..         \
                       -n 3                    \
                       {posargs}


### PR DESCRIPTION
tox ran beautifully on my laptop but when I moved to my work PC with a different version of python to test my project without installing five versions of python on my laptop it just wouldn't work. Careful inspection of the error message was not really helpful other than tox being unable to find my tests but I've had the spaces in path names issue with other software so I tried adding quotes in my tox.ini and it worked. I have made a trivial update to the documentation adding quotes on the page I was following. There may be more places where adding quotes would be advisable. Alternatively, tox should quote file paths internally making the documentation changes irrelevant. 