### PR TITLE
Update guide with instructions to disable spinner

### DIFF
--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -399,7 +399,7 @@ Parallel mode
   - ``auto`` to limit it to CPU count,
   - or pass an integer to set that limit.
 - Parallel mode displays a progress spinner while running tox environments in parallel, and reports outcome of
-  these as soon as completed with a human readable duration timing attached. This spinner can be disabled by 
+  these as soon as completed with a human readable duration timing attached. This spinner can be disabled by
   setting the environment variable ``TOX_PARALLEL_NO_SPINNER`` to the value ``1``.
 - Parallel mode by default shows output only of failed environments and ones marked as :conf:`parallel_show_output`
   ``=True``.

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -399,7 +399,8 @@ Parallel mode
   - ``auto`` to limit it to CPU count,
   - or pass an integer to set that limit.
 - Parallel mode displays a progress spinner while running tox environments in parallel, and reports outcome of
-  these as soon as completed with a human readable duration timing attached.
+  these as soon as completed with a human readable duration timing attached. This spinner can be disabled by 
+  setting the environment variable ``TOX_PARALLEL_NO_SPINNER`` to the value ``1``.
 - Parallel mode by default shows output only of failed environments and ones marked as :conf:`parallel_show_output`
   ``=True``.
 - There's now a concept of dependency between environments (specified via :conf:`depends`), tox will re-order the


### PR DESCRIPTION
`TOX_PARALLEL_NO_SPINNER` is mentioned in the command-line help, but can't be found anywhere obvious in the documentation besides the changelog.

## Contribution checklist:

- [x] wrote descriptive pull request text
- [ ] added/updated test(s) **N/A**
- [x] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body **N/A**
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)

I'm not sure the last two tasks add much value for a one-line documentation change, but I can update the changelog and contributors file if requested.