### PR TITLE
Update general.rst

### DIFF
--- a/docs/example/general.rst
+++ b/docs/example/general.rst
@@ -160,7 +160,7 @@ will be searched in your system ``PATH``. Similarly, for ``jython`` and
 ``pypy`` the respective ``jython`` and ``pypy-c`` names will be looked for.
 The executable must exist in order to successfully create *virtualenv*
 environments. On Windows a ``pythonX.Y`` named executable will be searched in
-typical default locations using the ``C:\PythonX.Y\python.exe`` pattern.
+typical default locations using the ``C:\PythonXY\python.exe`` pattern.
 
 All other targets will use the system ``python`` instead. You can override any
 of the default settings by defining the :conf:`basepython` variable in a
@@ -169,7 +169,7 @@ specific test environment section, for example:
 .. code-block:: ini
 
     [testenv:docs]
-    basepython = python2.7
+    basepython = python2.7  # or C:\mypath\pythons\3.9\python.exe
 
 Avoiding expensive sdist
 ------------------------

--- a/docs/example/general.rst
+++ b/docs/example/general.rst
@@ -169,7 +169,7 @@ specific test environment section, for example:
 .. code-block:: ini
 
     [testenv:docs]
-    basepython = python2.7  # or C:\mypath\pythons\3.9\python.exe
+    basepython = python2.7
 
 Avoiding expensive sdist
 ------------------------


### PR DESCRIPTION
Apologies on my forwardness for PRing without first opening an issue. 

A wee contribution to the documentation, for a couple of things that I felt are a bit unclear.
I am making this PR after spent 30 mins trying to remember if the 'predictable' python path in windows was C:\PythonXY or C:\PythonX.Y while trying to install a new python interpreter in my system; (doc's were saying X.Y but code was saying XY) 

Changes: 
- Removed that dot on the typical pattern example (i.e C:\PythonX.Y\python.exe -> C:\PythonXY\python.exe) to better reflect https://github.com/tox-dev/tox/blob/471b39f0edd015b8e873695c3cfb893ede36fae6/src/tox/interpreters/windows/__init__.py#L32

 - and added example that basepython can be an path to a python executable for clarity

