### PR TITLE
tests: add coverage for tox run

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,21 +1,19 @@
 import pytest
 from pytest_mock import MockerFixture
 
-import tox.run
 from tox.report import HandledError
+from tox.run import run
 
 
 @pytest.mark.parametrize("exception", [HandledError, KeyboardInterrupt])
-def test_run_raises_SystemExit_with_negative_two_exit_code_when_main_throws_expected_exception(
-    exception: Exception, mocker: MockerFixture
-) -> None:
-    mocker.patch.object(tox.run, "main", side_effect=exception)
+def test_exit_code_minus_2_on_expected_exit(exception: Exception, mocker: MockerFixture) -> None:
+    mocker.patch("tox.run.main", side_effect=exception)
     with pytest.raises(SystemExit) as system_exit:
-        tox.run.run()
+        run()
     assert system_exit.value.code == -2
 
 
-def test_run_reraises_when_main_throws_unexpected_exception(mocker: MockerFixture) -> None:
-    mocker.patch.object(tox.run, "main", side_effect=ValueError)
+def test_re_raises_on_unexpected_exit(mocker: MockerFixture) -> None:
+    mocker.patch("tox.run.main", side_effect=ValueError)
     with pytest.raises(ValueError):
-        tox.run.run()
+        run()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,21 @@
+import pytest
+from pytest_mock import MockerFixture
+
+import tox.run
+from tox.report import HandledError
+
+
+@pytest.mark.parametrize("exception", [HandledError, KeyboardInterrupt])
+def test_run_raises_SystemExit_with_negative_two_exit_code_when_main_throws_expected_exception(
+    exception: Exception, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(tox.run, "main", side_effect=exception)
+    with pytest.raises(SystemExit) as system_exit:
+        tox.run.run()
+    assert system_exit.value.code == -2
+
+
+def test_run_reraises_when_main_throws_unexpected_exception(mocker: MockerFixture) -> None:
+    mocker.patch.object(tox.run, "main", side_effect=ValueError)
+    with pytest.raises(ValueError):
+        tox.run.run()


### PR DESCRIPTION
**FOR THE REWRITE BRANCH**

Add full test coverage for the `run` method of `src/tox/run.py`

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation - N/A
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body - N/A
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog) - N/A
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order) -N/A
