### PR TITLE
Remove Python 3.4 from the supported Python version list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ classifiers =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7


### PR DESCRIPTION
Removes Python 3.4 from the supported Python versions list. refs #1483, #1456