### PR TITLE
Some headings aren't completely fixed, yet

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1067,7 +1067,7 @@ Other Rules and notes
   it will be considered as relative to the ``toxinidir``, the directory
   where the configuration file resides.
 
-cli
+CLI
 ===
 
 .. autoprogram:: tox.cli:cli

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -252,7 +252,7 @@ To force tox to recreate a (particular) virtual environment:
 would trigger a complete reinstallation of the existing py27 environment
 (or create it afresh if it doesn't exist).
 
-passing down environment variables
+Passing down environment variables
 -------------------------------------------
 
 .. versionadded:: 2.0


### PR DESCRIPTION
In commit [c2f6c9c](https://github.com/tox-dev/tox/tree/c2f6c9cb9a1d70ac79524076845bc32ed25489ad), I missed to fix some headings, sorry about that. This commit should covers all such missed cases.