### PR TITLE
Raise MissingSubstitution on access

### DIFF
--- a/docs/changelog/1716.bugfix.rst
+++ b/docs/changelog/1716.bugfix.rst
@@ -1,0 +1,1 @@
+Raise ``MissingSubstitution`` on access of broken ini setting. - by :user:`jayvdb`

--- a/src/tox/exception.py
+++ b/src/tox/exception.py
@@ -49,6 +49,7 @@ class MissingSubstitution(Error):
 
     def __init__(self, name):
         self.name = name
+        super(Error, self).__init__(name)
 
 
 class ConfigError(Error):

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -603,9 +603,14 @@ class VirtualEnv(object):
     def setupenv(self):
         if self.envconfig._missing_subs:
             self.status = (
-                "unresolvable substitution(s): {}. "
+                "unresolvable substitution(s):\n    {}\n"
                 "Environment variables are missing or defined recursively.".format(
-                    ",".join(["'{}'".format(m) for m in self.envconfig._missing_subs]),
+                    "\n    ".join(
+                        [
+                            "{}: '{}'".format(section_key, exc.name)
+                            for section_key, exc in sorted(self.envconfig._missing_subs.items())
+                        ],
+                    ),
                 )
             )
             return

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -724,7 +724,10 @@ class TestIniParser:
     def test_missing_env_sub_populates_missing_subs(self, newconfig):
         config = newconfig("[testenv:foo]\ncommands={env:VAR}")
         print(SectionReader("section", config._cfg).getstring("commands"))
-        assert config.envconfigs["foo"]._missing_subs == ["VAR"]
+
+        assert "commands" in config.envconfigs["foo"]._missing_subs
+        missing_exception = config.envconfigs["foo"]._missing_subs["commands"]
+        assert missing_exception.name == "VAR"
 
     def test_getstring_environment_substitution_with_default(self, monkeypatch, newconfig):
         monkeypatch.setenv("KEY1", "hello")

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -1080,12 +1080,19 @@ def test_envtmpdir(initproj, cmd):
 
 
 def test_missing_env_fails(initproj, cmd):
-    initproj("foo", filedefs={"tox.ini": "[testenv:foo]\ncommands={env:VAR}"})
+    ini = """
+    [testenv:foo]
+    install_command={env:FOO}
+    commands={env:VAR}
+    """
+    initproj("foo", filedefs={"tox.ini": ini})
     result = cmd()
     result.assert_fail()
     assert result.out.endswith(
-        "foo: unresolvable substitution(s): 'VAR'."
-        " Environment variables are missing or defined recursively.\n",
+        "foo: unresolvable substitution(s):\n"
+        "    commands: 'VAR'\n"
+        "    install_command: 'FOO'\n"
+        "Environment variables are missing or defined recursively.\n",
     )
 
 


### PR DESCRIPTION
Avoid unexpected invalid "TOX_MISSING_SUBSTITUTION" being inserted into settings.

Fixes https://github.com/tox-dev/tox/issues/1716

Contribution checklist:

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
