### PR TITLE
Fix congratulations message that occurs on KeyboardInterrupt during package installation

### DIFF
--- a/docs/changelog/1453.bugfix.rst
+++ b/docs/changelog/1453.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the false ``congratulations`` message that appears when a ``KeyboardInterrupt`` occurs during package installation. - by :user:`gnikonorov`

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -430,6 +430,9 @@ class VirtualEnv(object):
                 redirect=reporter.verbosity() < reporter.Verbosity.DEBUG,
                 env=env,
             )
+        except KeyboardInterrupt:
+            self.status = "keyboardinterrupt"
+            raise
         finally:
             sys.stdout = old_stdout
 
@@ -636,6 +639,9 @@ class VirtualEnv(object):
                 status = e
                 if self.envconfig.config.option.skip_missing_interpreters == "true":
                     default_ret_code = 0
+            except KeyboardInterrupt:
+                self.status = "keyboardinterrupt"
+                raise
             if status:
                 str_status = str(status)
                 command_log = envlog.get_commandlog("setup")


### PR DESCRIPTION
## Description
Fix congratulations message that occurs on `KeyboardInterrupt` during package installation.

Now `^C` will cause `tox` to show `ERROR: got KeyboardInterrupt signal` instead of `py27: commands succeeded congratulations :)`

Closes https://github.com/tox-dev/tox/issues/1453

This is similar to https://github.com/tox-dev/tox/pull/1258.

I also tested this locally, and could not get the description in the linked issue to reproduce

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
