### PR TITLE
Parse [tox:testenv] sections in setup.cfg

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -71,6 +71,7 @@ Matt Good
 Matt Jeffery
 Matthew Kenigsberg
 Mattieu Agopian
+Mauricio Villegas
 Mehdi Abaakouk
 Michael Manganiello
 Mickaël Schoentgen

--- a/docs/changelog/1724.feature.rst
+++ b/docs/changelog/1724.feature.rst
@@ -1,0 +1,1 @@
+Support parsing [tox:testenv*] sections in setup.cfg. - by :user:`mauvilsa`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -15,8 +15,9 @@ At the moment tox supports three configuration locations prioritized in the foll
 As far as the configuration format at the moment we only support standard ConfigParser_ "ini-style" format
 (there is a plan to add a pure TOML one soon).
 ``tox.ini`` and ``setup.cfg`` are such files. Note that ``setup.cfg`` requires the content to be under the
-``tox:tox`` section and is otherwise ignored. ``pyproject.toml`` on the other hand is in TOML format. However, one can inline
-the *ini-style* format under the ``tool.tox.legacy_tox_ini`` key as a multi-line string.
+``tox:tox`` and ``tox:testenv`` sections and is otherwise ignored. ``pyproject.toml`` on the other hand is
+in TOML format. However, one can inline the *ini-style* format under the ``tool.tox.legacy_tox_ini`` key
+as a multi-line string.
 
 Below you find the specification for the *ini-style* format, but you might want to skim some
 :doc:`examples` first and use this page as a reference.

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -91,6 +91,24 @@ class TestVenvConfig:
         envconfig = config.envconfigs["dev"]
         assert envconfig.envdir == config.toxworkdir.join("foobar")
 
+    def test_envdir_set_manually_setup_cfg(self, tmpdir, newconfig):
+        config = newconfig(
+            [],
+            """
+            [tox:tox]
+            envlist = py36,py37
+            [tox:testenv]
+            envdir = dev
+            [tox:testenv:py36]
+            envdir = dev36
+        """,
+            filename="setup.cfg",
+        )
+        envconfig = config.envconfigs["py36"]
+        assert envconfig.envdir == tmpdir.join("dev36")
+        envconfig = config.envconfigs["py37"]
+        assert envconfig.envdir == tmpdir.join("dev")
+
     def test_force_dep_version(self, initproj):
         """
         Make sure we can override dependencies configured in tox.ini when using the command line


### PR DESCRIPTION
I wanted to add tox to a project I am working on. I read in the documentation that setup.cfg is supported so I preferred to add the config there instead of adding a new file. The `[tox:tox]` section worked perfectly, but then I wanted to add `[tox:testenv]` but it did not work. I looked at the code and noted that it is not supported, but it did not require a big change so went ahead and implemented it. It is the first time I contribute to this project, so hopefully the change is adequate.

There is no issue associated to this pull request. Please let me know if it is fine to self-reference #1724 or an issue needs to be created.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [X] wrote descriptive pull request text
- [X] added/updated test(s)
- [X] updated/extended the documentation
- [X] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [X] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [X] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
