### PR TITLE
Replacer: Allow LocalPath to pass through

### DIFF
--- a/docs/changelog/1713.feature.rst
+++ b/docs/changelog/1713.feature.rst
@@ -1,0 +1,1 @@
+Preserve paths through the substitution engine. Adds global setting ``literal_paths`` to disable new behaviour. - by :user:`jayvdb`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -143,6 +143,19 @@ Global settings are defined under the ``tox`` section as:
     configure :conf:`basepython` in the global testenv without affecting environments
     that have implied base python versions.
 
+.. conf:: literal_paths ^ true|false ^ true
+
+    .. versionadded:: 3.21.0
+
+    tox defaults to interpretting values commencing with a path as a literal path, with
+    only segments inside ``{..}`` being substituted, without any need for quoting.
+
+    Disabling this setting to use shell-like syntax for all values, except settings of
+    type ``path``.
+
+    For settings of type ``path``, shell-like syntax can be activate by commencing the
+    value with a quotation mark.
+
 .. conf:: isolated_build ^ true|false ^ false
 
     .. versionadded:: 3.3.0


### PR DESCRIPTION
Paths were already stored inside SectionReader._subs as
path objects, however they are turned into strings when they
go through Replacer, and various transforms occur on these
paths, for example breaking paths containing '#' and ' '.

This change defaults to path objects being retained through the
Replacer, and path segments being joined together using path object
joining semantics.

This mode can be disabled for settings of type `path` by wrapping
the value in quotes, and disabled for other values by disabling
new global setting literal_paths.

Fixes #763 and #924

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
