### PR TITLE
Add --no-provision flag

### DIFF
--- a/docs/changelog/1921.feature.rst
+++ b/docs/changelog/1921.feature.rst
@@ -1,0 +1,6 @@
+tox can now be invoked with a new ``--no-provision`` flag that prevents provision,
+if :conf:`requires` or :conf:`minversion` are not satisfied,
+tox will fail;
+if a path is specified as an argument to the flag
+(e.g. as ``tox --no-provision missing.json``) and provision is prevented,
+provision metadata are written as JSON to that path - by :user:`hroncok`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -38,6 +38,11 @@ Global settings are defined under the ``tox`` section as:
    than this the tool will create an environment and provision it with a version of
    tox that satisfies this under :conf:`provision_tox_env`.
 
+   .. versionchanged:: 3.23.0
+
+   When tox is invoked with the ``--no-provision`` flag,
+   the provision won't be attempted, tox will fail instead.
+
 .. conf:: requires ^ LIST of PEP-508
 
     .. versionadded:: 3.2.0
@@ -54,12 +59,22 @@ Global settings are defined under the ``tox`` section as:
         requires = tox-pipenv
                    setuptools >= 30.0.0
 
+    .. versionchanged:: 3.23.0
+
+    When tox is invoked with the ``--no-provision`` flag,
+    the provision won't be attempted, tox will fail instead.
+
 .. conf:: provision_tox_env ^ string ^ .tox
 
     .. versionadded:: 3.8.0
 
     Name of the virtual environment used to provision a tox having all dependencies specified
     inside :conf:`requires` and :conf:`minversion`.
+
+    .. versionchanged:: 3.23.0
+
+    When tox is invoked with the ``--no-provision`` flag,
+    the provision won't be attempted, tox will fail instead.
 
 .. conf:: toxworkdir ^ PATH ^ {toxinidir}/.tox
 


### PR DESCRIPTION
Add --no-provision flag

tox can now be invoked with a new --no-provision flag that prevents provision,
if requires or minversion are not satisfied, tox will fail;
if a path is specified as an argument to the flag
(e.g. as `tox --no-provision missing.json`) and provision is prevented,
provision metadata are written as JSON to that path.

Fixes https://github.com/tox-dev/tox/issues/1921


## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
