### PR TITLE
Add more info about per-platform commands

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -90,6 +90,7 @@ Paweł Adamczak
 Philip Thiem
 Pierre-Jean Campigotto
 Pierre-Luc Tessier Gagné
+Prakhar Gurunani
 Ronald Evers
 Ronny Pfannschmidt
 Selim Belhaouane

--- a/docs/changelog/1144.doc.rst
+++ b/docs/changelog/1144.doc.rst
@@ -1,0 +1,1 @@
+Document more info about using ``platform`` setting. - by :user:`prakhargurunani`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -386,8 +386,8 @@ Complete list of settings that you can put into ``testenv*`` sections:
 
     A testenv can define a new ``platform`` setting as a regular expression.
     If a non-empty expression is defined and does not match against the
-    ``sys.platform`` string the entire test environment will be skipped and 
-    none of the commands will be executed. Running ``tox -e <platform_name>`` 
+    ``sys.platform`` string the entire test environment will be skipped and
+    none of the commands will be executed. Running ``tox -e <platform_name>``
     will run commands for a particular platform and skip the rest.
 
 .. conf:: setenv ^ MULTI-LINE-LIST

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -386,7 +386,9 @@ Complete list of settings that you can put into ``testenv*`` sections:
 
     A testenv can define a new ``platform`` setting as a regular expression.
     If a non-empty expression is defined and does not match against the
-    ``sys.platform`` string the test environment will be skipped.
+    ``sys.platform`` string the entire test environment will be skipped and 
+    none of the commands will be executed. Running ``tox -e <platform_name>`` 
+    will run commands for a particular platform and skip the rest.
 
 .. conf:: setenv ^ MULTI-LINE-LIST
 


### PR DESCRIPTION
fixes: #1144 

The docs don't cover about how to execute commands for a particular platform when multiple platforms are defined in `tox.ini`