### PR TITLE
Add PIP_TRUSTED_HOST to default passenv variables

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -28,6 +28,7 @@ Cyril Roelandt
 Dane Hillard
 David Staheli
 David Diaz
+Dmitry Ryzhikov
 Ederag
 Eli Collins
 Eugene Yunak

--- a/docs/changelog/1875.feature.rst
+++ b/docs/changelog/1875.feature.rst
@@ -1,0 +1,1 @@
+Add `PIP_TRUSTED_HOST` to default passenv variables - by :user:`d-ryzhikov`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -434,7 +434,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
     * passed through on all platforms: ``CURL_CA_BUNDLE``, ``PATH``,
       ``LANG``, ``LANGUAGE``,
       ``LD_LIBRARY_PATH``, ``PIP_INDEX_URL``, ``PIP_EXTRA_INDEX_URL``,
-      ``REQUESTS_CA_BUNDLE``, ``SSL_CERT_FILE``,
+      ``PIP_TRUSTED_HOST``, ``REQUESTS_CA_BUNDLE``, ``SSL_CERT_FILE``,
       ``HTTP_PROXY``, ``HTTPS_PROXY``, ``NO_PROXY``
     * Windows: ``SYSTEMDRIVE``, ``SYSTEMROOT``, ``PATHEXT``, ``TEMP``, ``TMP``
        ``NUMBER_OF_PROCESSORS``, ``USERPROFILE``, ``MSYSTEM``

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -759,6 +759,7 @@ def tox_addoption(parser):
             "PATH",
             "PIP_INDEX_URL",
             "PIP_EXTRA_INDEX_URL",
+            "PIP_TRUSTED_HOST",
             "REQUESTS_CA_BUNDLE",
             "SSL_CERT_FILE",
             "TOX_WORK_DIR",

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1502,6 +1502,7 @@ class TestConfigTestEnv:
         assert "PATH" in envconfig.passenv
         assert "PIP_INDEX_URL" in envconfig.passenv
         assert "PIP_EXTRA_INDEX_URL" in envconfig.passenv
+        assert "PIP_TRUSTED_HOST" in envconfig.passenv
         assert "REQUESTS_CA_BUNDLE" in envconfig.passenv
         assert "SSL_CERT_FILE" in envconfig.passenv
         assert "LANG" in envconfig.passenv


### PR DESCRIPTION
Add `PIP_TRUSTED_HOST` to default passenv variables.

Closes https://github.com/tox-dev/tox/issues/1875

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
