### PR TITLE
POC: tox4 catch plugin load failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,12 @@ jobs:
     coverage:
       with_toxenv: 'coverage' # generate .tox/.coverage, .tox/coverage.xml after test run
       for_envs: [py38, py37, py36, py35, py27, pypy3, pypy]
-
+    before:
+      - task: UsePythonVersion@0
+        condition: and(succeeded(), in(variables['TOXENV'], 'pypy'))
+        displayName: provision pypy 3
+        inputs:
+          versionSpec: 'pypy3'
 - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
   - template: publish-pypi.yml@tox
     parameters:

--- a/docs/changelog/1521.bugfix.rst
+++ b/docs/changelog/1521.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid pypy test failure due to undefined printout var. - by :user:`ssbarnea`

--- a/src/tox/session/commands/run/parallel.py
+++ b/src/tox/session/commands/run/parallel.py
@@ -35,6 +35,7 @@ def run_parallel(config, venv_dict):
 
         def run_in_thread(tox_env, os_env, processes):
             output = None
+            print_out = None
             env_name = tox_env.envconfig.envname
             status = "skipped tests" if config.option.notest else None
             try:


### PR DESCRIPTION
Not really working as the exception is opaque and does not give a hint on which plugin caused it.

Related: https://github.com/tox-dev/tox/discussions/1810