### PR TITLE
Replace some '/'s with '{/}'s in path creation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,6 +40,7 @@ Gleb Nikonorov
 Gonéri Le Bouder
 Hazal Ozturk
 Henk-Jaap Wagenaar
+Hong Xu
 Ian Stapleton Cordasco
 Igor Duarte Cardoso
 Ilya Kulakov

--- a/docs/changelog/1752.bugfix.rst
+++ b/docs/changelog/1752.bugfix.rst
@@ -1,0 +1,1 @@
+Use "{/}" instead of "/" in creating paths, as in {envdir}, {envtmpdir}, {envlogdir}, {toxworkdir}, {temp_dir}, {distdir}, {distshare}. - by :user:`xuhdev`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -61,11 +61,11 @@ Global settings are defined under the ``tox`` section as:
     Name of the virtual environment used to provision a tox having all dependencies specified
     inside :conf:`requires` and :conf:`minversion`.
 
-.. conf:: toxworkdir ^ PATH ^ {toxinidir}/.tox
+.. conf:: toxworkdir ^ PATH ^ {toxinidir}{/}.tox
 
    Directory for tox to generate its environments into, will be created if it does not exist.
 
-.. conf:: temp_dir ^ PATH ^ {toxworkdir}/.tmp
+.. conf:: temp_dir ^ PATH ^ {toxworkdir}{/}.tmp
 
    Directory where to put tox temporary files. For example: we create a hard link (if possible,
    otherwise new copy) in this directory for the project package. This ensures tox works correctly
@@ -82,21 +82,21 @@ Global settings are defined under the ``tox`` section as:
    Indicates where the packaging root file exists (historically the ``setup.py`` for ``setuptools``).
    This will be the working directory when performing the packaging.
 
-.. conf:: distdir ^ PATH ^ {toxworkdir}/dist
+.. conf:: distdir ^ PATH ^ {toxworkdir}{/}dist
 
    Directory where the packaged source distribution should be put. Note this is cleaned at the start of
    every packaging invocation.
 
-.. conf:: sdistsrc ^ PATH ^ {toxworkdir}/dist
+.. conf:: sdistsrc ^ PATH ^ None
 
    Do not build the package, but instead use the latest package available under this path.
    You can override it via the command line flag ``--installpkg``.
 
-.. conf:: distshare ^ PATH ^ {homedir}/.tox/distshare
+.. conf:: distshare ^ PATH ^ {homedir}{/}.tox{/}distshare
 
    Folder where the packaged source distribution will be moved, this is not cleaned between packaging
    invocations. On Jenkins (exists ``JENKINS_URL`` or ``HUDSON_URL`` environment variable)
-   the default path is ``{toxworkdir}/distshare``.
+   the default path is ``{toxworkdir}{/}distshare``.
 
 .. conf:: envlist ^ comma separated values
 
@@ -504,12 +504,12 @@ Complete list of settings that you can put into ``testenv*`` sections:
     to the ``changedir``. Default is true due to the exists-on-filesystem check it's
     usually safe to try rewriting.
 
-.. conf:: envtmpdir ^ PATH ^ {envdir}/tmp
+.. conf:: envtmpdir ^ PATH ^ {envdir}{/}tmp
 
     Defines a temporary directory for the virtualenv which will be cleared
     each time before the group of test commands is invoked.
 
-.. conf:: envlogdir ^ PATH ^ {envdir}/log
+.. conf:: envlogdir ^ PATH ^ {envdir}{/}log
 
     Defines a directory for logging where tox will put logs of tool
     invocation.
@@ -534,7 +534,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
     will make tox install all dependencies from this PyPI index server
     (including when installing the project sdist package).
 
-.. conf:: envdir ^ PATH ^ {toxworkdir}/{envname}
+.. conf:: envdir ^ PATH ^ {toxworkdir}{/}{envname}
 
     .. versionadded:: 1.5
 

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -590,7 +590,7 @@ def tox_addoption(parser):
     parser.add_testenv_attribute(
         name="envdir",
         type="path",
-        default="{toxworkdir}/{envname}",
+        default="{toxworkdir}{/}{envname}",
         help="set venv directory -- be very careful when changing this as tox "
         "will remove this directory when recreating an environment",
         postprocess=_set_envdir_from_devenv,
@@ -686,14 +686,14 @@ def tox_addoption(parser):
     parser.add_testenv_attribute(
         name="envtmpdir",
         type="path",
-        default="{envdir}/tmp",
+        default="{envdir}{/}tmp",
         help="venv temporary directory",
     )
 
     parser.add_testenv_attribute(
         name="envlogdir",
         type="path",
-        default="{envdir}/log",
+        default="{envdir}{/}log",
         help="venv log directory",
     )
 
@@ -1151,10 +1151,10 @@ class ParseIni(object):
                 prefix=prefix,
                 fallbacksections=[fallbacksection],
             )
-            dist_share_default = "{toxworkdir}/distshare"
+            dist_share_default = "{toxworkdir}{/}distshare"
         elif not context_name:
             reader = SectionReader("tox", self._cfg, prefix=prefix)
-            dist_share_default = "{homedir}/.tox/distshare"
+            dist_share_default = "{homedir}{/}.tox{/}distshare"
         else:
             raise ValueError("invalid context")
 
@@ -1169,7 +1169,7 @@ class ParseIni(object):
         reader.addsubstitutions(toxinidir=config.toxinidir, homedir=config.homedir)
 
         if config.option.workdir is None:
-            config.toxworkdir = reader.getpath("toxworkdir", "{toxinidir}/.tox")
+            config.toxworkdir = reader.getpath("toxworkdir", "{toxinidir}{/}.tox")
         else:
             config.toxworkdir = config.toxinidir.join(config.option.workdir, abs=True)
 
@@ -1179,12 +1179,12 @@ class ParseIni(object):
         reader.addsubstitutions(toxworkdir=config.toxworkdir)
         config.ignore_basepython_conflict = reader.getbool("ignore_basepython_conflict", False)
 
-        config.distdir = reader.getpath("distdir", "{toxworkdir}/dist")
+        config.distdir = reader.getpath("distdir", "{toxworkdir}{/}dist")
 
         reader.addsubstitutions(distdir=config.distdir)
         config.distshare = reader.getpath("distshare", dist_share_default)
         reader.addsubstitutions(distshare=config.distshare)
-        config.temp_dir = reader.getpath("temp_dir", "{toxworkdir}/.tmp")
+        config.temp_dir = reader.getpath("temp_dir", "{toxworkdir}{/}.tmp")
         reader.addsubstitutions(temp_dir=config.temp_dir)
         config.sdistsrc = reader.getpath("sdistsrc", None)
         config.setupdir = reader.getpath("setupdir", "{toxinidir}")


### PR DESCRIPTION
For consistency on Windows. This includes {envdir}, {envtmpdir}, {envlogdir}, {toxworkdir},
{temp_dir}, {distdir}, {distshare}.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ N/A ] (did not find existing tests for testing default values and compare them with the ones in the document) added/updated test(s)
- [x] updated/extended the documentation
- [ N/A ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
