### PR TITLE
Workaround a devpi-server bug

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ testing =
     flaky>=3.7
     freezegun>=1
     psutil>=5.7
+    pyramid<2  # workaround for https://github.com/devpi/devpi/issues/835
     pytest>=5.4.1
     pytest-cov>=2
     pytest-mock>=3
@@ -72,7 +73,6 @@ testing =
     re-assert>=1.1.0
     setuptools>=41
     wheel>=0.30
-    pyramid<2  # workaround for https://github.com/devpi/devpi/issues/835
 
 [options.package_data]
 tox = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ testing =
     re-assert>=1.1.0
     setuptools>=41
     wheel>=0.30
+    pyramid<2  # workaround for https://github.com/devpi/devpi/issues/835
 
 [options.package_data]
 tox = py.typed


### PR DESCRIPTION
devpi-server==5.5.0 is incompatible with pyramid>=2.0
See https://github.com/devpi/devpi/issues/835

## Contribution checklist:

- [x] wrote descriptive pull request text
- [ ] added/updated test(s) - N/A
- [ ] updated/extended the documentation - N/A
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body - N/A
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order) - CONTRIBUTORS: No such file or directory

# Additional info
https://github.com/devpi/devpi/issues/835#issuecomment-787890143
> Yes, pyramid 2 isn't supported in the 5.x line. The hopefully soon coming 6.0.0 will support it. Until then pinning to pyramid<2 is the correct workaround.

https://github.com/devpi/devpi/pull/836#issuecomment-787893053
> Thanks, but unless 6.0.0 will take a lot longer I won't make another release of the 5.x line. I hope to make the release by the end of this week.