### PR TITLE
Use a HOSTNAME environment variable instead of socket.getfqdn() in ResultLog

### DIFF
--- a/docs/changelog/1615.feature.rst
+++ b/docs/changelog/1615.feature.rst
@@ -1,0 +1,3 @@
+The ``ResultLog`` now prefers ``HOSTNAME`` environment variable value (if set) over the full qualified domain name of localhost.
+This makes it possible to disable an undesired DNS lookup,
+which happened on all ``tox`` invocations, including trivial ones - by :user:`hroncok`

--- a/src/tox/logs/result.py
+++ b/src/tox/logs/result.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import json
+import os
 import socket
 import sys
 
@@ -21,7 +22,7 @@ class ResultLog(object):
             "reportversion": "1",
             "toxversion": __version__,
             "platform": sys.platform,
-            "host": socket.getfqdn(),
+            "host": os.getenv(str("HOSTNAME")) or socket.getfqdn(),
             "commands": command_log,
         }
 


### PR DESCRIPTION
This makes it possible to prevent an undesired DNS query.

Fixes https://github.com/tox-dev/tox/issues/1615

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)

Not quite sure where to document this behavior.