### PR TITLE
[cleanup] Remove artefacts from old py34 support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Asmund Grammeltwedt
 Barney Gale
 Barry Warsaw
 Bartolome Sanchez Salado
+Bastien Vallet
 Benoit Pierre
 Bernat Gabor
 Brett Langdon

--- a/docs/drafts/tox_conda_notes_niccodemus.md
+++ b/docs/drafts/tox_conda_notes_niccodemus.md
@@ -33,7 +33,7 @@ type=conda-env
 
 1. Create a new ``create_env_command`` option.
 ;2. Create a new ``env_activate_command`` option (also consider how to make that platform dependent).
-2. New substitution variable: {python_version} ('3.4', '2.7', etc')
+2. New substitution variable: {python_version} ('3.5', '2.7', etc')
 3. env type concept: different types change the default options.
 
 1. tox_addoption can now add new "testenv" sections to tox.ini:

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -359,18 +359,18 @@ use :ref:`generative-envlist` and :ref:`conditional settings <factors>` to expre
 .. code-block:: ini
 
     [tox]
-    envlist = py{27,34,36}-django{15,16}-{sqlite,mysql}
+    envlist = py{36,37,38}-django{22,30}-{sqlite,mysql}
 
     [testenv]
     deps =
-        django15: Django>=1.5,<1.6
-        django16: Django>=1.6,<1.7
-        # use PyMySQL if factors "py34" and "mysql" are present in env name
-        py34-mysql: PyMySQL
-        # use urllib3 if any of "py36" or "py27" are present in env name
-        py27,py36: urllib3
-        # mocking sqlite on 2.7 and 3.6 if factor "sqlite" is present
-        py{27,36}-sqlite: mock
+        django22: Django>=2.2,<2.3
+        django30: Django>=3.0,<3.1
+        # use PyMySQL if factors "py37" and "mysql" are present in env name
+        py38-mysql: PyMySQL
+        # use urllib3 if any of "py36" or "py37" are present in env name
+        py36,py37: urllib3
+        # mocking sqlite on 3.6 and 3.7 if factor "sqlite" is present
+        py{36,37}-sqlite: mock
 
 
 Using generative section names

--- a/docs/example/unittest.rst
+++ b/docs/example/unittest.rst
@@ -48,7 +48,7 @@ that looks like this:
 .. code-block:: ini
 
     [tox]
-    envlist = py27,py34,py35,py36
+    envlist = py27,py35,py36,py37
 
     [testenv]
     deps = unittest2
@@ -74,7 +74,7 @@ that looks like this:
 
 mock uses unittest2_ to run the tests. Invoking ``tox`` starts test
 discovery by executing the ``unit2 discover``
-commands on Python 2.7, 3.4, 3.5 and 3.6 respectively.  Against
+commands on Python 2.7, 3.5, 3.6 and 3.7 respectively.  Against
 Python3.6 and Python2.7 it will additionally run sphinx-mediated
 doctests. If building the docs fails, due to a reST error, or
 any of the doctests fails, it will be reported by the tox run.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -139,7 +139,7 @@ Current features
 * uses pip_ and setuptools_ by default.  Support for configuring the installer command
   through :conf:`install_command=ARGV`.
 
-* **cross-Python compatible**: CPython-2.7, 3.4 and higher, Jython and pypy_.
+* **cross-Python compatible**: CPython-2.7, 3.5 and higher, Jython and pypy_.
 
 * **cross-platform**: Windows and Unix style environments
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,7 @@ tox installation
 Install info in a nutshell
 ----------------------------------
 
-**Pythons**: CPython 2.7 and 3.4 or later, Jython-2.5.1, pypy-1.9ff
+**Pythons**: CPython 2.7 and 3.5 or later, Jython-2.5.1, pypy-1.9ff
 
 **Operating systems**: Linux, Windows, OSX, Unix
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,12 +62,12 @@ testing =
     flaky>=3.4.0
     freezegun>=0.3.11
     pathlib2>=2.3.3
+    psutil>=5.6.1
     pytest>=4.0.0
     pytest-cov>=2.5.1
     pytest-mock>=1.10.0
     pytest-randomly>=1.0.0
     pytest-xdist>=1.22.2
-    psutil>=5.6.1;python_version != "3.4"
 
 [options.packages.find]
 where = src

--- a/tests/unit/session/test_list_env.py
+++ b/tests/unit/session/test_list_env.py
@@ -5,9 +5,9 @@ def test_listenvs(cmd, initproj, monkeypatch):
         filedefs={
             "tox.ini": """
         [tox]
-        envlist=py36,py27,py34,pypi,docs
+        envlist=py36,py27,py37,pypi,docs
         description= py27: run pytest on Python 2.7
-                     py34: run pytest on Python 3.6
+                     py37: run pytest on Python 3.6
                      pypi: publish to PyPI
                      docs: document stuff
                      notincluded: random extra
@@ -22,18 +22,18 @@ def test_listenvs(cmd, initproj, monkeypatch):
     )
 
     result = cmd("-l")
-    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs"]
+    assert result.outlines == ["py36", "py27", "py37", "pypi", "docs"]
 
     result = cmd("-l", "-e", "py")
-    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs"]
+    assert result.outlines == ["py36", "py27", "py37", "pypi", "docs"]
 
     monkeypatch.setenv(str("TOXENV"), str("py"))
     result = cmd("-l")
-    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs"]
+    assert result.outlines == ["py36", "py27", "py37", "pypi", "docs"]
 
     monkeypatch.setenv(str("TOXENV"), str("py36"))
     result = cmd("-l")
-    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs"]
+    assert result.outlines == ["py36", "py27", "py37", "pypi", "docs"]
 
 
 def test_listenvs_verbose_description(cmd, initproj):
@@ -42,11 +42,11 @@ def test_listenvs_verbose_description(cmd, initproj):
         filedefs={
             "tox.ini": """
         [tox]
-        envlist=py36,py27,py34,pypi,docs
+        envlist=py36,py27,py37,pypi,docs
         [testenv]
         description= py36: run pytest on Python 3.6
                      py27: run pytest on Python 2.7
-                     py34: run pytest on Python 3.4
+                     py37: run pytest on Python 3.7
                      pypi: publish to PyPI
                      docs: document stuff
                      notincluded: random extra
@@ -65,7 +65,7 @@ def test_listenvs_verbose_description(cmd, initproj):
         "default environments:",
         "py36 -> run pytest on Python 3.6",
         "py27 -> run pytest on Python 2.7",
-        "py34 -> run pytest on Python 3.4",
+        "py37 -> run pytest on Python 3.7",
         "pypi -> publish to PyPI",
         "docs -> let me overwrite that",
     ]
@@ -78,7 +78,7 @@ def test_listenvs_all(cmd, initproj, monkeypatch):
         filedefs={
             "tox.ini": """
         [tox]
-        envlist=py36,py27,py34,pypi,docs
+        envlist=py36,py27,py37,pypi,docs
 
         [testenv:notincluded]
         changedir = whatever
@@ -89,19 +89,19 @@ def test_listenvs_all(cmd, initproj, monkeypatch):
         },
     )
     result = cmd("-a")
-    expected = ["py36", "py27", "py34", "pypi", "docs", "notincluded"]
+    expected = ["py36", "py27", "py37", "pypi", "docs", "notincluded"]
     assert result.outlines == expected
 
     result = cmd("-a", "-e", "py")
-    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs", "py", "notincluded"]
+    assert result.outlines == ["py36", "py27", "py37", "pypi", "docs", "py", "notincluded"]
 
     monkeypatch.setenv(str("TOXENV"), str("py"))
     result = cmd("-a")
-    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs", "py", "notincluded"]
+    assert result.outlines == ["py36", "py27", "py37", "pypi", "docs", "py", "notincluded"]
 
     monkeypatch.setenv(str("TOXENV"), str("py36"))
     result = cmd("-a")
-    assert result.outlines == ["py36", "py27", "py34", "pypi", "docs", "notincluded"]
+    assert result.outlines == ["py36", "py27", "py37", "pypi", "docs", "notincluded"]
 
 
 def test_listenvs_all_verbose_description(cmd, initproj):
@@ -160,7 +160,7 @@ def test_listenvs_packaging_excluded(cmd, initproj):
         filedefs={
             "tox.ini": """
         [tox]
-        envlist = py36,py27,py34,pypi,docs
+        envlist = py36,py27,py37,pypi,docs
         isolated_build = True
 
         [testenv:notincluded]
@@ -172,7 +172,7 @@ def test_listenvs_packaging_excluded(cmd, initproj):
         },
     )
     result = cmd("-a")
-    expected = ["py36", "py27", "py34", "pypi", "docs", "notincluded"]
+    expected = ["py36", "py27", "py37", "pypi", "docs", "notincluded"]
     assert result.outlines == expected, result.outlines
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py27,
-          py34,
           py35,
           py36,
           py37,


### PR DESCRIPTION
## Thanks for contributing a pull request!

Remove mention of no longer supported pyhon 3.4

Following #1525 

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [N/a] added/updated test(s)
- [x] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
