### PR TITLE
config: Lazy evaluation 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,52 @@ with advance notice in the **Deprecations** section of releases.
 
 .. towncrier release notes start
 
+v3.21.0 (2021-01-08)
+--------------------
+
+Bugfixes
+^^^^^^^^
+
+- Fix the false ``congratulations`` message that appears when a ``KeyboardInterrupt`` occurs during package installation. - by :user:`gnikonorov`
+  `#1453 <https://github.com/tox-dev/tox/issues/1453>`_
+- Fix ``platform`` support for ``install_command``. - by :user:`jayvdb`
+  `#1464 <https://github.com/tox-dev/tox/issues/1464>`_
+- Fixed regression in v3.20.0 that caused escaped curly braces in setenv
+  to break usage of the variable elsewhere in tox.ini. - by :user:`jayvdb`
+  `#1690 <https://github.com/tox-dev/tox/issues/1690>`_
+- Prevent ``{}`` and require ``{:`` is only followed by ``}``. - by :user:`jayvdb`
+  `#1711 <https://github.com/tox-dev/tox/issues/1711>`_
+- Raise ``MissingSubstitution`` on access of broken ini setting. - by :user:`jayvdb`
+  `#1716 <https://github.com/tox-dev/tox/issues/1716>`_
+
+
+Features
+^^^^^^^^
+
+- Allow \{ and \} in default of {env:key:default}. - by :user:`jayvdb`
+  `#1502 <https://github.com/tox-dev/tox/issues/1502>`_
+- Allow {posargs} in setenv. - by :user:`jayvdb`
+  `#1695 <https://github.com/tox-dev/tox/issues/1695>`_
+- Allow {/} to refer to os.sep. - by :user:`jayvdb`
+  `#1700 <https://github.com/tox-dev/tox/issues/1700>`_
+- Make parsing [testenv] sections in setup.cfg official. - by :user:`mauvilsa`
+  `#1727 <https://github.com/tox-dev/tox/issues/1727>`_
+- Relax importlib requirement to allow 3.0.0 or any newer version - by
+  :user:`pkolbus`
+  `#1763 <https://github.com/tox-dev/tox/issues/1763>`_
+
+
+Documentation
+^^^^^^^^^^^^^
+
+- Document more info about using ``platform`` setting. - by :user:`prakhargurunani`
+  `#1144 <https://github.com/tox-dev/tox/issues/1144>`_
+- Replace ``indexserver`` in documentation with environment variables - by :user:`ziima`.
+  `#1357 <https://github.com/tox-dev/tox/issues/1357>`_
+- Document that the ``passenv`` environment setting is case insensitive. - by :user:`gnikonorov`
+  `#1534 <https://github.com/tox-dev/tox/issues/1534>`_
+
+
 v3.20.1 (2020-10-09)
 --------------------
 

--- a/docs/changelog/1144.doc.rst
+++ b/docs/changelog/1144.doc.rst
@@ -1,1 +1,0 @@
-Document more info about using ``platform`` setting. - by :user:`prakhargurunani`

--- a/docs/changelog/1357.doc.rst
+++ b/docs/changelog/1357.doc.rst
@@ -1,1 +1,0 @@
-Replace ``indexserver`` in documentation with environment variables - by :user:`ziima`.

--- a/docs/changelog/1453.bugfix.rst
+++ b/docs/changelog/1453.bugfix.rst
@@ -1,1 +1,0 @@
-Fix the false ``congratulations`` message that appears when a ``KeyboardInterrupt`` occurs during package installation. - by :user:`gnikonorov`

--- a/docs/changelog/1464.bugfix.rst
+++ b/docs/changelog/1464.bugfix.rst
@@ -1,1 +1,0 @@
-Fix ``platform`` support for ``install_command``. - by :user:`jayvdb`

--- a/docs/changelog/1502.feature.rst
+++ b/docs/changelog/1502.feature.rst
@@ -1,1 +1,0 @@
-Allow \{ and \} in default of {env:key:default}. - by :user:`jayvdb`

--- a/docs/changelog/1534.doc.rst
+++ b/docs/changelog/1534.doc.rst
@@ -1,1 +1,0 @@
-Document that the ``passenv`` environment setting is case insensitive. - by :user:`gnikonorov`

--- a/docs/changelog/1690.bugfix.rst
+++ b/docs/changelog/1690.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed regression in v3.20.0 that caused escaped curly braces in setenv
-to break usage of the variable elsewhere in tox.ini. - by :user:`jayvdb`

--- a/docs/changelog/1695.feature.rst
+++ b/docs/changelog/1695.feature.rst
@@ -1,1 +1,0 @@
-Allow {posargs} in setenv. - by :user:`jayvdb`

