### PR TITLE
Allow substitution refering to current section key

### DIFF
--- a/docs/changelog/1702.feature.rst
+++ b/docs/changelog/1702.feature.rst
@@ -1,0 +1,1 @@
+Allow {[]key_name} to refer to current section. - by :user:`jayvdb`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1841,6 +1841,12 @@ class Replacer:
         if key.startswith("[") and "]" in key:
             i = key.find("]")
             section, item = key[1:i], key[i + 1 :]
+            if section == "":
+                return self.reader.getstring(
+                    name=item,
+                    replace=True,
+                    crossonly=self.crossonly,
+                )
             cfg = self.reader._cfg
             if section in cfg and item in cfg[section]:
                 if (section, item) in self.reader._subststack:


### PR DESCRIPTION
Closes https://github.com/tox-dev/tox/issues/1702

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
