### PR TITLE
Fixed irrelevant Error message for invalid argument when running outside a directory with tox support files #1546

### DIFF
--- a/1547.bugfix.rst
+++ b/1547.bugfix.rst
@@ -1,0 +1,2 @@
+Fix irrelevant Error message for invalid argument when running outside a directory with tox support files by :user:`nkpro2000sr`.
+

--- a/docs/changelog/1547.bugfix.rst
+++ b/docs/changelog/1547.bugfix.rst
@@ -1,2 +1,1 @@
 Fix irrelevant Error message for invalid argument when running outside a directory with tox support files by :user:`nkpro2000sr`.
-

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -270,6 +270,11 @@ def parseconfig(args, plugins=()):
         pm.hook.tox_configure(config=config)  # post process config object
         break
     else:
+        parser = Parser()
+        pm.hook.tox_addoption(parser=parser)
+        # if no tox config file, now we need do a strict argument evaluation
+        # raise on unknown args
+        parser.parse_cli(args, strict=True)
         if option.help or option.helpini:
             return config
         msg = "tox config file (either {}) not found"

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -110,6 +110,25 @@ def test_notoxini_noerror_in_help_ini(initproj, cmd):
     assert result.err != msg
 
 
+def test_unrecognized_arguments_error(initproj, cmd):
+    initproj(
+        "examplepro1",
+        filedefs={
+            "tests": {"test_hello.py": "def test_hello(): pass"},
+            "tox.ini": """
+        [testenv:hello]
+        [testenv:world]
+        """,
+        },
+    )
+    result1 = cmd("--invalid-argument")
+    withtoxini = result1.err
+    initproj("examplepro2", filedefs={})
+    result2 = cmd("--invalid-argument")
+    notoxini = result2.err
+    assert withtoxini == notoxini
+
+
 def test_envdir_equals_toxini_errors_out(cmd, initproj):
     initproj(
         "interp123-0.7",


### PR DESCRIPTION
Fixed #1546 by adding pre argument evaluation for no tox supported files.  

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
