### PR TITLE
clarify legacy setup.py error message further

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -78,6 +78,7 @@ Sorin Sbarnea
 Sridhar Ratnakumar
 Stephen Finucane
 Sviatoslav Sydorenko
+Thomas Grainger
 Tim Laurence
 Ville Skyttä
 Xander Johnson

--- a/docs/changelog/1478.misc.rst
+++ b/docs/changelog/1478.misc.rst
@@ -1,0 +1,1 @@
+Clarify legacy setup.py error message: python projects should commit to a strong consistency of message regarding packaging. We no-longer tell people to add a setup.py to their already configured pep-517 project, otherwise it could imply that pyproject.toml isn't as well supported and recommended as it truly is - by :user:graingert

--- a/src/tox/package/builder/legacy.py
+++ b/src/tox/package/builder/legacy.py
@@ -8,16 +8,26 @@ from tox.util.path import ensure_empty_dir
 
 def make_sdist(config, session):
     setup = config.setupdir.join("setup.py")
-    if not setup.check():
+    pyproject = config.setupdir.join("pyproject.toml")
+    setup_check = setup.check()
+    if not setup_check and not pyproject.check():
         reporter.error(
-            "No setup.py file found. The expected location is:\n"
-            "  {}\n"
+            "No pyproject.toml or setup.py file found. The expected locations are:\n"
+            "  {pyproject} or {setup}\n"
             "You can\n"
             "  1. Create one:\n"
             "     https://tox.readthedocs.io/en/latest/example/package.html\n"
             "  2. Configure tox to avoid running sdist:\n"
             "     https://tox.readthedocs.io/en/latest/example/general.html\n"
-            "  3. Configure tox to use an isolated_build".format(setup)
+            "  3. Configure tox to use an isolated_build".format(pyproject=pyproject, setup=setup)
+        )
+        raise SystemExit(1)
+    if not setup_check:
+        reporter.error(
+            "pyproject.toml file found.\n"
+            "To use a PEP 517 build-backend you are required to "
+            "configure tox to use an isolated_build:\n"
+            "https://tox.readthedocs.io/en/latest/example/package.html\n"
         )
         raise SystemExit(1)
     with session.newaction("GLOB", "packaging") as action:

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tempfile
 
+import pathlib2
 import py
 import pytest
 
@@ -411,7 +412,31 @@ def test_no_setup_py_exits(cmd, initproj):
     result = cmd()
     result.assert_fail()
     assert any(
-        re.match(r".*ERROR.*No setup.py file found.*", l) for l in result.outlines
+        re.match(r".*ERROR.*No pyproject.toml or setup.py file found.*", l)
+        for l in result.outlines
+    ), result.outlines
+
+
+def test_no_setup_py_exits_but_pyproject_toml_does(cmd, initproj):
+    initproj(
+        "pkg123-0.7",
+        filedefs={
+            "tox.ini": """
+            [testenv]
+            commands=python -c "2 + 2"
+        """
+        },
+    )
+    os.remove("setup.py")
+    pathlib2.Path("pyproject.toml").touch()
+    result = cmd()
+    result.assert_fail()
+    assert any(
+        re.match(r".*ERROR.*pyproject.toml file found.*", l) for l in result.outlines
+    ), result.outlines
+    assert any(
+        re.match(r".*To use a PEP 517 build-backend you are required to*", l)
+        for l in result.outlines
     ), result.outlines
 
 


### PR DESCRIPTION
a follow up to #1467

python projects should commit to a strong consistency of message regarding packaging. eg we shouldn't tell people to add a `setup.py` to their already configured pep-517  project, otherwise it could imply that `pyproject.toml` isn't as well supported and recommended as it truly is

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
