### PR TITLE
Allow true separation of environment setup and test run

### DIFF
--- a/docs/changelog/1605.feature.rst
+++ b/docs/changelog/1605.feature.rst
@@ -1,0 +1,8 @@
+Allow skipping the package and installation step when passing the ``--skip-pkg-install``. This should be used in pair with the ``--notest``, so you can separate environment setup and test run:
+
+ .. code-block:: console
+
+    tox -e py --notest
+    tox -e py --skip-pkg-install
+
+by :user:`gaborbernat`.

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -447,6 +447,9 @@ def tox_addoption(parser):
     parser.add_argument(
         "--sdistonly", action="store_true", help="only perform the sdist packaging activity.",
     )
+    parser.add_argument(
+        "--skip-pkg-install", action="store_true", help="skip package installation for this run",
+    )
     add_parallel_flags(parser)
     parser.add_argument(
         "--parallel--safe-build",
@@ -661,10 +664,14 @@ def tox_addoption(parser):
 
     parser.add_testenv_attribute_obj(PosargsOption())
 
+    def skip_install_default(testenv_config, value):
+        return value is True or testenv_config.config.option.skip_pkg_install is True
+
     parser.add_testenv_attribute(
         name="skip_install",
         type="bool",
         default=False,
+        postprocess=skip_install_default,
         help="Do not install the current package. This can be used when you need the virtualenv "
         "management but do not want to install the current package",
     )

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -3121,3 +3121,19 @@ def test_config_no_version_data_in__name(newconfig, capsys):
     out, err = capsys.readouterr()
     assert not out
     assert not err
+
+
+def test_overwrite_skip_install_override(newconfig):
+    source = """
+        [tox]
+        envlist = py, skip
+        [testenv:skip]
+        skip_install = True
+        """
+    config = newconfig(args=[], source=source)
+    assert config.envconfigs["py"].skip_install is False  # by default do not skip
+    assert config.envconfigs["skip"].skip_install is True
+
+    config = newconfig(args=["--skip-pkg-install"], source=source)
+    assert config.envconfigs["py"].skip_install is True  # skip if the flag is passed
+    assert config.envconfigs["skip"].skip_install is True


### PR DESCRIPTION
By allowing to escape the package build and install upon passing in the
`--skip-pkg-install` flag.

Resolves #1605.