### PR TITLE
rewrite: Use time.monotonic for runtime durations

### DIFF
--- a/src/tox/run.py
+++ b/src/tox/run.py
@@ -1,7 +1,7 @@
 """Main entry point for tox."""
 import logging
 import sys
-from datetime import datetime
+import time
 from itertools import chain
 from pathlib import Path
 from typing import Optional, Sequence
@@ -42,7 +42,7 @@ def main(args: Sequence[str]) -> int:
 
 def setup_state(args: Sequence[str]) -> State:
     """Setup the state object of this run."""
-    start = datetime.now()
+    start = time.monotonic()
     # parse CLI arguments
     parsed, handlers, pos_args = get_options(*args)
     parsed.start = start


### PR DESCRIPTION
Running `datetime.datetime.now()` during a DST switch just to calculate a runtime duration may return false results, just like running it during a system clock update.

Since `tox/rewrite` is py3-only, it can use `time.monotonic` to get a strictly monotonically increasing counter of seconds that is perfect to calculate durations.

I have changed it in  `src/tox/session/cmd/run/sequential.py` and `src/tox/run.py`. There is `src/tox/util/spinner.py` where I'd like to change it as well, but there in https://github.com/tox-dev/tox/blob/rewrite/src/tox/util/spinner.py#L70 the `datetime` values are about to be printed as well. The questions is, whether this is really needed (the output is cut at the end of line automatically anyway), or we can use UTC or we want to work with local timezones.