### PR TITLE
Allow escaping of {} in defaults

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,6 +48,7 @@ Jake Windle
 Jannis Leidel
 Joachim Brandon LeBlanc
 Johannes Christ
+John Mark Vandenberg
 Jon Dufresne
 Josh Smeaton
 Josh Snyder

--- a/docs/changelog/1502.feature.rst
+++ b/docs/changelog/1502.feature.rst
@@ -1,0 +1,1 @@
+Allow \{ and \} in default of {env:key:default}. - by :user:`jayvdb`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1731,7 +1731,7 @@ class Replacer:
         (?<!\\)[{]
         (?:(?P<sub_type>[^[:{}]+):)?    # optional sub_type for special rules
         (?P<substitution_value>(?:\[[^,{}]*\])?[^:,{}]*)  # substitution key
-        (?::(?P<default_value>[^{}]*))?   # default value
+        (?::(?P<default_value>([^{}]|\\{|\\})*))?   # default value
         [}]
         """,
         re.VERBOSE,

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -453,6 +453,17 @@ class TestIniParserAgainstCommandsKey:
         envconfig = config.envconfigs["python"]
         assert envconfig.commands == [["echo", "bar"]]
 
+    def test_command_env_substitution_default_escape(self, newconfig):
+        """Ensure literal { and } in default of {env:key:default} values."""
+        config = newconfig(
+            r"""
+            [testenv]
+            commands = echo {env:FOO:\{bar\}}
+        """,
+        )
+        envconfig = config.envconfigs["python"]
+        assert envconfig.commands == [["echo", "{bar}"]]
+
     def test_regression_issue595(self, newconfig):
         config = newconfig(
             """


### PR DESCRIPTION
Fixes https://github.com/tox-dev/tox/issues/1502


- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)