### PR TITLE
Fix provisioning from pyvenv interpreter

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,6 +31,7 @@ Hazal Ozturk
 Henk-Jaap Wagenaar
 Ian Stapleton Cordasco
 Igor Duarte Cardoso
+Ilya Kulakov
 Ionel Maries Cristian
 Itxaka Serrano
 Jake Windle

--- a/docs/changelog/1452.bugfix.rst
+++ b/docs/changelog/1452.bugfix.rst
@@ -1,0 +1,1 @@
+Fix provisioning from a pyvenv interpreter. — by :user:`kentzo`

--- a/src/tox/session/commands/provision.py
+++ b/src/tox/session/commands/provision.py
@@ -13,6 +13,7 @@ def provision_tox(provision_venv, args):
         try:
             env = os.environ.copy()
             env[str("TOX_PROVISION")] = str("1")
+            env.pop('__PYVENV_LAUNCHER__', None)
             action.popen(provision_args, redirect=False, report_fail=False, env=env)
             return 0
         except InvocationError as exception:

--- a/tests/integration/test_provision_int.py
+++ b/tests/integration/test_provision_int.py
@@ -41,6 +41,26 @@ def test_provision_missing(initproj, cmd):
     assert meta_python.exists()
 
 
+def test_provision_from_pyvenv(initproj, cmd, monkeypatch):
+    initproj(
+        "pkg123-0.7",
+        filedefs={
+            "tox.ini": """\
+                [tox]
+                skipsdist=True
+                minversion = 3.7.0
+                requires =
+                    setuptools == 40.6.3
+                [testenv]
+                commands=python -c "import sys; print(sys.executable); raise SystemExit(1)"
+            """
+        },
+    )
+    monkeypatch.setenv(str("__PYVENV_LAUNCHER__"), sys.executable)
+    result = cmd("-e", "py", "-vv")
+    result.assert_fail()
+    assert '.tox/.tox/bin/python -m virtualenv' in result.out
+
 @pytest.mark.skipif(
     "sys.platform == 'win32'", reason="triggering SIGINT reliably on Windows is hard"
 )


### PR DESCRIPTION
The bug is related to #148.

When the original interpreter [0] tox is called with is actually a pyvenv
it will set the `__PYVENV_LAUNCHER__` environment variable the path of pyvenv
interpreter.

If tox configuration specifies `requires` and the requirements are not
satifsfied by [0], tox will create an intermediate virtual environment [1].

After setting up [1] tox will delegate the original call to it by spawning
a new [1] interpreter with the list of arguments identical to [0].

It would also pass the value of `__PYVENV_LAUNCHER__` if present. This in turn
causes `sys.executable` to resolve to [0] instead of [1] therefore ignoring all
modifications including installed requirements.

The fix is to make sure that when [0] spawns [1], `__PYVENV_LAUNCHER__` is removed
from the environment.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
