### PR TITLE
Do not use setup.cfg file that does not have tox:tox namespace

### DIFF
--- a/docs/changelog/1045.bugfix.rst
+++ b/docs/changelog/1045.bugfix.rst
@@ -1,0 +1,1 @@
+skip ``setup.cfg`` if it has no ``tox:tox`` namespace - by :user:`hroncok`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -15,7 +15,7 @@ At the moment tox supports three configuration locations prioritized in the foll
 As far as the configuration format at the moment we only support standard ConfigParser_ "ini-style" format
 (there is a plan to add a pure TOML one soon).
 ``tox.ini`` and ``setup.cfg`` are such files. Note that ``setup.cfg`` requires the content to be under the
-``tox:tox`` section. ``pyproject.toml`` on the other hand is in TOML format. However, one can inline
+``tox:tox`` section and is otherwise ignored. ``pyproject.toml`` on the other hand is in TOML format. However, one can inline
 the *ini-style* format under the ``tool.tox.legacy_tox_ini`` key as a multi-line string.
 
 Below you find the specification for the *ini-style* format, but you might want to skim some

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -3023,6 +3023,21 @@ def test_config_bad_pyproject_specified(initproj, capsys):
     assert "ERROR:" not in out
 
 
+def test_config_setup_cfg_no_tox_section(initproj, capsys):
+    setup_cfg = """
+        [nope:nope]
+        envlist = py37
+    """
+    initproj("setup_cfg_no_tox-0.1", filedefs={"setup.cfg": setup_cfg})
+    with pytest.raises(SystemExit):
+        parseconfig([])
+
+    out, err = capsys.readouterr()
+    msg = "ERROR: tox config file (either pyproject.toml, tox.ini, setup.cfg) not found\n"
+    assert err == msg
+    assert "ERROR:" not in out
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="no named pipes on Windows")
 def test_config_bad_config_type_specified(monkeypatch, tmpdir, capsys):
     monkeypatch.chdir(tmpdir)


### PR DESCRIPTION
Do not use setup.cfg file that does not have tox:tox namespace

When tox is invoked without a tox configuration file (and without command line
options that could be used instead), it fails with:

    $ tox
    ERROR: tox config file (either pyproject.toml, tox.ini, setup.cfg) not found

This is useful: If there is no config, test didn't run and such error should
not pass silently.

However, until this commit, when there was a setup.cfg file it was considered
as a tox config even when there was no `[tox:tox]` section:

    $ tox
    GLOB sdist-make: .../setup.py
    python create: .../.tox/python
    python inst: ...
    python installed: ...
    python run-test-pre: PYTHONHASHSEED='1234567890'
    ___________________________________ summary ____________________________________
      python: commands succeeded
      congratulations :)

That is not safe, because setup.cfg can exist even if there is no tox
configuration in it and the success creates a false sense of safety.

To fix this and to match the behavior of pyproject.toml without a tox section,
tox now skips setup.cfg, if there is no `[tox:tox]` section.

Fixes https://github.com/tox-dev/tox/issues/1045

## Contribution checklist:

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
