### PR TITLE
expand section names

### DIFF
--- a/docs/changelog/1545.feature.rst
+++ b/docs/changelog/1545.feature.rst
@@ -1,0 +1,1 @@
+Allow generative section name expansion. - by :user:`bruchar1`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -830,6 +830,27 @@ are stripped, so the following line defines the same environment names::
         flake
 
 
+.. _generative-sections:
+
+Generative section names
+++++++++++++++++++++++++
+
+.. versionadded:: 3.15
+
+Using similar syntax, it is possible to generate sections::
+
+    [testenv:py{27,36}-flake]
+
+This is equivalent to defining distinct sections::
+
+    $ tox -a
+    py27-flake
+    py36-flake
+
+It is useful when you need an environment different from the default one,
+but still want to take advantage of factor-conditional settings.
+
+
 .. _factors:
 
 Factors and factor-conditional settings

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -372,6 +372,29 @@ use :ref:`generative-envlist` and :ref:`conditional settings <factors>` to expre
         # mocking sqlite on 2.7 and 3.6 if factor "sqlite" is present
         py{27,36}-sqlite: mock
 
+
+Using generative section names
+------------------------------
+
+Suppose you have some binary packages, and need to run tests both in 32 and 64 bits.
+You also want an environment to create your virtual env for the developers.
+
+.. code-block:: ini
+
+    [testenv]
+    basepython =
+        py38-x86: python3.8-32
+        py38-x64: python3.8-64
+    commands = pytest
+
+    [testenv:py38-{x86,x64}-venv]
+    usedevelop = true
+    envdir =
+        x86: .venv-x86
+        x64: .venv-x64
+    commands =
+
+
 Prevent symbolic links in virtualenv
 ------------------------------------
 By default virtualenv will use symlinks to point to the system's python files, modules, etc.

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1358,11 +1358,12 @@ class ParseIni(object):
         The parser will see it as two different sections: [testenv:py36-cov], [testenv:py37-cov]
 
         """
-        factor_re = re.compile(r"\{([\w,]+)\}")
+        factor_re = re.compile(r"\{\s*([\w\s,]+)\s*\}")
+        split_re = re.compile(r"\s*,\s*")
         to_remove = set()
         for section in list(config.sections):
             split_section = factor_re.split(section)
-            for parts in itertools.product(*map(lambda g: g.split(","), split_section)):
+            for parts in itertools.product(*map(split_re.split, split_section)):
                 section_name = "".join(parts)
                 if section_name not in config.sections:
                     config.sections[section_name] = config.sections[section]

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -859,9 +859,9 @@ class TestIniParser:
         (msg,) = excinfo.value.args
         assert msg == "key5: boolean value 'yes' needs to be 'True' or 'False'"
 
-
     def test_expand_section_name(self, newconfig):
-        config = newconfig("""
+        config = newconfig(
+            """
             [testenv:custom-{one,two,three}-{four,five}-six]
         """
         )

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -860,6 +860,15 @@ class TestIniParser:
         assert msg == "key5: boolean value 'yes' needs to be 'True' or 'False'"
 
 
+    def test_expand_section_name(self, newconfig):
+        config = newconfig("""
+            [testenv:custom-{one,two,three}-{four,five}-six]
+        """
+        )
+        assert "testenv:custom-one-five-six" in config._cfg.sections
+        assert "testenv:custom-{one,two,three}-{four,five}-six" not in config._cfg.sections
+
+
 class TestIniParserPrefix:
     def test_basic_section_access(self, newconfig):
         config = newconfig(


### PR DESCRIPTION
This is a proposition to allow generative section names.

In conjecture with factors, it will allow to write more succinct config files, when using factors in the default [testenv] is not sufficient.

Let me know if you like it.
