### PR TITLE
[WIP] Make skipsdist = factor: true work

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,6 +48,7 @@ Josh Snyder
 Julian Krause
 Jurko Gospodnetić
 Krisztian Fekete
+Kyle Altendorf
 Laszlo Vasko
 Lukasz Balcerzak
 Lukasz Rogalski

--- a/docs/changelog/1567.bugfix.rst
+++ b/docs/changelog/1567.bugfix.rst
@@ -1,1 +1,1 @@
-Fix exception when specifying factor for skipsdist - by :user:`altendky`
+Fix exception when specifying factor for skipsdist - by :user:`altendky`.

--- a/docs/changelog/1567.bugfix.rst
+++ b/docs/changelog/1567.bugfix.rst
@@ -1,0 +1,1 @@
+Fix exception when specifying factor for skipsdist - by :user:`altendky`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1461,12 +1461,12 @@ E.g. {[base]commands}
 
 class SectionReader:
     def __init__(self, section_name, cfgparser, fallbacksections=None, factors=None, prefix=None):
+        if factors is None:
+            factors = set()
         if prefix is None:
             self.section_name = section_name
         else:
             self.section_name = "{}:{}".format(prefix, section_name)
-        if factors is None:
-            factors = set()
         self._cfg = cfgparser
         self.fallbacksections = fallbacksections or []
         self.factors = factors

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1460,11 +1460,13 @@ E.g. {[base]commands}
 
 
 class SectionReader:
-    def __init__(self, section_name, cfgparser, fallbacksections=None, factors=(), prefix=None):
+    def __init__(self, section_name, cfgparser, fallbacksections=None, factors=None, prefix=None):
         if prefix is None:
             self.section_name = section_name
         else:
             self.section_name = "{}:{}".format(prefix, section_name)
+        if factors is None:
+            factors = set()
         self._cfg = cfgparser
         self.fallbacksections = fallbacksections or []
         self.factors = factors

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -356,6 +356,34 @@ class TestIniParserAgainstCommandsKey:
         x = reader.getargvlist("commands")
         assert x == [["echo", "whatever"]]
 
+    def test_skipsdist_factor_with_no_factor(self, newconfig):
+        config = newconfig(
+            """
+            [tox]
+            skipsdist = factor: true
+            [testenv]
+            commands =
+                echo {[tox]skipsdist}
+            """
+        )
+        reader = SectionReader("testenv", config._cfg)
+        x = reader.getargvlist("commands")
+        assert x == [["echo", "false"]]
+
+    def test_skipsdist_factor_with_factor(self, newconfig):
+        config = newconfig(
+            """
+            [tox]
+            skipsdist = factor: true
+            [testenv]
+            commands =
+                echo {[tox]skipsdist}
+            """
+        )
+        reader = SectionReader("testenv", config._cfg, factors={'factor'})
+        x = reader.getargvlist("commands")
+        assert x == [["echo", "true"]]
+
     def test_command_substitution_from_other_section_multiline(self, newconfig):
         """Ensure referenced multiline commands form from other section injected
         as multiple commands."""


### PR DESCRIPTION
Make the following `tox.ini` with the factor not result in an exception and also respect the factor.  Fixes #1567.

```ini
[tox]
skipsdist = factor: true
```

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
