### PR TITLE
Implement support for PEP517 backend-path setting

### DIFF
--- a/docs/changelog/1575.feature.rst
+++ b/docs/changelog/1575.feature.rst
@@ -1,0 +1,3 @@
+Implement support for building projects
+having :pep:`517#in-tree-build-backends` ``backend-path`` setting -
+by :user:`webknjaz`

--- a/src/tox/helper/build_isolated.py
+++ b/src/tox/helper/build_isolated.py
@@ -8,6 +8,24 @@ tarball.
 import os
 import sys
 
+
+def _ensure_module_in_paths(module, paths):
+    """Verify that the imported backend belongs in-tree."""
+    if not paths:
+        return
+
+    module_path = os.path.normcase(os.path.abspath(module.__file__))
+    normalized_paths = (os.path.normcase(os.path.abspath(path)) for path in paths)
+
+    if any(os.path.commonprefix((module_path, path)) == path for path in normalized_paths):
+        return
+
+    raise SystemExit(
+        "build-backend ({!r}) must exist in one of the paths "
+        "specified by backend-path ({!r})".format(module, paths),
+    )
+
+
 dist_folder = sys.argv[1]
 backend_spec = sys.argv[2]
 backend_obj = sys.argv[3] if len(sys.argv) >= 4 else None
@@ -16,6 +34,7 @@ backend_paths = sys.argv[4].split(os.path.pathsep) if sys.argv[4] else []
 sys.path[:0] = backend_paths
 
 backend = __import__(backend_spec, fromlist=["_trash"])
+_ensure_module_in_paths(backend, backend_paths)
 if backend_obj:
     backend = getattr(backend, backend_obj)
 

--- a/src/tox/helper/build_isolated.py
+++ b/src/tox/helper/build_isolated.py
@@ -1,8 +1,19 @@
+"""PEP 517 build backend invocation script.
+
+It accepts externally parsed build configuration from `[build-system]`
+in `pyproject.toml` and invokes an API endpoint for building an sdist
+tarball.
+"""
+
+import os
 import sys
 
 dist_folder = sys.argv[1]
 backend_spec = sys.argv[2]
 backend_obj = sys.argv[3] if len(sys.argv) >= 4 else None
+backend_paths = sys.argv[4].split(os.path.pathsep) if sys.argv[4] else []
+
+sys.path[:0] = backend_paths
 
 backend = __import__(backend_spec, fromlist=["_trash"])
 if backend_obj:

--- a/src/tox/package/builder/isolated.py
+++ b/src/tox/package/builder/isolated.py
@@ -50,17 +50,6 @@ def build(config, session):
     return perform_isolated_build(build_info, package_venv, config.distdir, config.setupdir)
 
 
-def _ensure_importable_in_path(python_path, importable):
-    """Figure out if the importable exists in the given path."""
-    mod_chunks = importable.split(".")
-    pkg_path = python_path.join(*mod_chunks[:-1])
-    if not pkg_path.exists():
-        return False
-    if pkg_path.join(mod_chunks[-1], "__init__.py").exists():
-        return True
-    return pkg_path.join(mod_chunks[-1] + ".py").exists()
-
-
 def get_build_info(folder):
     toml_file = folder.join("pyproject.toml")
 
@@ -102,9 +91,6 @@ def get_build_info(folder):
     if not isinstance(backend_paths, list):
         abort("backend-path key at build-system section must be a list, if specified")
     backend_paths = [folder.join(p) for p in backend_paths]
-
-    if backend_paths and not any(_ensure_importable_in_path(p, module) for p in backend_paths):
-        abort("build-backend must exist in one of the paths specified by backend-path")
 
     return BuildInfo(requires, module, obj, backend_paths)
 

--- a/tests/unit/package/builder/test_package_builder_isolated.py
+++ b/tests/unit/package/builder/test_package_builder_isolated.py
@@ -138,3 +138,18 @@ def test_package_isolated_toml_bad_backend(initproj):
     build-backend = []
     """,
     )
+
+
+def test_package_isolated_toml_bad_backend_path(initproj):
+    """Verify that a non-list 'backend-path' is forbidden."""
+    toml_file_check(
+        initproj,
+        6,
+        "backend-path key at build-system section must be a list, if specified",
+        """
+    [build-system]
+    requires = []
+    build-backend = 'setuptools.build_meta'
+    backend-path = 42
+    """,
+    )


### PR DESCRIPTION
This change implements support for `backend-path` in the `[build-system]` section of
`pyproject.toml` as described @ https://www.python.org/dev/peps/pep-0517/#in-tree-build-backends.

Resolves #1575.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
