### PR TITLE
tests: do not depend on pathlib2 for modern python

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,13 +61,13 @@ docs =
 testing =
     flaky>=3.4.0
     freezegun>=0.3.11
-    pathlib2>=2.3.3
     psutil>=5.6.1
     pytest>=4.0.0
     pytest-cov>=2.5.1
     pytest-mock>=1.10.0
     pytest-randomly>=1.0.0
     pytest-xdist>=1.22.2
+    pathlib2>=2.3.3;python_version<"3.4"
 
 [options.packages.find]
 where = src

--- a/tests/integration/test_package_int.py
+++ b/tests/integration/test_package_int.py
@@ -4,7 +4,11 @@ import subprocess
 import sys
 
 import pytest
-from pathlib2 import Path
+
+if sys.version_info[:2] >= (3, 4):
+    from pathlib import Path
+else:
+    from pathlib2 import Path
 
 from tests.lib import need_git
 

--- a/tests/integration/test_parallel_interrupt.py
+++ b/tests/integration/test_parallel_interrupt.py
@@ -7,7 +7,11 @@ from datetime import datetime
 
 import pytest
 from flaky import flaky
-from pathlib2 import Path
+
+if sys.version_info[:2] >= (3, 4):
+    from pathlib import Path
+else:
+    from pathlib2 import Path
 
 from tox.constants import INFO
 from tox.util.main import MAIN_FILE

--- a/tests/integration/test_provision_int.py
+++ b/tests/integration/test_provision_int.py
@@ -4,7 +4,11 @@ import sys
 import time
 
 import pytest
-from pathlib2 import Path
+
+if sys.version_info[:2] >= (3, 4):
+    from pathlib import Path
+else:
+    from pathlib2 import Path
 
 from tox.constants import INFO
 from tox.util.main import MAIN_FILE

--- a/tests/unit/package/test_package.py
+++ b/tests/unit/package/test_package.py
@@ -132,12 +132,17 @@ def test_build_backend_without_submodule(initproj, cmd):
             # To trigger original bug, must be package with __init__.py
             "inline_backend": {
                 "__init__.py": """\
+                    import sys
                     def get_requires_for_build_sdist(*args, **kwargs):
-                        return ["pathlib2"]
+                        return ["pathlib2;python_version<'3.4'"]
 
                     def build_sdist(sdist_directory, config_settings=None):
-                        import pathlib2
-                        (pathlib2.Path(sdist_directory) / "magic-0.1.0.tar.gz").touch()
+                        if sys.version_info[:2] >= (3, 4):
+                            import pathlib
+                        else:
+                            import pathlib2 as pathlib
+
+                        (pathlib.Path(sdist_directory) / "magic-0.1.0.tar.gz").touch()
                         return "magic-0.1.0.tar.gz"
                 """,
             },

--- a/tests/unit/session/test_provision.py
+++ b/tests/unit/session/test_provision.py
@@ -7,7 +7,12 @@ import sys
 
 import py
 import pytest
-from pathlib2 import Path
+
+if sys.version_info[:2] >= (3, 4):
+    from pathlib import Path
+else:
+    from pathlib2 import Path
+
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.request import pathname2url
 

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 import tempfile
 
-import pathlib2
+if sys.version_info[:2] >= (3, 4):
+    import pathlib
+else:
+    import pathlib2 as pathlib
 import py
 import pytest
 
@@ -462,7 +465,7 @@ def test_no_setup_py_exits_but_pyproject_toml_does(cmd, initproj):
         },
     )
     os.remove("setup.py")
-    pathlib2.Path("pyproject.toml").touch()
+    pathlib.Path("pyproject.toml").touch()
     result = cmd()
     result.assert_fail()
     assert any(


### PR DESCRIPTION
Try pathlib and fall back to pathlib2.

The latter is technically installable on python 3.4+, but does nothing the stdlib doesn't do better. And in tightly constrained build environments, e.g. distro packaging, any dependency or test dependency must be a system package, but old, python2-specific backports of the stdlib might not actually be packaged...

Make the job of distro packagers easier by not requiring patches to use pathlib while testing python3.

Fixes #1549

## Contribution checklist:

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
