### PR TITLE
tests: add full coverage for tox.session.cmd.run.common

### DIFF
--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -14,7 +14,7 @@ class SkipMissingInterpreterAction(Action):
     ) -> None:
         value = "true" if values is None else values
         if value not in ("config", "true", "false"):
-            raise ArgumentTypeError("value must be config, true or false")
+            raise ArgumentTypeError(f"value must be 'config', 'true', or 'false' (got {repr(value)})")
         setattr(args, self.dest, value)
 
 

--- a/tests/session/cmd/run/test_common.py
+++ b/tests/session/cmd/run/test_common.py
@@ -1,0 +1,20 @@
+from argparse import ArgumentParser, ArgumentTypeError, Namespace
+from typing import Optional
+
+import pytest
+
+from tox.session.cmd.run.common import SkipMissingInterpreterAction
+
+
+@pytest.mark.parametrize("values", ["config", None, "true", "false"])
+def test_skip_missing_interpreter_action_ok(values: Optional[str]) -> None:
+    args_namespace = Namespace()
+    SkipMissingInterpreterAction(option_strings=["-i"], dest="into")(ArgumentParser(), args_namespace, values)
+    expected = "true" if values is None else values
+    assert args_namespace.into == expected
+
+
+def test_skip_missing_interpreter_action_nok() -> None:
+    argument_parser = ArgumentParser()
+    with pytest.raises(ArgumentTypeError, match=r"value must be 'config', 'true', or 'false' \(got 'bad value'\)"):
+        SkipMissingInterpreterAction(option_strings=["-i"], dest="into")(argument_parser, Namespace(), "bad value")


### PR DESCRIPTION
**FOR THE REWRITE BRANCH**

Add full test coverage for `session/cmd/run/common.py`

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation - N/A
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body - N/A
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog) - N/A
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order) -N/A
