### PR TITLE
Fix the args_are_paths default in the docs.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -484,7 +484,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
     Set to ``true`` if you want virtualenv to upgrade pip/wheel/setuptools to
     the latest version.
 
-.. conf:: args_are_paths ^ true|false ^ false
+.. conf:: args_are_paths ^ true|false ^ true
 
     Treat positional arguments passed to ``tox`` as file system paths
     and - if they exist on the filesystem - rewrite them according


### PR DESCRIPTION
The text below looks correct that the default is True.

(Not sure if you use towncrier entries for trivial PRs or not, if so obviously can add one -- I see e.g. the last PR to hit master didn't use one, so assuming you may not).