### PR TITLE
Document that the passenv environment setting is case insensitive

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ Florian Bruhin
 Florian Preinstorfer
 Florian Schulze
 George Alton
+Gleb Nikonorov
 Gonéri Le Bouder
 Hazal Ozturk
 Henk-Jaap Wagenaar

--- a/docs/changelog/1534.doc.rst
+++ b/docs/changelog/1534.doc.rst
@@ -1,0 +1,1 @@
+Document that the ``passenv`` environment setting is case insensitive. - by :user:`gnikonorov`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -418,7 +418,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
 
     A list of wildcard environment variable names which
     shall be copied from the tox invocation environment to the test
-    environment when executing test commands. If a specified environment
+    environment when executing test commands.  If a specified environment
     variable doesn't exist in the tox invocation environment it is ignored.
     You can use ``*`` and ``?`` to match multiple environment variables with
     one name. The list of environment variable names is not case sensitive, and

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -418,10 +418,12 @@ Complete list of settings that you can put into ``testenv*`` sections:
 
     A list of wildcard environment variable names which
     shall be copied from the tox invocation environment to the test
-    environment when executing test commands.  If a specified environment
+    environment when executing test commands. If a specified environment
     variable doesn't exist in the tox invocation environment it is ignored.
     You can use ``*`` and ``?`` to match multiple environment variables with
-    one name.
+    one name. The list of environment variable names is not case sensitive, and
+    all variables that match when upper cased will be passed. For example, passing
+    ``A`` will pass both ``A`` and ``a``.
 
     Some variables are always passed through to ensure the basic functionality
     of standard library functions or tooling like pip:


### PR DESCRIPTION
## Description

Document that `passenv` is case insensitive as this was not clear from the current documentation.

Closes https://github.com/tox-dev/tox/issues/1534

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s) - not applicable
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
