### PR TITLE
Prevent {} and tighten parsing of {:}

### DIFF
--- a/docs/changelog/1711.bugfix.rst
+++ b/docs/changelog/1711.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent ``{}`` and require ``{:`` is only followed by ``}``. - by :user:`jayvdb`

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -603,6 +603,33 @@ class TestIniParser:
         x = reader.getstring("hello", "world")
         assert x == "world"
 
+    def test_substitution_empty(self, newconfig):
+        config = newconfig(
+            """
+            [mydefault]
+            key2={}
+        """,
+        )
+        reader = SectionReader("mydefault", config._cfg, fallbacksections=["mydefault"])
+        assert reader is not None
+        with pytest.raises(tox.exception.ConfigError, match="no substitution type provided"):
+            reader.getstring("key2")
+
+    def test_substitution_colon_prefix(self, newconfig):
+        config = newconfig(
+            """
+            [mydefault]
+            key2={:abc}
+        """,
+        )
+        reader = SectionReader("mydefault", config._cfg, fallbacksections=["mydefault"])
+        assert reader is not None
+        with pytest.raises(
+            tox.exception.ConfigError,
+            match="Malformed substitution with prefix ':'",
+        ):
+            reader.getstring("key2")
+
     def test_missing_substitution(self, newconfig):
         config = newconfig(
             """
@@ -612,7 +639,7 @@ class TestIniParser:
         )
         reader = SectionReader("mydefault", config._cfg, fallbacksections=["mydefault"])
         assert reader is not None
-        with pytest.raises(tox.exception.ConfigError):
+        with pytest.raises(tox.exception.ConfigError, match="substitution key '.*' not found"):
             reader.getstring("key2")
 
     def test_getstring_fallback_sections(self, newconfig):


### PR DESCRIPTION
Fixes https://github.com/tox-dev/tox/issues/1711

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
