### PR TITLE
Allow parallel mode without arguments

### DIFF
--- a/docs/changelog/1418.feature.rst
+++ b/docs/changelog/1418.feature.rst
@@ -1,0 +1,1 @@
+Allow parallel mode without arguments. - by :user:`ssbarnea`

--- a/src/tox/config/parallel.py
+++ b/src/tox/config/parallel.py
@@ -45,9 +45,11 @@ def add_parallel_flags(parser):
     parser.add_argument(
         "-p",
         "--parallel",
+        nargs="?",
+        const="auto",
         dest="parallel",
         help="run tox environments in parallel, the argument controls limit: all,"
-        " auto - cpu count, some positive number, zero is turn off",
+        " auto or missing argument - cpu count, some positive number, 0 to turn off",
         action="store",
         type=parse_num_processes,
         default=DEFAULT_PARALLEL,


### PR DESCRIPTION
Allows calling tox with `tox -p` in order to use auto mode. Previously
it was mandatory to mention `auto` in order to enable parallel mode.

This will not change behavior of tox when called without `-p`, which
will still keep the non-parallel mode.

Fixes: #1418
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>


