### PR TITLE
Fix `tox --help` and `tox --help-ini` shows an error when run outside a directory with tox support files #1509 #1540

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -65,6 +65,7 @@ Mikhail Kyshtymov
 Miro Hrončok
 Monty Taylor
 Morgan Fainberg
+Naveen S R
 Nick Douma
 Nick Prendergast
 Oliver Bestwalter

--- a/docs/changelog/1539.bugfix.rst
+++ b/docs/changelog/1539.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``tox -h`` and ``tox --hi`` shows an error when run outside a directory with tox support files by :user:`nkpro2000sr`.

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -270,6 +270,8 @@ def parseconfig(args, plugins=()):
         pm.hook.tox_configure(config=config)  # post process config object
         break
     else:
+        if option.help or option.helpini:
+            return config
         msg = "tox config file (either {}) not found"
         candidates = ", ".join(INFO.CONFIG_CANDIDATES)
         feedback(msg.format(candidates), sysexit=not (option.help or option.helpini))

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -84,11 +84,16 @@ class TestSession:
 def test_notoxini_help_still_works(initproj, cmd):
     initproj("example123-0.5", filedefs={"tests": {"test_hello.py": "def test_hello(): pass"}})
     result = cmd("-h")
-    msg = "ERROR: tox config file (either pyproject.toml, tox.ini, setup.cfg) not found\n"
-    assert result.err == msg
     assert result.out.startswith("usage: ")
     assert any("--help" in l for l in result.outlines), result.outlines
     result.assert_success(is_run_test_env=False)
+
+
+def test_notoxini_noerror_in_help(initproj, cmd):
+    initproj("examplepro", filedefs={})
+    result = cmd("-h")
+    msg = "ERROR: tox config file (either pyproject.toml, tox.ini, setup.cfg) not found\n"
+    assert result.err != msg
 
 
 def test_notoxini_help_ini_still_works(initproj, cmd):
@@ -96,6 +101,13 @@ def test_notoxini_help_ini_still_works(initproj, cmd):
     result = cmd("--help-ini")
     assert any("setenv" in l for l in result.outlines), result.outlines
     result.assert_success(is_run_test_env=False)
+
+
+def test_notoxini_noerror_in_help_ini(initproj, cmd):
+    initproj("examplepro", filedefs={})
+    result = cmd("--help-ini")
+    msg = "ERROR: tox config file (either pyproject.toml, tox.ini, setup.cfg) not found\n"
+    assert result.err != msg
 
 
 def test_envdir_equals_toxini_errors_out(cmd, initproj):

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,8 @@ passenv =
     SSL_CERT_FILE
     PYTEST_*
     PIP_CACHE_DIR
-deps = pip >= 19.3.1
+deps =
+    pip >= 19.3.1
 extras = testing
 commands = pytest \
            --cov "{envsitepackagesdir}/tox" \
@@ -39,7 +40,7 @@ commands = pytest \
            {posargs:.}
 
 [testenv:pypy]
-deps = 
+deps =
     pip >= 19.3.1
     psutil <= 5.6.7
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,11 @@ commands = pytest \
            -n={env:PYTEST_XDIST_PROC_NR:auto} \
            {posargs:.}
 
+[testenv:pypy]
+deps = 
+    pip >= 19.3.1
+    psutil <= 5.6.7
+
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
 basepython = python3.8


### PR DESCRIPTION
closes #1509, closes #1540 

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
