### PR TITLE
Allow to config the behavior on CTRL+C

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -57,6 +57,7 @@ Mark Hirota
 Matt Good
 Matt Jeffery
 Mattieu Agopian
+Mehdi Abaakouk
 Michael Manganiello
 Mickaël Schoentgen
 Mikhail Kyshtymov

--- a/docs/changelog/1493.feature.rst
+++ b/docs/changelog/1493.feature.rst
@@ -1,0 +1,1 @@
+Add ``interrupt_timeout`` and ``terminate_timeout`` that configure delay between SIGINT, SIGTERM and SIGKILL when tox is interrupted. - by :user:`sileht`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -160,6 +160,21 @@ Global settings are defined under the ``tox`` section as:
     Name of the virtual environment used to create a source distribution from the
     source tree.
 
+.. conf:: interrupt_timeout ^ float ^ 0.3
+
+    .. versionadded:: 3.15.0
+
+    When tox is interrupted, it propagates the signal to the child process,
+    wait :conf:``interrupt_timeout`` seconds, and sends it a SIGTERM if it haven't
+    exited.
+
+.. conf:: terminate_timeout ^ float ^ 0.2
+
+    .. versionadded:: 3.15.0
+
+    When tox is interrupted, it propagates the signal to the child process,
+    wait :conf:``interrupt_timeout`` seconds, sends it a SIGTERM, wait
+    :conf:``terminate_timeout`` seconds, and sends it a SIGKILL if it haven't exited.
 
 Jenkins override
 ++++++++++++++++

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -54,6 +54,9 @@ Import hookimpl directly from tox instead.
 
 WITHIN_PROVISION = os.environ.get(str("TOX_PROVISION")) == "1"
 
+INTERRUPT_TIMEOUT = 0.3
+TERMINATE_TIMEOUT = 0.2
+
 
 def get_plugin_manager(plugins=()):
     # initialize plugin manager
@@ -799,6 +802,20 @@ def tox_addoption(parser):
     parser.add_testenv_attribute_obj(DepOption())
 
     parser.add_testenv_attribute(
+        name="interrupt_timeout",
+        type="float",
+        default=INTERRUPT_TIMEOUT,
+        help="timeout before sending SIGTERM after SIGINT",
+    )
+
+    parser.add_testenv_attribute(
+        name="terminate_timeout",
+        type="float",
+        default=TERMINATE_TIMEOUT,
+        help="timeout before sending SIGKILL after SIGTERM",
+    )
+
+    parser.add_testenv_attribute(
         name="commands",
         type="argvlist",
         default="",
@@ -1231,7 +1248,16 @@ class ParseIni(object):
         for env_attr in config._testenv_attr:
             atype = env_attr.type
             try:
-                if atype in ("bool", "path", "string", "dict", "dict_setenv", "argv", "argvlist"):
+                if atype in (
+                    "bool",
+                    "float",
+                    "path",
+                    "string",
+                    "dict",
+                    "dict_setenv",
+                    "argv",
+                    "argvlist",
+                ):
                     meth = getattr(reader, "get{}".format(atype))
                     res = meth(env_attr.name, env_attr.default, replace=replace)
                 elif atype == "basepython":
@@ -1447,6 +1473,20 @@ class SectionReader:
                 d[name.strip()] = rest.strip()
 
         return d
+
+    def getfloat(self, name, default=None, replace=True):
+        s = self.getstring(name, default, replace=replace)
+        if not s or not replace:
+            s = default
+        if s is None:
+            raise KeyError("no config value [{}] {} found".format(self.section_name, name))
+
+        if not isinstance(s, float):
+            try:
+                s = float(s)
+            except ValueError:
+                raise tox.exception.ConfigError("{}: invalid float {!r}".format(name, s))
+        return s
 
     def getbool(self, name, default=None, replace=True):
         s = self.getstring(name, default, replace=replace)

--- a/src/tox/session/__init__.py
+++ b/src/tox/session/__init__.py
@@ -19,7 +19,7 @@ import py
 import tox
 from tox import reporter
 from tox.action import Action
-from tox.config import parseconfig
+from tox.config import INTERRUPT_TIMEOUT, TERMINATE_TIMEOUT, parseconfig
 from tox.config.parallel import ENV_VAR_KEY_PRIVATE as PARALLEL_ENV_VAR_KEY_PRIVATE
 from tox.config.parallel import OFF_VALUE as PARALLEL_OFF
 from tox.logs.result import ResultLog
@@ -170,6 +170,8 @@ class Session(object):
             self.resultlog.command_log,
             self.popen,
             sys.executable,
+            INTERRUPT_TIMEOUT,
+            TERMINATE_TIMEOUT,
         )
 
     def runcommand(self):

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -130,6 +130,8 @@ class VirtualEnv(object):
             command_log,
             self.popen,
             self.envconfig.envpython,
+            self.envconfig.interrupt_timeout,
+            self.envconfig.terminate_timeout,
         )
 
     def get_result_json_path(self):

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -175,6 +175,25 @@ class TestVenvConfig:
         assert DepOption._is_same_dep("pkg_hello-world3==1.0", "pkg_hello-world3<=2.0")
         assert not DepOption._is_same_dep("pkg_hello-world3==1.0", "otherpkg>=2.0")
 
+    def test_interrupt_terminate_timeout_set_manually(self, newconfig):
+        config = newconfig(
+            [],
+            """
+            [testenv:dev]
+            interrupt_timeout = 5.0
+            terminate_timeout = 10.0
+
+            [testenv:other]
+        """,
+        )
+        envconfig = config.envconfigs["other"]
+        assert 0.3 == envconfig.interrupt_timeout
+        assert 0.2 == envconfig.terminate_timeout
+
+        envconfig = config.envconfigs["dev"]
+        assert 5.0 == envconfig.interrupt_timeout
+        assert 10.0 == envconfig.terminate_timeout
+
 
 class TestConfigPlatform:
     def test_config_parse_platform(self, newconfig):


### PR DESCRIPTION
By default, we run SIGKILL after 0.5 seconds. Most of the time is
enough. But if the interrupted command have a complex processes tree,
it might not be enough to propagate the signal.

In such case processes are left behind and never killed.
If theses processes use static network port or keep file open. Next
call of tox will fail until the all processes left behind are manually
killed.

This change adds some configuration to be able to config the timeout
before signals are sent.

If the approach work for you, I will polish the PR (doc+test)

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)