### PR TITLE
Fix: accept hyphens in generative section names

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -94,6 +94,7 @@ Stephen Finucane
 Sviatoslav Sydorenko
 Thomas Grainger
 Tim Laurence
+Tyagraj Desigar
 Ville Skyttä
 Xander Johnson
 anatoly techtonik

--- a/docs/changelog/1636.bugfix.rst
+++ b/docs/changelog/1636.bugfix.rst
@@ -1,0 +1,1 @@
+Allow hyphens and empty factors in generative section name. - by :user:`tyagdit`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1420,7 +1420,7 @@ class ParseIni(object):
         The parser will see it as two different sections: [testenv:py36-cov], [testenv:py37-cov]
 
         """
-        factor_re = re.compile(r"\{\s*([\w\s,]+)\s*\}")
+        factor_re = re.compile(r"\{\s*([\w\s,-]+)\s*\}")
         split_re = re.compile(r"\s*,\s*")
         to_remove = set()
         for section in list(config.sections):

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -865,10 +865,11 @@ class TestIniParser:
     def test_expand_section_name(self, newconfig):
         config = newconfig(
             """
-            [testenv:custom-{one,two,three}-{four,five}-six]
+            [testenv:custom{,-one,-two,-three}-{four,five}-six]
         """,
         )
         assert "testenv:custom-one-five-six" in config._cfg.sections
+        assert "testenv:custom-four-six" in config._cfg.sections
         assert "testenv:custom-{one,two,three}-{four,five}-six" not in config._cfg.sections
 
 


### PR DESCRIPTION
Generative section names wouldn't work if there were hyphens within the braces. the regex caused everything after the hyphen to be omitted resulting in not being able to use empty factors like `[testenv:foo{,-factor}]` and forcing users to put the hyphens outside the braces.

Fixes #1636 

## Contribution checklist:

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
