### PR TITLE
Use `not PY2` instead of `PY3` for python4.x compat

### DIFF
--- a/src/tox/_pytestplugin.py
+++ b/src/tox/_pytestplugin.py
@@ -210,7 +210,7 @@ class ReportExpectMock:
 
     def clear(self):
         self._index = -1
-        if six.PY3:
+        if not six.PY2:
             self.instance.reported_lines.clear()
         else:
             del self.instance.reported_lines[:]
@@ -291,7 +291,7 @@ def create_mocksession(request):
             self.report = ReportExpectMock()
 
         def _clearmocks(self):
-            if six.PY3:
+            if not six.PY2:
                 self._pcalls.clear()
             else:
                 del self._pcalls[:]

--- a/src/tox/interpreters/py_spec.py
+++ b/src/tox/interpreters/py_spec.py
@@ -26,7 +26,7 @@ class PythonSpec(object):
 
     def __str__(self):
         msg = repr(self)
-        return msg if six.PY3 else msg.encode("utf-8")
+        return msg.encode("utf-8") if six.PY2 else msg
 
     def satisfies(self, req):
         if req.is_abs and self.is_abs and self.path != req.path:


### PR DESCRIPTION
found via [flake8-2020](https://github.com/asottile/flake8-2020)