### PR TITLE
Update recommended packaging information for Flit

### DIFF
--- a/docs/changelog/1613.doc.rst
+++ b/docs/changelog/1613.doc.rst
@@ -1,0 +1,1 @@
+Update packaging information for Flit.

--- a/docs/example/package.rst
+++ b/docs/example/package.rst
@@ -43,8 +43,8 @@ file as that information is also added to the ``pyproject.toml`` file.
 .. code-block:: toml
 
     [build-system]
-    requires = ["flit >= 1.1"]
-    build-backend = "flit.buildapi"
+    requires = ["flit_core >=2,<4"]
+    build-backend = "flit_core.buildapi"
 
     [tool.flit.metadata]
     module = "package_toml_flit"
@@ -57,13 +57,6 @@ file as that information is also added to the ``pyproject.toml`` file.
    # tox.ini
    [tox]
    isolated_build = True
-
-   [tox:.package]
-   # note tox will use the same python version as under what tox is installed to package
-   # so unless this is python 3 you can require a given python version for the packaging
-   # environment via the basepython key
-   basepython = python3
-
 
 poetry
 ------


### PR DESCRIPTION
The recommended build-system details are now `flit_core` - see Flit's docs: https://flit.readthedocs.io/en/latest/

`flit_core` 2.x can run on Python 2, so this should work without the `basepython` option as well.