### PR TITLE
Fix using platform with install_command

### DIFF
--- a/docs/changelog/1464.bugfix.rst
+++ b/docs/changelog/1464.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``platform`` support for ``install_command``. - by :user:`jayvdb`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1684,6 +1684,13 @@ class SectionReader:
 
     def getargv_install_command(self, name, default="", replace=True):
         s = self.getstring(name, default, replace=False)
+        if not s:
+            # This occurs when factors are used, and a testenv doesnt have
+            # a factorised value for install_command, most commonly occurring
+            # if setting platform is also used.
+            # An empty value causes error install_command must contain '{packages}'.
+            s = default
+
         if "{packages}" in s:
             s = s.replace("{packages}", r"\{packages\}")
         if "{opts}" in s:


### PR DESCRIPTION
Fix ``platform`` support for ``install_command``

Fixes https://github.com/tox-dev/tox/issues/1464

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)