### PR TITLE
use get_python_info for consistency and caching

### DIFF
--- a/docs/changelog/1462.misc.rst
+++ b/docs/changelog/1462.misc.rst
@@ -1,0 +1,1 @@
+improve performance with internal lookup of Python version information - by :user:`blueyed`

--- a/src/tox/interpreters/__init__.py
+++ b/src/tox/interpreters/__init__.py
@@ -5,7 +5,8 @@ import sys
 
 import tox
 from tox import reporter
-from tox.constants import SITE_PACKAGE_QUERY_SCRIPT, VERSION_QUERY_SCRIPT
+from tox.constants import SITE_PACKAGE_QUERY_SCRIPT
+from tox.interpreters.via_path import get_python_info
 
 
 class Interpreters:
@@ -56,7 +57,7 @@ class Interpreters:
 def run_and_get_interpreter_info(name, executable):
     assert executable
     try:
-        result = exec_on_interpreter(str(executable), VERSION_QUERY_SCRIPT)
+        result = get_python_info(str(executable))
         result["version_info"] = tuple(result["version_info"])  # fix json dump transformation
         del result["name"]
         del result["version"]

--- a/src/tox/logs/env.py
+++ b/src/tox/logs/env.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-import json
-import subprocess
-
-from tox.constants import VERSION_QUERY_SCRIPT
+from tox.interpreters.via_path import get_python_info
 
 from .command import CommandLog
 
@@ -17,9 +14,7 @@ class EnvLog(object):
         self.dict = dict
 
     def set_python_info(self, python_executable):
-        cmd = [str(python_executable), VERSION_QUERY_SCRIPT]
-        result = subprocess.check_output(cmd, universal_newlines=True)
-        answer = json.loads(result)
+        answer = get_python_info(str(python_executable))
         answer["executable"] = python_executable
         self.dict["python"] = answer
 


### PR DESCRIPTION
I've came across this when looking at the code - it obviously needs some cleanup, but passes all tests and got me a cache hit at least with a typical run.  (IIRC it saves 0.2+s at least due to this).

Let me know if you like it and I/we can finish it.