### PR TITLE
tests: fix test_create_KeyboardInterrupt

### DIFF
--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -92,9 +92,9 @@ def test_create_KeyboardInterrupt(mocksession, newconfig, mocker):
     )
     mocksession.new_config(config)
     venv = mocksession.getvenv("py123")
-    with mocker.patch.object(venv, "_pcall", side_effect=KeyboardInterrupt):
-        with pytest.raises(KeyboardInterrupt):
-            venv.setupenv()
+    mocker.patch.object(venv, "_pcall", side_effect=KeyboardInterrupt)
+    with pytest.raises(KeyboardInterrupt):
+        venv.setupenv()
 
     assert venv.status == "keyboardinterrupt"
 


### PR DESCRIPTION
pytest-mock 1.11.2 raises:

> ValueError: Using mocker in a with context is not supported.
> https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager