### PR TITLE
fix colouring on windows

### DIFF
--- a/docs/changelog/1471.bugfix.rst
+++ b/docs/changelog/1471.bugfix.rst
@@ -1,0 +1,1 @@
+Fix colouring on windows: colorama is a dep. - by :user:`1138-4EB`

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     virtualenv >= 16.0.0
     toml >=0.9.4
     filelock >= 3.0.0, <4
+    colorama >= 0.4.1 ;platform_system=="Windows"
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Ref #1468

Currently, `colorama` is required in order to get coloured output on Windows, even if it is not used. This is because of:

https://github.com/pytest-dev/py/blob/1e99d20f31ef511fc2f1a9e49ba970acad441d4e/py/_io/terminalwriter.py#L16-L24

Since neither tox nor TerminalWriter do install colorama explicitly, it falls back to `win32_and_ctypes`, which does not work. In this PR, colorama is added to `install_requires`, for it to be installed on Windows only.

At first, I was not convinced about adding the dependency, because it is not required for minimal usage of tox (i.e., without colours). However, I saw that it will be included for all platforms in #1400, so I guess that it is acceptable.