### PR TITLE
Improve substitution recursion check

### DIFF
--- a/src/tox/exception.py
+++ b/src/tox/exception.py
@@ -56,6 +56,10 @@ class ConfigError(Error):
     """Error in tox configuration."""
 
 
+class SubstitutionStackError(ConfigError, ValueError):
+    """Error in tox configuration recursive substitution."""
+
+
 class UnsupportedInterpreter(Error):
     """Signals an unsupported Interpreter."""
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -438,10 +438,7 @@ class TestIniParserAgainstCommandsKey:
     """Test parsing commands with substitutions"""
 
     def test_command_substitution_recursion_error_same_section(self, newconfig):
-        expected = (
-            r"\('testenv:a', 'commands'\) already in "
-            r"\[\('testenv:a', None\), \('testenv:a', 'commands'\)\]"
-        )
+        expected = r"\('testenv:a', 'commands'\) already in \[\('testenv:a', 'commands'\)\]"
         with pytest.raises(tox.exception.ConfigError, match=expected):
             newconfig(
                 """
@@ -452,9 +449,9 @@ class TestIniParserAgainstCommandsKey:
 
     def test_command_substitution_recursion_error_other_section(self, newconfig):
         expected = (
-            r"\('testenv:base', 'foo'\) already in "
-            r"\[\('testenv:py27', None\), \('testenv:base', 'foo'\), "
-            r"\('testenv:py27', 'commands'\)\]"
+            r"\('testenv:py27', 'commands'\) already in "
+            r"\[\('testenv:py27', 'commands'\), "
+            r"\('testenv:base', 'foo'\)\]"
         )
         with pytest.raises(tox.exception.ConfigError, match=expected):
             newconfig(
@@ -472,7 +469,7 @@ class TestIniParserAgainstCommandsKey:
         # could be optimised away, or emit a warning, or give a custom error
         expected = (
             r"\('testenv:base', 'foo'\) already in "
-            r"\[\('testenv:py27', None\), \('testenv:base', 'foo'\)\]"
+            r"\[\('testenv:py27', 'commands'\), \('testenv:base', 'foo'\)\]"
         )
         with pytest.raises(tox.exception.ConfigError, match=expected):
             newconfig(


### PR DESCRIPTION
Creates SubstitutionStackError and trace recursion from
the beginning of substitution, allowing prevention of the
recursion to halt sooner, and avoid None in error message.

Related to https://github.com/tox-dev/tox/issues/1716
----

Note this doesnt really fix anything that is user-facing, except inside the exception message that 90% of users will not read anyway.

So very low priority / optional.  I dont have anything which depends on this area.

One reason to reject this is the amount of `git blame` changes is high for no actual benefit to the user, and very small benefit to developers.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
