### PR TITLE
Simplify td_human_readable function

### DIFF
--- a/src/tox/util/spinner.py
+++ b/src/tox/util/spinner.py
@@ -5,7 +5,7 @@ import threading
 import time
 from collections import OrderedDict
 from types import TracebackType
-from typing import IO, Dict, Optional, Sequence, Type, TypeVar
+from typing import IO, Dict, List, Optional, Sequence, Type, TypeVar
 
 from colorama import Fore
 
@@ -167,16 +167,14 @@ _PERIODS = [
 
 
 def td_human_readable(seconds: float) -> str:
-    texts = []
-    total_seconds = seconds
+    texts: List[str] = []
     for period_name, period_seconds in _PERIODS:
-        if seconds > period_seconds or period_seconds == 1:
-            period_value = int(seconds) // period_seconds
-            seconds %= period_seconds
-            if period_name == "second":
-                ms = period_value + total_seconds - int(total_seconds)
-                period_str = f"{ms:.2f}".rstrip("0").rstrip(".")
-            else:
-                period_str = str(period_value)
+        period_str = None
+        if period_name == "second" and (seconds >= 0.01 or not texts):
+            period_str = f"{seconds:.2f}".rstrip("0").rstrip(".")
+        elif seconds >= period_seconds:
+            period_value, seconds = divmod(seconds, period_seconds)
+            period_str = f"{period_value:.0f}"
+        if period_str is not None:
             texts.append(f"{period_str} {period_name}{'' if period_str == '1' else 's'}")
     return " ".join(texts)

--- a/tests/util/test_spinner.py
+++ b/tests/util/test_spinner.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import time
-from datetime import timedelta
 
 import pytest
 from colorama import Fore
@@ -135,10 +134,12 @@ def test_spinner_stdout_not_unicode(capfd: CaptureFixture, mocker: MockerFixture
         (4.13, "4.13 seconds"),
         (4.137, "4.14 seconds"),
         (42.12345, "42.12 seconds"),
+        (60, "1 minute"),
         (61, "1 minute 1 second"),
+        (120, "2 minutes"),
+        (40 * 24 * 60 * 60 + 5 * 60, "40 days 5 minutes"),
         (40 * 24 * 60 * 60 + 4 * 60 * 60 + 5 * 60 + 1.5, "40 days 4 hours 5 minutes 1.5 seconds"),
     ],
 )
 def test_td_human_readable(seconds: float, expected: str) -> None:
-    dt = timedelta(seconds=seconds)
-    assert spinner.td_human_readable(dt.total_seconds()) == expected
+    assert spinner.td_human_readable(seconds) == expected


### PR DESCRIPTION
We're still miles away from `datetime.timedelta.__format__`, so this is to clean up and simplify the `td_human_readable` function. No external functionality would be affected, so no need to update anything else.

Looking forward to tox 4!