### PR TITLE
Doc: Don't use deprecated plugin in the example

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -51,7 +51,7 @@ Global settings are defined under the ``tox`` section as:
     .. code-block:: ini
 
         [tox]
-        requires = tox-venv
+        requires = tox-pipenv
                    setuptools >= 30.0.0
 
 .. conf:: provision_tox_env ^ string ^ .tox


### PR DESCRIPTION
[tox-venv](https://github.com/tox-dev/tox-venv) has been deprecated.