--- a/docs/changelog/1700.feature.rst
+++ b/docs/changelog/1700.feature.rst
@@ -1,1 +1,0 @@
-Allow {/} to refer to os.sep. - by :user:`jayvdb`

--- a/docs/changelog/1711.bugfix.rst
+++ b/docs/changelog/1711.bugfix.rst
@@ -1,1 +1,0 @@
-Prevent ``{}`` and require ``{:`` is only followed by ``}``. - by :user:`jayvdb`

--- a/docs/changelog/1716.bugfix.rst
+++ b/docs/changelog/1716.bugfix.rst
@@ -1,1 +1,0 @@
-Raise ``MissingSubstitution`` on access of broken ini setting. - by :user:`jayvdb`

--- a/docs/changelog/1727.feature.rst
+++ b/docs/changelog/1727.feature.rst
@@ -1,1 +1,0 @@
-Make parsing [testenv] sections in setup.cfg official. - by :user:`mauvilsa`

--- a/docs/changelog/1763.feature.rst
+++ b/docs/changelog/1763.feature.rst
@@ -1,2 +1,0 @@
-Relax importlib requirement to allow 3.0.0 or any newer version - by
-:user:`pkolbus`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -99,7 +99,7 @@ class Parser:
             prog="tox",
             formatter_class=HelpFormatter,
         )
-        self._testenv_attr = []
+        self._testenv_attr = {}
 
     def add_argument(self, *args, **kwargs):
         """add argument to command line parser.  This takes the
@@ -122,7 +122,7 @@ class Parser:
         Any postprocess function must return a value which will then be set
         as the final value in the testenv section.
         """
-        self._testenv_attr.append(VenvAttribute(name, type, default, help, postprocess))
+        self._testenv_attr[name] = VenvAttribute(name, type, default, help, postprocess)
 
     def add_testenv_attribute_obj(self, obj):
         """add an ini-file variable as an object.
@@ -134,7 +134,7 @@ class Parser:
         assert hasattr(obj, "type")
         assert hasattr(obj, "help")
         assert hasattr(obj, "postprocess")
-        self._testenv_attr.append(obj)
+        self._testenv_attr[obj.name] = obj
 
     def parse_cli(self, args, strict=False):
         args, argv = self.argparser.parse_known_args(args)
@@ -1390,7 +1390,7 @@ class ParseIni(object):
             envpython=tc.get_envpython,
             **subs
         )
-        for env_attr in config._testenv_attr:
+        for env_attr in config._testenv_attr.values():
             atype = env_attr.type
             try:
                 if atype in (

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1379,6 +1379,7 @@ class ParseIni(object):
         return factors
 
     def make_envconfig(self, name, section, subs, config, replace=True):
+        replace=True
         factors = set(name.split("-"))
         reader = SectionReader(section, self._cfg, fallbacksections=["testenv"], factors=factors)
         tc = TestenvConfig(name, config, factors, reader)

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1374,6 +1374,7 @@ class ParseIni(object):
                 config,
             )
             env_config.deps = deps
+            env_config.basepython = sys.executable
             config.envconfigs[config.provision_tox_env] = env_config
             raise tox.exception.MissingRequirement(config)
         # if provisioning is not on, now we need do a strict argument evaluation

--- a/src/tox/session/commands/help_ini.py
+++ b/src/tox/session/commands/help_ini.py
@@ -3,7 +3,7 @@ from tox import reporter
 
 def show_help_ini(config):
     reporter.separator("-", "per-testenv attributes", reporter.Verbosity.INFO)
-    for env_attr in config._testenv_attr:
+    for env_attr in config._testenv_attr.values():
         reporter.line(
             "{:<15} {:<8} default: {}".format(
                 env_attr.name,

--- a/src/tox/session/commands/show_config.py
+++ b/src/tox/session/commands/show_config.py
@@ -42,7 +42,7 @@ def tox_envs_info(config, parser):
     for name in env_list:
         env_config = config.envconfigs[name]
         values = OrderedDict(
-            (attr.name, str(getattr(env_config, attr.name)))
+            (attr, str(getattr(env_config, attr)))
             for attr in config._parser._testenv_attr
         )
         section = "testenv:{}".format(name)

--- a/tox.ini
+++ b/tox.ini
@@ -33,10 +33,6 @@ deps =
     pip >= 19.3.1
 extras = testing
 commands = pytest \
-           --cov "{envsitepackagesdir}/tox" \
-           --cov-config "{toxinidir}/tox.ini" \
-           --junitxml {toxworkdir}/junit.{envname}.xml \
-           -n={env:PYTEST_XDIST_PROC_NR:auto} \
            {posargs:.}
 
 [testenv:pypy]


### PR DESCRIPTION
Delay evaluation of config until accessed.

Fixes https://github.com/tox-dev/tox/issues/1191

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
