### PR TITLE
Fix support of the PEP517 backend-path key

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -78,6 +78,7 @@ Morgan Fainberg
 Naveen S R
 Nick Douma
 Nick Prendergast
+Nicolas Vivet
 Oliver Bestwalter
 Pablo Galindo
 Paul Moore

--- a/docs/changelog/1654.bugfix.rst
+++ b/docs/changelog/1654.bugfix.rst
@@ -1,0 +1,1 @@
+Support for PEP517 in-tree build backend-path key in ``get-build-requires``. - by :user:`nizox`

--- a/src/tox/helper/build_requires.py
+++ b/src/tox/helper/build_requires.py
@@ -1,8 +1,12 @@
 import json
+import os
 import sys
 
 backend_spec = sys.argv[1]
 backend_obj = sys.argv[2] if len(sys.argv) >= 3 else None
+backend_paths = sys.argv[3].split(os.path.pathsep) if len(sys.argv) >= 4 else []
+
+sys.path[:0] = backend_paths
 
 backend = __import__(backend_spec, fromlist=["_trash"])
 if backend_obj:

--- a/src/tox/package/builder/isolated.py
+++ b/src/tox/package/builder/isolated.py
@@ -92,6 +92,15 @@ def get_build_info(folder):
         abort("backend-path key at build-system section must be a list, if specified")
     backend_paths = [folder.join(p) for p in backend_paths]
 
+    normalized_folder = os.path.normcase(str(folder.realpath()))
+    normalized_paths = (os.path.normcase(str(path.realpath())) for path in backend_paths)
+
+    if not all(
+        os.path.commonprefix((normalized_folder, path)) == normalized_folder
+        for path in normalized_paths
+    ):
+        abort("backend-path must exist in the project root")
+
     return BuildInfo(requires, module, obj, backend_paths)
 
 
@@ -129,6 +138,7 @@ def get_build_requires(build_info, package_venv, setup_dir):
                 BUILD_REQUIRE_SCRIPT,
                 build_info.backend_module,
                 build_info.backend_object,
+                os.path.pathsep.join(str(p) for p in build_info.backend_paths),
             ],
             returnout=True,
             action=action,

--- a/tests/unit/package/builder/test_package_builder_isolated.py
+++ b/tests/unit/package/builder/test_package_builder_isolated.py
@@ -153,3 +153,43 @@ def test_package_isolated_toml_bad_backend_path(initproj):
     backend-path = 42
     """,
     )
+
+
+def test_package_isolated_toml_backend_path_outside_root(initproj):
+    """Verify that a 'backend-path' outside the project root is forbidden."""
+    toml_file_check(
+        initproj,
+        6,
+        "backend-path must exist in the project root",
+        """
+    [build-system]
+    requires = []
+    build-backend = 'setuptools.build_meta'
+    backend-path = ['..']
+    """,
+    )
+
+
+def test_verbose_isolated_build_in_tree(initproj, mock_venv, cmd):
+    initproj(
+        "example123-0.5",
+        filedefs={
+            "tox.ini": """
+                    [tox]
+                    isolated_build = true
+                    """,
+            "build.py": """
+                    from setuptools.build_meta import *
+                    """,
+            "pyproject.toml": """
+                    [build-system]
+                    requires = ["setuptools >= 35.0.2"]
+                    build-backend = 'build'
+                    backend-path = ['.']
+                                """,
+        },
+    )
+    result = cmd("--sdistonly", "-v", "-v", "-v", "-e", "py")
+    assert "running sdist" in result.out, result.out
+    assert "running egg_info" in result.out, result.out
+    assert "Writing example123-0.5{}setup.cfg".format(os.sep) in result.out, result.out


### PR DESCRIPTION
This PR fixes support for the PEP517 `backend-path` key and checks that the paths are in the project root according to https://www.python.org/dev/peps/pep-0517/#build-requirements.

Resolves #1654.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [X] wrote descriptive pull request text
- [X] added/updated test(s)
- [ ] updated/extended the documentation
- [X] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
