### PR TITLE
Respect attempts to change PATH via setenv

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ Alexander Schepanovski
 Alexandre Conrad
 Allan Feldman
 Andrii Soldatenko
+Andrzej Klajnert
 Anthon van der Neuth
 Anthony Sottile
 Anudit Nagar

--- a/docs/changelog/1423.bugfix.rst
+++ b/docs/changelog/1423.bugfix.rst
@@ -1,0 +1,1 @@
+Respect attempts to change `PATH` via `setenv`. - by :user:`aklajnert`

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -557,7 +557,8 @@ class VirtualEnv(object):
         # construct environment variables
         env.pop("VIRTUALENV_PYTHON", None)
         bin_dir = str(self.envconfig.envbindir)
-        env["PATH"] = os.pathsep.join([bin_dir, os.environ["PATH"]])
+        path = self.envconfig.setenv.get("PATH") or os.environ["PATH"]
+        env["PATH"] = os.pathsep.join([bin_dir, path])
         reporter.verbosity2("setting PATH={}".format(env["PATH"]))
 
         # get command


### PR DESCRIPTION
Closes #1423

This PR fixes `setenv` behavior to allow changing `PATH`. Currently, an attempt to change it is ignored.