### PR TITLE
Passenv PIP_EXTRA_INDEX_URL by default

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -168,7 +168,7 @@ Here is a simple overview, with tox-specific bits:
 
     $ tox -e dev
 
-   To get information about all environements, type:
+   To get information about all environments, type:
 
    $ tox -av
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ Eugene Yunak
 Fernando L. Pereira
 Florian Preinstorfer
 Florian Schulze
+George Alton
 Gonéri Le Bouder
 Hazal Ozturk
 Henk-Jaap Wagenaar

--- a/docs/changelog/1561.feature.rst
+++ b/docs/changelog/1561.feature.rst
@@ -1,0 +1,1 @@
+default to passing the env var PIP_EXTRA_INDEX_URL by :user:`georgealton`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -402,7 +402,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
 
     * passed through on all platforms: ``CURL_CA_BUNDLE``, ``PATH``,
       ``LANG``, ``LANGUAGE``,
-      ``LD_LIBRARY_PATH``, ``PIP_INDEX_URL``,
+      ``LD_LIBRARY_PATH``, ``PIP_INDEX_URL``, ``PIP_EXTRA_INDEX_URL``,
       ``REQUESTS_CA_BUNDLE``, ``SSL_CERT_FILE``,
       ``HTTP_PROXY``, ``HTTPS_PROXY``, ``NO_PROXY``
     * Windows: ``SYSTEMDRIVE``, ``SYSTEMROOT``, ``PATHEXT``, ``TEMP``, ``TMP``

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -688,6 +688,7 @@ def tox_addoption(parser):
             "LD_LIBRARY_PATH",
             "PATH",
             "PIP_INDEX_URL",
+            "PIP_EXTRA_INDEX_URL",
             "REQUESTS_CA_BUNDLE",
             "SSL_CERT_FILE",
             "TOX_WORK_DIR",

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1100,6 +1100,7 @@ class TestConfigTestEnv:
         assert "CURL_CA_BUNDLE" in envconfig.passenv
         assert "PATH" in envconfig.passenv
         assert "PIP_INDEX_URL" in envconfig.passenv
+        assert "PIP_EXTRA_INDEX_URL" in envconfig.passenv
         assert "REQUESTS_CA_BUNDLE" in envconfig.passenv
         assert "SSL_CERT_FILE" in envconfig.passenv
         assert "LANG" in envconfig.passenv


### PR DESCRIPTION
This Pull Request passes the `PIP_EXTRA_INDEX_URL` environment variable to tox environments by default. Allowing pip index configuration to pass to tox environments without having to set `passenv` configuration. 

I believe this is in spirit with the current `PIP_INDEX_URL` default passing behaviour. 

This closes #1561 