### PR TITLE
Update constraint for importlib-metadata

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -97,6 +97,7 @@ Sviatoslav Sydorenko
 Thomas Grainger
 Tim Laurence
 Tyagraj Desigar
+Usama Sadiq
 Ville Skyttä
 Xander Johnson
 anatoly techtonik

--- a/docs/changelog/1682.bugfix.rst
+++ b/docs/changelog/1682.bugfix.rst
@@ -1,0 +1,1 @@
+Relax importlib requirement to allow version<3 - by :user:`usamasadiq`

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     toml>=0.9.4
     virtualenv!=20.0.0,!=20.0.1,!=20.0.2,!=20.0.3,!=20.0.4,!=20.0.5,!=20.0.6,!=20.0.7,>=16.0.0
     colorama>=0.4.1 ;platform_system=="Windows"
-    importlib-metadata>=0.12,<2;python_version<"3.8"
+    importlib-metadata>=0.12,<3;python_version<"3.8"
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 
 [options.entry_points]


### PR DESCRIPTION
## Thanks for contributing a pull request!

On Python<3.8, `importlib-metadata==2.0.0` causes dependency conflicts because of the pinned constraint `python<3.8`. There is no breaking change in the importlib-metadata [version 2.0.0](https://importlib-metadata.readthedocs.io/en/latest/changelog%20%28links%29.html#v2-0-0).

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
