### PR TITLE
Precompile common regular expressions

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Barry Warsaw
 Bartolome Sanchez Salado
 Benoit Pierre
 Bernat Gabor
+Brett Langdon
 Bruno Oliveira
 Carl Meyer
 Charles Brunet

--- a/docs/changelog/1603.misc.rst
+++ b/docs/changelog/1603.misc.rst
@@ -1,0 +1,1 @@
+Improve config parsing performance by precompiling commonly used regular expressions - by :user:`brettlangdon`


### PR DESCRIPTION
For very large tox.ini configurations there is a lot of time spent calling `re._compile` for static regular expressions. By precompiling these common/static regular expressions I was able to get our `tox -l` run from 7.79s to 6.63s

Example of our [tox.ini](https://github.com/DataDog/dd-trace-py/blob/9b106d8b51c0a7e874a5e2f125ee19eaa43fcbc4/tox.ini)

```
$ python ./src/tox/__main__.py -c ~/example/tox.ini -l | wc -l
1199

$ time python ./src/tox/__main__.py -c ~/example/tox.ini -l > /dev/null
python ./src/tox/__main__.py -c ~/example/tox.ini -l > /dev/null  7.79s user 0.97s system 107% cpu 8.122 total

$ time python ./src/tox/__main__.py -c ~/example/tox.ini -l > /dev/null
python ./src/tox/__main__.py -c ~/example/tox.ini -l > /dev/null  6.63s user 0.95s system 109% cpu 6.924 total
```


## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
