### PR TITLE
Fix tests when HOSTNAME is set, but empty string

### DIFF
--- a/docs/changelog/1616.bugfix.rst
+++ b/docs/changelog/1616.bugfix.rst
@@ -1,0 +1,1 @@
+Fix tests when the ``HOSTNAME`` environment variable is set, but empty string - by :user:`hroncok`


### PR DESCRIPTION
See https://github.com/tox-dev/tox/pull/1616#issuecomment-658437312

This is a fixup of cfe66fd0fe8a81bd65f79f589486b7721632a4cb.

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
