### PR TITLE
Make the passenv environment setting case sensitive

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ Florian Bruhin
 Florian Preinstorfer
 Florian Schulze
 George Alton
+Gleb Nikonorov
 Gonéri Le Bouder
 Hazal Ozturk
 Henk-Jaap Wagenaar

--- a/docs/changelog/1534.bugfix.rst
+++ b/docs/changelog/1534.bugfix.rst
@@ -1,0 +1,1 @@
+Make the ``passenv`` environment setting case sensitive. - by :user:`gnikonorov`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -793,7 +793,7 @@ def tox_addoption(parser):
             passenv.add("TMPDIR")
         for spec in value:
             for name in os.environ:
-                if fnmatchcase(name.upper(), spec.upper()):
+                if fnmatchcase(name, spec):
                     passenv.add(name)
         return passenv
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1350,6 +1350,21 @@ class TestConfigTestEnv:
         assert "A1" in env.passenv
         assert "A2" in env.passenv
 
+    def test_passenv_is_case_sensitive(self, newconfig, monkeypatch):
+        monkeypatch.setenv("FOO", "upper case foo")
+        monkeypatch.setenv("fOo", "mixed case foo")
+        monkeypatch.setenv("foo", "lower case foo")
+        config = newconfig(
+            """
+            [testenv]
+            passenv=FOO
+        """,
+        )
+        env = config.envconfigs["python"]
+        assert "FOO" in env.passenv
+        assert "fOo" not in env.passenv
+        assert "foo" not in env.passenv
+
     def test_passenv_glob_from_global_env(self, newconfig, monkeypatch):
         monkeypatch.setenv("A1", "a1")
         monkeypatch.setenv("A2", "a2")

--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -788,7 +788,7 @@ def test_env_variables_added_to_pcall(tmpdir, mocksession, newconfig, monkeypatc
 
         [testenv:python]
         commands=python -V
-        passenv = x123
+        passenv = X123
         setenv =
             ENV_VAR = value
             ESCAPED_VAR = \{value\}


### PR DESCRIPTION
## Description
Make the `passenv` environment setting case sensitive. Before this change it was including all environment variables that matched in a case insensitive fashion ( `FOO` included `FOO`, `fOo`, and `foo` for example )

Closes https://github.com/tox-dev/tox/issues/1534

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation - Not applicable in this case 
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
