### PR TITLE
Add documentation for 'download' testenv option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -460,6 +460,13 @@ Complete list of settings that you can put into ``testenv*`` sections:
     This is useful for situations where hardlinks don't work (e.g. running in
     VMS with Windows guests).
 
+.. conf:: download ^ true|false ^ false
+
+    .. versionadded:: 3.10
+
+    Set to ``true`` if you want virtualenv to upgrade pip/wheel/setuptools to
+    the latest version.
+
 .. conf:: args_are_paths ^ true|false ^ false
 
     Treat positional arguments passed to ``tox`` as file system paths


### PR DESCRIPTION
In #1283, the 'download' option was added, but without documentation.