### PR TITLE
🐛 Register `{temp_dir}` as a valid substitution

### DIFF
--- a/docs/changelog/1609.bugfix.rst
+++ b/docs/changelog/1609.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the support for using ``{temp_dir}`` in ``tox.ini`` - by :user:`webknjaz`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1102,8 +1102,9 @@ class ParseIni(object):
 
         reader.addsubstitutions(distdir=config.distdir)
         config.distshare = reader.getpath("distshare", dist_share_default)
-        config.temp_dir = reader.getpath("temp_dir", "{toxworkdir}/.tmp")
         reader.addsubstitutions(distshare=config.distshare)
+        config.temp_dir = reader.getpath("temp_dir", "{toxworkdir}/.tmp")
+        reader.addsubstitutions(temp_dir=config.temp_dir)
         config.sdistsrc = reader.getpath("sdistsrc", None)
         config.setupdir = reader.getpath("setupdir", "{toxinidir}")
         config.logdir = config.toxworkdir.join("log")


### PR DESCRIPTION
This change recovers a missing `temp_dir` substitution.
The docs for it were added in #1032 but it never actually worked.

Fixes #1608

## Contribution checklist:

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
