### PR TITLE
Fix reporting exit due to (real) signal

### DIFF
--- a/docs/changelog/1401.bugfix.rst
+++ b/docs/changelog/1401.bugfix.rst
@@ -1,0 +1,1 @@
+fix reporting of exiting due to (real) signals - by :user:`blueyed`

--- a/src/tox/exception.py
+++ b/src/tox/exception.py
@@ -17,18 +17,24 @@ def exit_code_str(exception_name, command, exit_code):
     """
     str_ = "{} for command {}".format(exception_name, command)
     if exit_code is not None:
-        str_ += " (exited with code {:d})".format(exit_code)
-        if (os.name == "posix") and (exit_code > 128):
+        if (exit_code < 0 or (os.name == "posix" and exit_code > 128)):
             signals = {
                 number: name for name, number in vars(signal).items() if name.startswith("SIG")
             }
-            number = exit_code - 128
-            name = signals.get(number)
-            if name:
-                str_ += (
-                    "\nNote: this might indicate a fatal error signal "
-                    "({:d} - 128 = {:d}: {})".format(number + 128, number, name)
-                )
+            if exit_code < 0:
+                # Signal reported via subprocess.Popen.
+                sig_name = signals.get(-exit_code)
+                str_ += " (exited with code {:d} ({}))".format(exit_code, sig_name)
+            else:
+                str_ += " (exited with code {:d})".format(exit_code)
+                number = exit_code - 128
+                name = signals.get(number)
+                if name:
+                    str_ += (
+                        ")\nNote: this might indicate a fatal error signal "
+                        "({:d} - 128 = {:d}: {})".format(exit_code, number, name)
+                    )
+        str_ += " (exited with code {:d})".format(exit_code)
     return str_
 
 

--- a/tests/unit/test_result.py
+++ b/tests/unit/test_result.py
@@ -72,7 +72,7 @@ def test_get_commandlog(pkg):
     assert setuplog2.list == setuplog.list
 
 
-@pytest.mark.parametrize("exit_code", [None, 0, 5, 128 + signal.SIGTERM, 1234])
+@pytest.mark.parametrize("exit_code", [None, 0, 5, 128 + signal.SIGTERM, 1234, -15])
 @pytest.mark.parametrize("os_name", ["posix", "nt"])
 def test_invocation_error(exit_code, os_name, mocker, monkeypatch):
     monkeypatch.setattr(os, "name", value=os_name)
@@ -85,6 +85,8 @@ def test_invocation_error(exit_code, os_name, mocker, monkeypatch):
     assert call_args == mocker.call("InvocationError", "<command>", exit_code)
     if exit_code is None:
         assert "(exited with code" not in result
+    elif exit_code is -15:
+        assert "(exited with code -15 (SIGTERM))" in result
     else:
         assert "(exited with code %d)" % exit_code in result
         note = "Note: this might indicate a fatal error signal"


### PR DESCRIPTION
`subprocess` reports a negative exit code for signals (the assumption in
https://github.com/tox-dev/tox/pull/760#discussion_r165831005 was
wrong).

TODO:

- [x] faster test (takes >3s)