### PR TITLE
Exclude virtualenvs vers w/ regressions 20.0.[0-7]

### DIFF
--- a/docs/changelog/1537.bugfix.rst
+++ b/docs/changelog/1537.bugfix.rst
@@ -1,0 +1,2 @@
+Exclude virtualenv depencency versions with known
+regressions (20.0.[0-7]) - by :user:`webknjaz`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     pluggy >= 0.12.0, <1
     py >= 1.4.17, <2
     six >= 1.14.0, <2  # required when virtualenv>=20
-    virtualenv >= 16.0.0
+    virtualenv >= 16.0.0, !=20.0.0, !=20.0.1, !=20.0.2, !=20.0.3, !=20.0.4, !=20.0.5, !=20.0.6, !=20.0.7
     toml >=0.9.4
     filelock >= 3.0.0, <4
     colorama >= 0.4.1 ;platform_system=="Windows"


### PR DESCRIPTION
virtualenv 20 series has had a number of regressions. This PR explicitly excludes versions with known issues that are hard to debug.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
