### PR TITLE
Expose tox requires via the config object

### DIFF
--- a/docs/changelog/1918.feature.rst
+++ b/docs/changelog/1918.feature.rst
@@ -1,0 +1,2 @@
+The value of the :conf:`requires` configuration option is now exposed via
+the :class:`tox.config.Config` object - by :user:`hroncok`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1295,11 +1295,11 @@ class ParseIni(object):
             feedback("--devenv requires only a single -e", sysexit=True)
 
     def handle_provision(self, config, reader):
-        requires_list = reader.getlist("requires")
+        config.requires = reader.getlist("requires")
         config.minversion = reader.getstring("minversion", None)
         config.provision_tox_env = name = reader.getstring("provision_tox_env", ".tox")
         min_version = "tox >= {}".format(config.minversion or Version(tox.__version__).public)
-        deps = self.ensure_requires_satisfied(config, requires_list, min_version)
+        deps = self.ensure_requires_satisfied(config, config.requires, min_version)
         if config.run_provision:
             section_name = "testenv:{}".format(name)
             if section_name not in self._cfg.sections:

--- a/tests/unit/session/test_provision.py
+++ b/tests/unit/session/test_provision.py
@@ -47,6 +47,35 @@ def test_provision_min_version_is_requires(newconfig, next_tox_major):
     assert config.ignore_basepython_conflict is False
 
 
+def test_provision_config_has_minversion_and_requires(newconfig, next_tox_major):
+    with pytest.raises(MissingRequirement) as context:
+        newconfig(
+            [],
+            """\
+            [tox]
+            minversion = {}
+            requires =
+                setuptools > 2
+                pip > 3
+            """.format(
+                next_tox_major,
+            ),
+        )
+    config = context.value.config
+
+    assert config.run_provision is True
+    assert config.minversion == next_tox_major
+    assert config.requires == ["setuptools > 2", "pip > 3"]
+
+
+def test_provision_config_empty_minversion_and_requires(newconfig, next_tox_major):
+    config = newconfig([], "")
+
+    assert config.run_provision is False
+    assert config.minversion is None
+    assert config.requires == []
+
+
 def test_provision_tox_change_name(newconfig):
     config = newconfig(
         [],


### PR DESCRIPTION
Fixes https://github.com/tox-dev/tox/issues/1918

This also fixes broken `__str__` of `MissingRequirement`, which is never actually used but is helpful when debugging.

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation -- I don't know how to properly document the attributes of `config`. the existing are mostly missing. any ideas? could this be left as another issue?
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
