### PR TITLE
use latest version of importlib_metadata

### DIFF
--- a/docs/changelog/1472.misc.rst
+++ b/docs/changelog/1472.misc.rst
@@ -1,0 +1,1 @@
+Use latest version of importlib_metadata package - by :user:`kammala`

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ classifiers =
 packages = find:
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 install_requires =
-    importlib-metadata >= 0.12, <1;python_version<"3.8"
+    importlib-metadata >= 1.1.0, <2;python_version<"3.8"
     packaging >= 14
     pluggy >= 0.12.0, <1
     py >= 1.4.17, <2


### PR DESCRIPTION
Since [November 30](https://gitlab.com/python-devs/importlib_metadata/commit/0d8384c031bf1d18c7b3f8edfaf383fae111c5ca) `importlib_metadata` uses semver and has latest version 1.1.0.

If you use `twine` or `pytest`(which do not pin upper bound of `importlib_metadata` dependency) and `tox` in the same virtualenv and check for package integrity with `pip check`, you can easily run into the trouble that python installs `importlib_metadata` incompatible with `tox`.

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
