### PR TITLE
mark poetry tests as xfail on windows

### DIFF
--- a/docs/changelog/1474.misc.rst
+++ b/docs/changelog/1474.misc.rst
@@ -1,0 +1,1 @@
+Mark poetry related tests as xfail since its dependency pyrsistent won't install in ci due to missing wheels/build deps. - by :user:`RonnyPfannschmidt`

--- a/tests/integration/test_package_int.py
+++ b/tests/integration/test_package_int.py
@@ -79,8 +79,7 @@ def test_package_flit(initproj, cmd):
 @pytest.mark.network
 @pytest.mark.skipif(sys.version_info < (3, 0), reason="poetry is Python 3 only")
 @pytest.mark.xfail(
-    os.name == "nt",
-    reason="https://github.com/tobgu/pyrsistent/issues/88 breaks poetry install",
+    os.name == "nt", reason="https://github.com/tobgu/pyrsistent/issues/88 breaks poetry install",
 )
 def test_package_poetry(initproj, cmd):
     initproj(

--- a/tests/integration/test_package_int.py
+++ b/tests/integration/test_package_int.py
@@ -78,6 +78,10 @@ def test_package_flit(initproj, cmd):
 
 @pytest.mark.network
 @pytest.mark.skipif(sys.version_info < (3, 0), reason="poetry is Python 3 only")
+@pytest.mark.xfail(
+    os.name == "nt",
+    reason="https://github.com/tobgu/pyrsistent/issues/88 breaks easy poetry install",
+)
 def test_package_poetry(initproj, cmd):
     initproj(
         "magic-0.1",

--- a/tests/integration/test_package_int.py
+++ b/tests/integration/test_package_int.py
@@ -80,7 +80,7 @@ def test_package_flit(initproj, cmd):
 @pytest.mark.skipif(sys.version_info < (3, 0), reason="poetry is Python 3 only")
 @pytest.mark.xfail(
     os.name == "nt",
-    reason="https://github.com/tobgu/pyrsistent/issues/88 breaks easy poetry install",
+    reason="https://github.com/tobgu/pyrsistent/issues/88 breaks poetry install",
 )
 def test_package_poetry(initproj, cmd):
     initproj(


### PR DESCRIPTION
https://github.com/tobgu/pyrsistent/issues/88 triggers extra requirements on building anything on windows,

this also hit poetry, thus its installation fails

the `xfail` is to make the test-suite green while the situation is being resolved on a more fundamental level

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
