### PR TITLE
config: Fix parsing posargs default with colon

### DIFF
--- a/docs/changelog/1785.bugfix.rst
+++ b/docs/changelog/1785.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression parsing posargs default containing colon. - by :user:`jayvdb`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1852,6 +1852,13 @@ class Replacer:
             return self.reader.getposargs(default_value)
 
         sub_type = g["sub_type"]
+        if sub_type == "posargs":
+            if default_value:
+                value = "{}:{}".format(sub_value, default_value)
+            else:
+                value = sub_value
+            return self.reader.getposargs(value)
+
         if not sub_type and not sub_value:
             raise tox.exception.ConfigError(
                 "Malformed substitution; no substitution type provided. "


### PR DESCRIPTION
e4d0d60 introduced a regression when posargs default
contained a colon, as the common substitution arg
regex splits on the colon, and uses different replace
types depending on the number of colons found.

Fixes https://github.com/tox-dev/tox/issues/1785

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)