### PR TITLE
Add long --verbose/--quiet cli arguments

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,6 +30,7 @@ Ederag
 Eli Collins
 Eugene Yunak
 Fernando L. Pereira
+Florian Bruhin
 Florian Preinstorfer
 Florian Schulze
 George Alton

--- a/docs/changelog/1612.feature.rst
+++ b/docs/changelog/1612.feature.rst
@@ -1,0 +1,1 @@
+The long arguments ``--verbose`` and ``--quiet`` (rather than only their short forms, ``-v`` and ``-q``) are now accepted.

--- a/src/tox/config/reporter.py
+++ b/src/tox/config/reporter.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 def add_verbosity_commands(parser):
     parser.add_argument(
         "-v",
+        "--verbose",
         action="count",
         dest="verbose_level",
         default=0,
@@ -13,6 +14,7 @@ def add_verbosity_commands(parser):
     )
     parser.add_argument(
         "-q",
+        "--quiet",
         action="count",
         dest="quiet_level",
         default=0,

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2126,15 +2126,18 @@ class TestGlobalOptions:
         config = newconfig(["--notest"], "")
         assert config.option.notest
 
-    def test_verbosity(self, newconfig):
-        config = newconfig([], "")
-        assert config.option.verbose_level == 0
-        config = newconfig(["-v"], "")
-        assert config.option.verbose_level == 1
-        config = newconfig(["-vv"], "")
-        assert config.option.verbose_level == 2
+    @pytest.mark.parametrize(
+        "args, expected",
+        [([], 0), (["-v"], 1), (["-vv"], 2), (["--verbose", "--verbose"], 2), (["-vvv"], 3)],
+    )
+    def test_verbosity(self, args, expected, newconfig):
+        config = newconfig(args, "")
+        assert config.option.verbose_level == expected
 
-    @pytest.mark.parametrize("args, expected", [([], 0), (["-q"], 1), (["-qq"], 2), (["-qqq"], 3)])
+    @pytest.mark.parametrize(
+        "args, expected",
+        [([], 0), (["-q"], 1), (["-qq"], 2), (["--quiet", "--quiet"], 2), (["-qqq"], 3)],
+    )
     def test_quiet(self, args, expected, newconfig):
         config = newconfig(args, "")
         assert config.option.quiet_level == expected


### PR DESCRIPTION
As those are pretty common across different projects I'd say.

Will add tests/changelog (?) if this sounds like a good idea.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
