### PR TITLE
Adds SSL proxy variables to default passenv

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -72,6 +72,7 @@ Pierre-Luc Tessier Gagné
 Ronald Evers
 Ronny Pfannschmidt
 Selim Belhaouane
+Sorin Sbarnea
 Sridhar Ratnakumar
 Stephen Finucane
 Sviatoslav Sydorenko

--- a/docs/changelog/1437.bugfix.rst
+++ b/docs/changelog/1437.bugfix.rst
@@ -1,0 +1,1 @@
+Adds ``CURL_CA_BUNDLE``, ``REQUESTS_CA_BUNDLE``, ``SSL_CERT_FILE`` to the default passenv values. - by :user:`ssbarnea`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -385,8 +385,10 @@ Complete list of settings that you can put into ``testenv*`` sections:
     Some variables are always passed through to ensure the basic functionality
     of standard library functions or tooling like pip:
 
-    * passed through on all platforms: ``PATH``, ``LANG``, ``LANGUAGE``,
-      ``LD_LIBRARY_PATH``, ``PIP_INDEX_URL``
+    * passed through on all platforms: ``CURL_CA_BUNDLE`, ``PATH``,
+      ``LANG``, ``LANGUAGE``,
+      ``LD_LIBRARY_PATH``, ``PIP_INDEX_URL``,
+      ``REQUESTS_CA_BUNDLE``, ``SSL_CERT_FILE``
     * Windows: ``SYSTEMDRIVE``, ``SYSTEMROOT``, ``PATHEXT``, ``TEMP``, ``TMP``
        ``NUMBER_OF_PROCESSORS``, ``USERPROFILE``, ``MSYSTEM``
     * Others (e.g. UNIX, macOS): ``TMPDIR``

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -663,11 +663,14 @@ def tox_addoption(parser):
         value = list(itertools.chain.from_iterable([x.split(" ") for x in value]))
 
         passenv = {
-            "PATH",
-            "PIP_INDEX_URL",
+            "CURL_CA_BUNDLE",
             "LANG",
             "LANGUAGE",
             "LD_LIBRARY_PATH",
+            "PATH",
+            "PIP_INDEX_URL",
+            "REQUESTS_CA_BUNDLE",
+            "SSL_CERT_FILE",
             "TOX_WORK_DIR",
             str(REPORTER_TIMESTAMP_ON_ENV),
             str(PARALLEL_ENV_VAR_KEY),

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1068,8 +1068,11 @@ class TestConfigTestEnv:
             assert "MSYSTEM" in envconfig.passenv
         else:
             assert "TMPDIR" in envconfig.passenv
+        assert "CURL_CA_BUNDLE" in envconfig.passenv
         assert "PATH" in envconfig.passenv
         assert "PIP_INDEX_URL" in envconfig.passenv
+        assert "REQUESTS_CA_BUNDLE" in envconfig.passenv
+        assert "SSL_CERT_FILE" in envconfig.passenv
         assert "LANG" in envconfig.passenv
         assert "LANGUAGE" in envconfig.passenv
         assert "LD_LIBRARY_PATH" in envconfig.passenv

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,14 @@ description = run the tests with pytest under {basepython}
 setenv = PIP_DISABLE_VERSION_CHECK = 1
          COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
          VIRTUALENV_NO_DOWNLOAD = 1
-passenv = http_proxy https_proxy no_proxy SSL_CERT_FILE PYTEST_*
+passenv =
+    CURL_CA_BUNDLE
+    http_proxy
+    https_proxy
+    no_proxy
+    REQUESTS_CA_BUNDLE
+    SSL_CERT_FILE
+    PYTEST_*
 deps = pip == 19.1.1
 extras = testing
 commands = pytest \


### PR DESCRIPTION
This shouls avoid SSL failures with HTTP requests from pip, requests
or other libraries.

Also sorts existing values in order to make it easier to update the
list in the future.

Fixes: #1437

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
