### PR TITLE
Allow `PATH` modifications via `prependpath` and `appendpath`.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ Alexander Schepanovski
 Alexandre Conrad
 Allan Feldman
 Andrii Soldatenko
+Andrzej Klajnert
 Anthon van der Neuth
 Anthony Sottile
 Anudit Nagar

--- a/docs/changelog/1423.feature.rst
+++ b/docs/changelog/1423.feature.rst
@@ -1,0 +1,1 @@
+Allow ``PATH`` modifications via ``prependpath`` and ``appendpath``. - by :user:`aklajnert`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -386,6 +386,9 @@ Complete list of settings that you can put into ``testenv*`` sections:
         setenv   =
             PYTHONPATH = {env:PYTHONPATH}{:}{toxinidir}
 
+    .. warning:: Setting ``PATH`` variable will be ignored to avoid breaking tox internals,
+        use ``prependpath`` or ``appendpath`` to manipulate it.
+
 .. conf:: passenv ^ SPACE-SEPARATED-GLOBNAMES
 
     .. versionadded:: 2.0
@@ -420,6 +423,29 @@ Complete list of settings that you can put into ``testenv*`` sections:
         ``PYTHONPATH`` will be passed down if explicitly defined. If
         ``PYTHONPATH`` exists in the host environment but is **not** declared
         in ``passenv`` a warning will be emitted.
+
+.. conf:: prependpath ^ string
+
+    .. versionadded:: 3.14.8
+
+    Add path fragments **before** ``PATH`` variable.
+
+    .. code-block:: ini
+
+        [testenv]
+        prependpath = {toxinidir}/bin/
+
+.. conf:: appendpath ^ string
+
+    .. versionadded:: 3.14.8
+
+    Add path fragments **after** ``PATH`` variable.
+
+    .. code-block:: ini
+
+        [testenv]
+        appendpath = {toxinidir}/bin/
+
 
 .. conf:: recreate ^ true|false ^ false
 

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -557,7 +557,9 @@ class VirtualEnv(object):
         # construct environment variables
         env.pop("VIRTUALENV_PYTHON", None)
         bin_dir = str(self.envconfig.envbindir)
-        env["PATH"] = os.pathsep.join([bin_dir, os.environ["PATH"]])
+        env["PATH"] = os.pathsep.join(
+            [*self.envconfig.prependpath, bin_dir, os.environ["PATH"], *self.envconfig.appendpath]
+        )
         reporter.verbosity2("setting PATH={}".format(env["PATH"]))
 
         # get command


### PR DESCRIPTION
Closes #1423

Two changes here:
- Warn if a user attempts to change `PATH` via `setenv`,
- Allow extending `PATH` via `prependenv` and `appendenv` variables.