### PR TITLE
Fix isolated build helper scripts

### DIFF
--- a/docs/changelog/1629.bugfix.rst
+++ b/docs/changelog/1629.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``TypeError`` when using isolated_build with backends that are not submodules (e.g. ``maturin``)

--- a/src/tox/helper/build_isolated.py
+++ b/src/tox/helper/build_isolated.py
@@ -4,7 +4,7 @@ dist_folder = sys.argv[1]
 backend_spec = sys.argv[2]
 backend_obj = sys.argv[3] if len(sys.argv) >= 4 else None
 
-backend = __import__(backend_spec, fromlist=[None])
+backend = __import__(backend_spec, fromlist=["_trash"])
 if backend_obj:
     backend = getattr(backend, backend_obj)
 

--- a/src/tox/helper/build_requires.py
+++ b/src/tox/helper/build_requires.py
@@ -4,7 +4,7 @@ import sys
 backend_spec = sys.argv[1]
 backend_obj = sys.argv[2] if len(sys.argv) >= 3 else None
 
-backend = __import__(backend_spec, fromlist=[None])
+backend = __import__(backend_spec, fromlist=["_trash"])
 if backend_obj:
     backend = getattr(backend, backend_obj)
 


### PR DESCRIPTION
Fixes #1344 

The PEP 517 isolated build uses these helper scripts, but they invoke the `__import__` builtin incorrectly.