### PR TITLE
Make setup.py test admonition sterner as it is deprecated

### DIFF
--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -321,10 +321,7 @@ Integration with "setup.py test" command
 
   ``setup.py test`` is `deprecated
   <https://setuptools.readthedocs.io/en/latest/setuptools.html#test-build-package-and-run-a-unittest-suite>`_
-  and will be removed in a future version. It breaks packaging/testing approaches
-  used by downstream distributions which expect ``setup.py test`` to run tests
-  with the invocation interpreter rather than setting up many virtualenvs and
-  installing packages.
+  and will be removed in a future version.
 
 .. _`ignoring exit code`:
 


### PR DESCRIPTION
## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
