### PR TITLE
Bracketed escaping

### DIFF
--- a/docs/changelog/1690.bugfix.rst
+++ b/docs/changelog/1690.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed regression in v3.20.0 that caused escaped curly braces in setenv
+to break usage of the variable elsewhere in tox.ini. - by :user:`jayvdb`

--- a/docs/changelog/1700.feature.rst
+++ b/docs/changelog/1700.feature.rst
@@ -1,0 +1,1 @@
+Allow {/} to refer to os.sep. - by :user:`jayvdb`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -669,6 +669,12 @@ Globally available substitutions
     OS-specific path separator (``:`` os \*nix family, ``;`` on Windows). May be used in ``setenv``,
     when target variable is path variable (e.g. PATH or PYTHONPATH).
 
+``{/}``
+    OS-specific directory separator (``/`` os \*nix family, ``\\`` on Windows).
+    Useful for deriving filenames from preset paths, as arguments for commands
+    that requires ``\\`` on Windows. e.g. ``{distdir}{/}file.txt``.
+    It is not usually needed when using commands written in Python.
+
 Substitutions for virtualenv-related sections
 +++++++++++++++++++++++++++++++++++++++++++++
 

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1826,8 +1826,12 @@ class Replacer:
                 "Malformed substitution; no substitution type provided",
             )
 
-        if not sub_type and not g["default_value"] and sub_value == "/":
-            return os.sep
+        if not sub_type and not g["default_value"]:
+            if sub_value == "\\":
+                return "\\"
+            if sub_value == "/":
+                return os.sep
+
         if sub_type == "env":
             return self._replace_env(match)
         if sub_type == "tty":

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -390,9 +390,7 @@ class SetenvDict(object):
                 return os.environ.get(name, default)
             self._lookupstack.append(name)
             try:
-                res = self.reader._replace(val)
-                res = res.replace("\\{", "{").replace("\\}", "}")
-                self.resolved[name] = res
+                self.resolved[name] = res = self.reader._replace(val)
             finally:
                 self._lookupstack.pop()
             return res
@@ -409,6 +407,19 @@ class SetenvDict(object):
     def __setitem__(self, name, value):
         self.definitions[name] = value
         self.resolved[name] = value
+
+    def items(self):
+        return ((name, self[name]) for name in self.definitions)
+
+    def export(self):
+        # post-process items to avoid internal syntax/semantics
+        # such as {} being escaped using \{\}, suitable for use with
+        # os.environ .
+        return {
+            name: Replacer._unescape(value)
+            for name, value in self.items()
+            if value is not self._DUMMY
+        }
 
 
 @tox.hookimpl
@@ -1787,6 +1798,10 @@ class Replacer:
 
         return expanded
 
+    @staticmethod
+    def _unescape(s):
+        return s.replace("\\{", "{").replace("\\}", "}")
+
     def _replace_match(self, match):
         g = match.groupdict()
         sub_value = g["substitution_value"]
@@ -1928,7 +1943,7 @@ class _ArgvlistReader:
                 new_arg = ""
                 new_word = reader._replace(word)
                 new_word = reader._replace(new_word)
-                new_word = new_word.replace("\\{", "{").replace("\\}", "}")
+                new_word = Replacer._unescape(new_word)
                 new_arg += new_word
                 newcommand += new_arg
         else:

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1811,6 +1811,8 @@ class Replacer:
                 "Malformed substitution; no substitution type provided",
             )
 
+        if not sub_type and not g["default_value"] and sub_value == "/":
+            return os.sep
         if sub_type == "env":
             return self._replace_env(match)
         if sub_type == "tty":

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -493,7 +493,7 @@ class VirtualEnv(object):
             env = os.environ.copy()
 
         # in any case we honor per-testenv setenv configuration
-        env.update(self.envconfig.setenv)
+        env.update(self.envconfig.setenv.export())
 
         env["VIRTUAL_ENV"] = str(self.path)
         return env

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2803,6 +2803,20 @@ class TestIndexServer:
 
 
 class TestConfigConstSubstitutions:
+    def test_replace_backslash(self, newconfig):
+        r"""Replace {\} with literal \."""
+        config = newconfig(
+            r"""
+            [testenv]
+            setenv =
+                FOO = a{\}b
+            commands = echo {env:FOO} c{\}d
+            """,
+        )
+        envconfig = config.envconfigs["python"]
+        assert envconfig.commands[0] == ["echo", "a\\b", "c\\d"]
+        assert envconfig.setenv["FOO"] == "a\\b"
+
     @pytest.mark.parametrize("pathsep", [":", ";"])
     def test_replace_pathsep(self, monkeypatch, newconfig, pathsep):
         """Replace {:} with OS path separator."""

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2120,9 +2120,12 @@ class TestConfigTestEnv:
             [testenv]
             setenv =
                 VAR = \{val\}
+            commands =
+                {env:VAR}
         """
         configs = newconfig([], inisource).envconfigs
-        assert configs["python"].setenv["VAR"] == "{val}"
+        assert configs["python"].setenv["VAR"] == r"\{val\}"
+        assert configs["python"].commands[0] == ["{val}"]
 
     def test_factor_use_not_checked(self, newconfig):
         inisource = """
@@ -2731,12 +2734,21 @@ class TestSetenv:
                 env_path,
             ),
         ).envconfigs["python"]
+
         envs = env_config.setenv.definitions
+
         assert envs["ALPHA"] == "1"
         if has_magic:
             assert envs["MAGIC"] == "yes"
         else:
             assert "MAGIC" not in envs
+
+        expected_vars = ["ALPHA", "PYTHONHASHSEED", "TOX_ENV_DIR", "TOX_ENV_NAME"]
+        if has_magic:
+            expected_vars = sorted(expected_vars + ["MAGIC"])
+
+        exported = env_config.setenv.export()
+        assert sorted(exported) == expected_vars
 
 
 class TestIndexServer:

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2817,6 +2817,34 @@ class TestConfigConstSubstitutions:
         assert envconfig.commands[0] == ["echo", "a\\b", "c\\d"]
         assert envconfig.setenv["FOO"] == "a\\b"
 
+    def test_replace_bracket(self, newconfig):
+        """Replace {{} and {}} with literal { and }."""
+        config = newconfig(
+            """
+            [testenv]
+            setenv =
+                FOO = a{{}b
+            commands = echo {env:FOO} c{}}d
+        """,
+        )
+        envconfig = config.envconfigs["python"]
+        assert envconfig.setenv["FOO"] == "a{b"
+        assert envconfig.commands[0] == ["echo", "a{b", "c}d"]
+
+    def test_replace_bracket_broken(self, newconfig):
+        """Replace {{} and {}} with literal { and } but it fails."""
+        config = newconfig(
+            """
+            [testenv]
+            setenv =
+                FOO = a{{}b c{}}d
+            """,
+        )
+        envconfig = config.envconfigs["python"]
+        assert envconfig
+        # This fails: ConfigError: substitution key 'b c' not found
+        # assert envconfig.setenv["FOO"] == "a{b c}d"
+
     @pytest.mark.parametrize("pathsep", [":", ";"])
     def test_replace_pathsep(self, monkeypatch, newconfig, pathsep):
         """Replace {:} with OS path separator."""


### PR DESCRIPTION
Adds `{\}`, `{{}` and `{}}` as an escaping mechanism in settings.

`{{}` and `{}}` are not implemented so they can be used safely together.
Additional coding is needed to handle values from the engine being pushed
back into the engine, so they are re-escaped.

Fixes https://github.com/tox-dev/tox/issues/1708

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
