### PR TITLE
Allow to use --devenv without tox config

### DIFF
--- a/docs/changelog/1643.feature.rst
+++ b/docs/changelog/1643.feature.rst
@@ -1,0 +1,1 @@
+Don't require a tox config file for ``tox --devenv`` - by :user:`hroncok`

--- a/docs/example/devenv.rst
+++ b/docs/example/devenv.rst
@@ -35,6 +35,9 @@ If you don't specify an environment with ``-e``, the devenv feature will
 default to ``-e py`` -- usually taking the interpreter you're running ``tox``
 with and the default ``[testenv]`` configuration.
 
+It is possible to use the ``--devenv`` option without a tox configuration file,
+however the configuration file is respected if present.
+
 Creating development environments using configuration
 =====================================================
 

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -285,6 +285,11 @@ def parseconfig(args, plugins=()):
         parser.parse_cli(args, strict=True)
         if option.help or option.helpini:
             return config
+        if option.devenv:
+            # To load defaults, we parse an empty config
+            ParseIni(config, py.path.local(), "")
+            pm.hook.tox_configure(config=config)
+            return config
         msg = "tox config file (either {}) not found"
         candidates = ", ".join(INFO.CONFIG_CANDIDATES)
         feedback(msg.format(candidates), sysexit=not (option.help or option.helpini))
@@ -1056,7 +1061,7 @@ class ParseIni(object):
     def __init__(self, config, ini_path, ini_data):  # noqa
         config.toxinipath = ini_path
         using("tox.ini: {} (pid {})".format(config.toxinipath, os.getpid()))
-        config.toxinidir = config.toxinipath.dirpath()
+        config.toxinidir = config.toxinipath.dirpath() if ini_path.check(file=True) else ini_path
 
         self._cfg = py.iniconfig.IniConfig(config.toxinipath, ini_data)
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -3038,6 +3038,17 @@ def test_config_setup_cfg_no_tox_section(initproj, capsys):
     assert "ERROR:" not in out
 
 
+def test_config_file_not_required_with_devenv(initproj, capsys):
+    initproj("no_tox_config-0.7")
+    config = parseconfig(["--devenv", "myenv"])
+
+    out, err = capsys.readouterr()
+    assert "ERROR:" not in err
+    assert "ERROR:" not in out
+    assert config.option.devenv == "myenv"
+    assert config.option.notest is True
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="no named pipes on Windows")
 def test_config_bad_config_type_specified(monkeypatch, tmpdir, capsys):
     monkeypatch.chdir(tmpdir)

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -882,15 +882,18 @@ def test_notest_setup_py_error(initproj, cmd):
     assert re.search("ERROR:.*InvocationError", result.out)
 
 
-def test_devenv(initproj, cmd):
-    initproj(
-        "example123",
-        filedefs={
-            "setup.py": """\
-                from setuptools import setup
-                setup(name='x')
-            """,
-            "tox.ini": """\
+@pytest.mark.parametrize("has_config", [True, False])
+def test_devenv(initproj, cmd, has_config):
+    filedefs = {
+        "setup.py": """\
+            from setuptools import setup
+            setup(name='x')
+        """,
+    }
+    if has_config:
+        filedefs[
+            "tox.ini"
+        ] = """\
             [tox]
             # envlist is ignored for --devenv
             envlist = foo,bar,baz
@@ -898,8 +901,9 @@ def test_devenv(initproj, cmd):
             [testenv]
             # --devenv implies --notest
             commands = python -c "exit(1)"
-            """,
-        },
+            """
+    initproj(
+        "example123", filedefs=filedefs,
     )
     result = cmd("--devenv", "venv")
     result.assert_success()


### PR DESCRIPTION
Fixes https://github.com/tox-dev/tox/issues/1643

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
