### PR TITLE
Fix global configuration fallback in Jenkins runs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,6 +19,7 @@ Chris Jerdonek
 Chris Rose
 Clark Boylan
 Cyril Roelandt
+Dane Hillard
 David Staheli
 Ederag
 Eli Collins

--- a/docs/changelog/1428.bugfix.rst
+++ b/docs/changelog/1428.bugfix.rst
@@ -1,0 +1,1 @@
+Fix fallback to global configuration when running in Jenkins. - by :user:`daneah`

--- a/src/tox/_pytestplugin.py
+++ b/src/tox/_pytestplugin.py
@@ -102,12 +102,12 @@ def check_os_environ_stable():
 
 @pytest.fixture(name="newconfig")
 def create_new_config_file(tmpdir):
-    def create_new_config_file_(args, source=None, plugins=()):
+    def create_new_config_file_(args, source=None, plugins=(), filename="tox.ini"):
         if source is None:
             source = args
             args = []
         s = textwrap.dedent(source)
-        p = tmpdir.join("tox.ini")
+        p = tmpdir.join(filename)
         p.write(s)
         tox.session.setup_reporter(args)
         with tmpdir.as_cwd():

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -991,11 +991,12 @@ class ParseIni(object):
         self.config = config
 
         prefix = "tox" if ini_path.basename == "setup.cfg" else None
+        fallbacksection = "tox:tox" if ini_path.basename == "setup.cfg" else "tox"
 
         context_name = getcontextname()
         if context_name == "jenkins":
             reader = SectionReader(
-                "tox:jenkins", self._cfg, prefix=prefix, fallbacksections=["tox"]
+                "tox:jenkins", self._cfg, prefix=prefix, fallbacksections=[fallbacksection]
             )
             dist_share_default = "{toxworkdir}/distshare"
         elif not context_name:

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2104,6 +2104,17 @@ class TestGlobalOptions:
         config = newconfig(args, "")
         assert config.option.quiet_level == expected
 
+    def test_substitution_jenkins_global(self, monkeypatch, newconfig):
+        monkeypatch.setenv("HUDSON_URL", "xyz")
+        config = newconfig(
+            """
+            [tox:tox]
+            envlist = py37
+        """,
+            filename="setup.cfg",
+        )
+        assert "py37" in config.envconfigs
+
     def test_substitution_jenkins_default(self, monkeypatch, newconfig):
         monkeypatch.setenv("HUDSON_URL", "xyz")
         config = newconfig(


### PR DESCRIPTION
Fixes #1428

When running in Jenkins and using `setup.cfg`, tox would not fall back to the `[tox:tox]` configuration section properly. This was due to how the fallback section name was calculated under this specific combination of characteristics.

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
