### PR TITLE
Allow escaping curly braces in setenv

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -67,6 +67,7 @@ Mariusz Rusiniak
 Mark Hirota
 Matt Good
 Matt Jeffery
+Matthew Kenigsberg
 Mattieu Agopian
 Mehdi Abaakouk
 Michael Manganiello

--- a/docs/changelog/1656.bugfix.rst
+++ b/docs/changelog/1656.bugfix.rst
@@ -1,0 +1,1 @@
+Allow escaping curly braces in setenv. - by :user:`mkenigs`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -382,7 +382,9 @@ class SetenvDict(object):
                 return os.environ.get(name, default)
             self._lookupstack.append(name)
             try:
-                self.resolved[name] = res = self.reader._replace(val)
+                res = self.reader._replace(val)
+                res = res.replace("\\{", "{").replace("\\}", "}")
+                self.resolved[name] = res
             finally:
                 self._lookupstack.pop()
             return res

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2074,6 +2074,15 @@ class TestConfigTestEnv:
         assert configs["py27"].setenv["X"] == "1"
         assert "X" not in configs["py36"].setenv
 
+    def test_curly_braces_in_setenv(self, newconfig):
+        inisource = r"""
+            [testenv]
+            setenv =
+                VAR = \{val\}
+        """
+        configs = newconfig([], inisource).envconfigs
+        assert configs["python"].setenv["VAR"] == "{val}"
+
     def test_factor_use_not_checked(self, newconfig):
         inisource = """
             [tox]


### PR DESCRIPTION
Currently braces can be escaped, but the backslashes are not removed,
making it impossible to add a plain curly brace

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
