### PR TITLE
Fix escaping brackets in setenv

### DIFF
--- a/docs/changelog/1690.bugfix.rst
+++ b/docs/changelog/1690.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed regression in v3.20.0 that caused escaped curly braces in setenv
+to break usage of the variable elsewhere in tox.ini. - by :user:`jayvdb`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -390,9 +390,7 @@ class SetenvDict(object):
                 return os.environ.get(name, default)
             self._lookupstack.append(name)
             try:
-                res = self.reader._replace(val)
-                res = res.replace("\\{", "{").replace("\\}", "}")
-                self.resolved[name] = res
+                self.resolved[name] = res = self.reader._replace(val)
             finally:
                 self._lookupstack.pop()
             return res

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -493,7 +493,7 @@ class VirtualEnv(object):
             env = os.environ.copy()
 
         # in any case we honor per-testenv setenv configuration
-        env.update(self.envconfig.setenv)
+        env.update(self.envconfig.setenv.export())
 
         env["VIRTUAL_ENV"] = str(self.path)
         return env

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2120,9 +2120,12 @@ class TestConfigTestEnv:
             [testenv]
             setenv =
                 VAR = \{val\}
+            commands =
+                {env:VAR}
         """
         configs = newconfig([], inisource).envconfigs
-        assert configs["python"].setenv["VAR"] == "{val}"
+        assert configs["python"].setenv["VAR"] == r"\{val\}"
+        assert configs["python"].commands[0] == ["{val}"]
 
     def test_factor_use_not_checked(self, newconfig):
         inisource = """

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2734,12 +2734,21 @@ class TestSetenv:
                 env_path,
             ),
         ).envconfigs["python"]
+
         envs = env_config.setenv.definitions
+
         assert envs["ALPHA"] == "1"
         if has_magic:
             assert envs["MAGIC"] == "yes"
         else:
             assert "MAGIC" not in envs
+
+        expected_vars = ["ALPHA", "PYTHONHASHSEED", "TOX_ENV_DIR", "TOX_ENV_NAME"]
+        if has_magic:
+            expected_vars = sorted(expected_vars + ["MAGIC"])
+
+        exported = env_config.setenv.export()
+        assert sorted(exported) == expected_vars
 
 
 class TestIndexServer:


### PR DESCRIPTION
Fixs regression in v3.20.0 that caused escaped curly braces in setenv to break usage of the variable elsewhere in tox.ini.

Fixes https://github.com/tox-dev/tox/issues/1690

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
