### PR TITLE
Correct statement on PEP-518

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -65,6 +65,7 @@ Monty Taylor
 Morgan Fainberg
 Nick Douma
 Nick Prendergast
+Nuno André Novo
 Oliver Bestwalter
 Pablo Galindo
 Paweł Adamczak

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -63,18 +63,14 @@ The environment ``py`` uses the version of Python used to invoke tox.
 However, you can also create your own test environment names,
 see some of the examples in :doc:`examples <../examples>`.
 
-pyproject.toml tox legacy ini
+pyproject.toml legacy tox ini
 -----------------------------
 
-The tox configuration can also be in ``pyproject.toml`` (if you want to avoid an extra file).
+The tox configuration can also be in ``pyproject.toml`` (the `Python's standard`_ configuration file for software packages).
 
 Currently only the old format is supported via ``legacy_tox_ini``, a native implementation is planned though.
 
 .. code-block:: toml
-
-   [build-system]
-   requires = [ "setuptools >= 35.0.2", "wheel >= 0.29.0"]
-   build-backend = "setuptools.build_meta"
 
    [tool.tox]
    legacy_tox_ini = """
@@ -86,7 +82,8 @@ Currently only the old format is supported via ``legacy_tox_ini``, a native impl
    commands = pytest
    """
 
-Note that when you define a ``pyproject.toml`` you must define the ``build-requires`` section per PEP-518.
+.. _Python's standard:
+   https://www.python.org/dev/peps/pep-0518
 
 specifying a platform
 -----------------------------------------------


### PR DESCRIPTION
As explicitly stated in [PEP-518](https://www.python.org/dev/peps/pep-0518/#build-system-table):

> _Tools should not require the existence of the `[build-system]` table. A `pyproject.toml` file may be used to store configuration details other than build-related data and thus lack a `[build-system]` table legitimately. It is up to the tool to decide how to handle this case._

Also removed _(if you want to avoid an extra file)_ since is not uncommon for a `pyproject.toml` to have the configuration of a single tool that otherwise would have its own file.