### PR TITLE
Avoid incompatible six

### DIFF
--- a/docs/changelog/1519.bugfix.rst
+++ b/docs/changelog/1519.bugfix.rst
@@ -1,0 +1,2 @@
+Bump minimal six version needed to avoid using one incompatible with newer
+virtualenv. - by :user:`ssbarnea`

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     packaging >= 14
     pluggy >= 0.12.0, <1
     py >= 1.4.17, <2
-    six >= 1.0.0, <2
+    six >= 1.14.0, <2  # required when virtualenv>=20
     virtualenv >= 16.0.0
     toml >=0.9.4
     filelock >= 3.0.0, <4


### PR DESCRIPTION
Avoids problem introduced by newer virtualenv which broke installion
of tox on systems that already had a six version >1.0 installed but
which was older than minimal needed by tox.

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.
Avoids installing tox with a combination of virtualenv-six that is broken, mainly introduced by newer virtualenv which dropped vendored six and which requires six>=1.14.0. 

Pip fails to install correct dependency because we list six already as a dependecy. We cannot drop it but we can bump it to assure we avoid ending with incompatible setup.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
