### PR TITLE
Fix exeception when command is empty

### DIFF
--- a/docs/changelog/1544.bugfix.rst
+++ b/docs/changelog/1544.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent exception when command is empty. - by :user:`bruchar1`

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -497,7 +497,7 @@ class VirtualEnv(object):
                 env = self._get_os_environ(is_test_command=True)
                 # Display PYTHONHASHSEED to assist with reproducibility.
                 action.setactivity(name, "PYTHONHASHSEED={!r}".format(env.get("PYTHONHASHSEED")))
-            for i, argv in enumerate(filter(lambda c: bool(c), commands)):
+            for i, argv in enumerate(filter(bool, commands)):
                 # have to make strings as _pcall changes argv[0] to a local()
                 # happens if the same environment is invoked twice
                 message = "commands[{}] | {}".format(

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -497,7 +497,7 @@ class VirtualEnv(object):
                 env = self._get_os_environ(is_test_command=True)
                 # Display PYTHONHASHSEED to assist with reproducibility.
                 action.setactivity(name, "PYTHONHASHSEED={!r}".format(env.get("PYTHONHASHSEED")))
-            for i, argv in enumerate(commands):
+            for i, argv in enumerate(filter(lambda c: bool(c), commands)):
                 # have to make strings as _pcall changes argv[0] to a local()
                 # happens if the same environment is invoked twice
                 message = "commands[{}] | {}".format(

--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -355,6 +355,25 @@ def test_env_variables_added_to_needs_reinstall(tmpdir, mocksession, newconfig, 
     assert env["TEMP_NOPASS_VAR"] == "456"
 
 
+def test_test_empty_commands(newmocksession):
+    mocksession = newmocksession(
+        [],
+        """\
+        [testenv]
+        commands =
+            {posargs}
+            echo foo bar
+        """,
+    )
+    venv = mocksession.getvenv("python")
+    with mocksession.newaction(venv.name, "update") as action:
+        venv.update(action)
+    venv.test()
+    # The first command is empty. It should be skipped.
+    # Therefore, echo foo bar has index 0.
+    mocksession.report.expect("verbosity0", "*run-test:*commands?0? | echo foo bar")
+
+
 def test_test_hashseed_is_in_output(newmocksession, monkeypatch):
     seed = "123456789"
     monkeypatch.setattr("tox.config.make_hashseed", lambda: seed)


### PR DESCRIPTION
Under some circumstances (e.g. commands = {posargs} ), tox try to run an empty command.
It causes an exception when looking for the first character of an empty string.