### PR TITLE
Allow both pre- and post- PEP 610 outputs in test_venv_special_chars_issue252

### DIFF
--- a/docs/changelog/1594.misc.rst
+++ b/docs/changelog/1594.misc.rst
@@ -1,0 +1,1 @@
+Allow to run the tests with pip 19.3.1 once again while preserving the ability to use pip 20.1 - by :user:`hroncok`

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -337,7 +337,7 @@ def test_venv_special_chars_issue252(cmd, initproj):
     )
     result = cmd()
     result.assert_success()
-    pattern = re.compile("special&&1 installed: .*pkg123 @ .*-0.7.zip.*")
+    pattern = re.compile(r"special&&1 installed: .*pkg123( @ .*-|==)0\.7(\.zip)?.*")
     assert any(pattern.match(line) for line in result.outlines), "\n".join(result.outlines)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ passenv =
     PYTEST_*
     PIP_CACHE_DIR
 deps =
-    pip >= 20.1
+    pip >= 19.3.1
 extras = testing
 commands = pytest \
            --cov "{envsitepackagesdir}/tox" \


### PR DESCRIPTION
pip 20.1+ supports PEP 610 https://www.python.org/dev/peps/pep-0610/
Hence the output is changed a bit.
This was acknowledged in 553d6f282119481cbd4cf2a78e633eb8b506659e.

Here we allow to run the tests with pip 19.3.x again
by relaxing the regex to match both the old and the new format.

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] <del>updated/extended the documentation</del> (trivial change)
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body (added a commit link)
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (already there)
