### PR TITLE
Fix negated factor condition example for not-a-and-not-b

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -964,7 +964,7 @@ special case for a combination of factors. Here is how you do it:
         py{27,36}-sqlite: mock  # mocking sqlite in python 2.x & 3.6
         !py34-sqlite: mock      # mocking sqlite, except in python 3.4
         sqlite-!py34: mock      # (same as the line above)
-        !py34,!py36: enum34     # use if neither py34 nor py36 are in the env name
+        !py34-!py36: enum34     # use if neither py34 nor py36 are in the env name
 
 Take a look at the first ``deps`` line. It shows how you can special case
 something for a combination of factors, by just hyphenating the combining


### PR DESCRIPTION
test_factor_ops makes it clear that `!a,!b` is "not-a OR not-b" and that
the "not-a AND not-b" (implied by the docs) should be `!a-!b`.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
