### PR TITLE
config: Revert removal of {packages}/{opts} hack

### DIFF
--- a/docs/changelog/1777.bugfix.rst
+++ b/docs/changelog/1777.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression that broke using install_command in config replacements - by :user:`jayvdb`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1848,6 +1848,12 @@ class Replacer:
             return os.pathsep
 
         default_value = g["default_value"]
+        # special case: opts and packages. Leave {opts} and
+        # {packages} intact, they are replaced manually in
+        # _venv.VirtualEnv.run_install_command.
+        if sub_value in ("opts", "packages"):
+            return "{{{}}}".format(sub_value)
+
         if sub_value == "posargs":
             return self.reader.getposargs(default_value)
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1670,6 +1670,26 @@ class TestConfigTestEnv:
         ]
         assert envconfig.install_command == expected_deps
 
+    def test_install_command_substitutions_other_section(self, newconfig):
+        config = newconfig(
+            """
+            [base]
+            install_command=some_install --arg={toxinidir}/foo \
+                {envname} {opts} {packages}
+            [testenv]
+            install_command={[base]install_command}
+        """,
+        )
+        envconfig = config.envconfigs["python"]
+        expected_deps = [
+            "some_install",
+            "--arg={}/foo".format(config.toxinidir),
+            "python",
+            "{opts}",
+            "{packages}",
+        ]
+        assert envconfig.install_command == expected_deps
+
     def test_pip_pre(self, newconfig):
         config = newconfig(
             """


### PR DESCRIPTION
Closes https://github.com/tox-dev/tox/issues/1777

Re-submitting https://github.com/tox-dev/tox/pull/1794 which appears to be lost after merging.

Also I suspect the auto-closing didnt work, and I see now that is because the two commits with specific messages were merged into a single commit using the GitHub merge features.