### PR TITLE
Remove high constraint for importlib-metadata

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -87,6 +87,7 @@ Oliver Bestwalter
 Pablo Galindo
 Paul Moore
 Paweł Adamczak
+Peter Kolbus
 Philip Thiem
 Pierre-Jean Campigotto
 Pierre-Luc Tessier Gagné

--- a/docs/changelog/1763.feature.rst
+++ b/docs/changelog/1763.feature.rst
@@ -1,0 +1,2 @@
+Relax importlib requirement to allow 3.0.0 or any newer version - by
+:user:`pkolbus`

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     toml>=0.9.4
     virtualenv!=20.0.0,!=20.0.1,!=20.0.2,!=20.0.3,!=20.0.4,!=20.0.5,!=20.0.6,!=20.0.7,>=16.0.0
     colorama>=0.4.1 ;platform_system=="Windows"
-    importlib-metadata>=0.12,<3;python_version<"3.8"
+    importlib-metadata>=0.12;python_version<"3.8"
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 
 [options.entry_points]


### PR DESCRIPTION
Since importlib-metadata is a backport from CPython, new major versions are much more likely to be to adjust supported Python versions, and not change the API. Remove the upper bound on the version constraint.

Closes #1763.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
