### PR TITLE
Include HTTP proxy environment variables in default passenv

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -68,6 +68,7 @@ Nick Douma
 Nick Prendergast
 Oliver Bestwalter
 Pablo Galindo
+Paul Moore
 Paweł Adamczak
 Philip Thiem
 Pierre-Jean Campigotto

--- a/docs/changelog/1498.feature.rst
+++ b/docs/changelog/1498.feature.rst
@@ -1,0 +1,1 @@
+Add ``HTTP_PROXY``, ``HTTPS_PROXY`` and ``NO_PROXY`` to default passenv. - by :user:`pfmoore`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -403,7 +403,8 @@ Complete list of settings that you can put into ``testenv*`` sections:
     * passed through on all platforms: ``CURL_CA_BUNDLE`, ``PATH``,
       ``LANG``, ``LANGUAGE``,
       ``LD_LIBRARY_PATH``, ``PIP_INDEX_URL``,
-      ``REQUESTS_CA_BUNDLE``, ``SSL_CERT_FILE``
+      ``REQUESTS_CA_BUNDLE``, ``SSL_CERT_FILE``,
+      ``HTTP_PROXY``, ``HTTPS_PROXY``,``NO_PROXY``
     * Windows: ``SYSTEMDRIVE``, ``SYSTEMROOT``, ``PATHEXT``, ``TEMP``, ``TMP``
        ``NUMBER_OF_PROCESSORS``, ``USERPROFILE``, ``MSYSTEM``
     * Others (e.g. UNIX, macOS): ``TMPDIR``

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -676,6 +676,9 @@ def tox_addoption(parser):
             "REQUESTS_CA_BUNDLE",
             "SSL_CERT_FILE",
             "TOX_WORK_DIR",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "NO_PROXY",
             str(REPORTER_TIMESTAMP_ON_ENV),
             str(PARALLEL_ENV_VAR_KEY_PUBLIC),
         }

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1096,6 +1096,9 @@ class TestConfigTestEnv:
         assert "LANG" in envconfig.passenv
         assert "LANGUAGE" in envconfig.passenv
         assert "LD_LIBRARY_PATH" in envconfig.passenv
+        assert "HTTP_PROXY" in envconfig.passenv
+        assert "HTTPS_PROXY" in envconfig.passenv
+        assert "NO_PROXY" in envconfig.passenv
         assert PARALLEL_ENV_VAR_KEY_PUBLIC in envconfig.passenv
         assert PARALLEL_ENV_VAR_KEY_PRIVATE not in envconfig.passenv
         assert "A123A" in envconfig.passenv


### PR DESCRIPTION
## Add HTTP proxy variables to the default passenv

Closes #1498

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
