### PR TITLE
tests: add coverage for tox.info

### DIFF
--- a/tests/tox_env/test_info.py
+++ b/tests/tox_env/test_info.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+from tox.tox_env.info import Info
+
+def test_Info_dunder_repr_method() -> None:
+    info_object = Info(Path())
+    assert repr(info_object) == 'Info(path=.tox-info.json)'

--- a/tests/tox_env/test_info.py
+++ b/tests/tox_env/test_info.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tox.tox_env.info import Info
 
 
-def test_Info_dunder_repr_method() -> None:
-    info_object = Info(Path())
-    assert repr(info_object) == "Info(path=.tox-info.json)"
+def test_info_repr() -> None:
+    at_loc = Path().absolute()
+    info_object = Info(at_loc)
+    assert repr(info_object) == f"Info(path={ at_loc / '.tox-info.json' })"

--- a/tests/tox_env/test_info.py
+++ b/tests/tox_env/test_info.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from tox.tox_env.info import Info
 
+
 def test_Info_dunder_repr_method() -> None:
     info_object = Info(Path())
-    assert repr(info_object) == 'Info(path=.tox-info.json)'
+    assert repr(info_object) == "Info(path=.tox-info.json)"


### PR DESCRIPTION
**FOR THE REWRITE BRANCH**

Add full test coverage for `src/tox/tox_env/info.py`

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation - N/A
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body - N/A
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog) - N/A
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order) -N/A
