### PR TITLE
📝 Use a GH Sponsors link for `:user:` Sphinx role

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,5 +125,5 @@ linkcheck_ignore = [r"https://holgerkrekel.net"]
 extlinks = {
     "issue": ("https://github.com/tox-dev/tox/issues/%s", "#"),
     "pull": ("https://github.com/tox-dev/tox/pull/%s", "p"),
-    "user": ("https://github.com/%s", "@"),
+    "user": ("https://github.com/sponsors/%s", "@"),
 }


### PR DESCRIPTION
Links to https://github.com/sponsors/{{ username }} open as GitHub
Sponsors page if the target `username` has it enabled and redirect
to https://github.com/{{ username }} if it's disabled.