### PR TITLE
Remove usage of threads for parsing ini

### DIFF
--- a/docs/changelog/1604.misc.rst
+++ b/docs/changelog/1604.misc.rst
@@ -1,0 +1,1 @@
+Remove threading from config parsing for performance improvements - by :user:`brettlangdon`


### PR DESCRIPTION
The GIL prevents us from using threads to optimize this process. So we end up paying the costs of threading coordination without any of the benefits.

On small config files this makes almost no difference in performance, but for large config files it does.

For our large config file (1199 envs) it drops runtime by about 1.5s.

```
$ python ./src/tox/__main__.py -c ~/example/tox.ini -l | wc -l
1199

$ time python ./src/tox/__main__.py -c ~/example/tox.ini -l > /dev/null
python ./src/tox/__main__.py -c ~/example/tox.ini -l > /dev/null  8.39s user 1.18s system 109% cpu 8.712 total

$ time python ./src/tox/__main__.py -c ~/example/tox.ini -l > /dev/null
python ./src/tox/__main__.py -c ~/example/tox.ini -l > /dev/null  6.82s user 0.40s system 99% cpu 7.258 total
```

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
  - Added in a previous approved PR
