### PR TITLE
If TOX_WORK_DIR is indicated in the environment, honor it.

### DIFF
--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1109,7 +1109,8 @@ class ParseIni(object):
         reader.addsubstitutions(toxinidir=config.toxinidir, homedir=config.homedir)
 
         if config.option.workdir is None:
-            config.toxworkdir = reader.getpath("toxworkdir", "{toxinidir}/.tox")
+            default = os.environ.get('TOX_WORK_DIR', "{toxinidir}/.tox")
+            config.toxworkdir = reader.getpath("toxworkdir", default)
         else:
             config.toxworkdir = config.toxinidir.join(config.option.workdir, abs=True)
 


### PR DESCRIPTION
Closes #20.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
