### PR TITLE
Add a test for #1928

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ testing =
     flaky>=3.7
     freezegun>=1
     psutil>=5.7
+    pyramid<2  # workaround for https://github.com/devpi/devpi/issues/835
     pytest>=5.4.1
     pytest-cov>=2
     pytest-mock>=3

--- a/tests/bug/test_gh_1928.py
+++ b/tests/bug/test_gh_1928.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from pprint import pprint
+from typing import Any, List
+
+import pytest
+
+from tox.pytest import ToxProjectCreator
+
+
+@pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
+@pytest.mark.parametrize(("posargs", "expected"), [([], ["probe.py"]), (["foo"], ["probe.py", "foo"])])
+def test_gh1928(  # noqa: SC200
+    tox_project: ToxProjectCreator,
+    tmp_path: Path,
+    enable_pip_pypi_access: Any,  # noqa: U100
+    posargs: List[str],  # noqa: SC200
+    expected: List[str],
+) -> None:
+    out_path = tmp_path / "out.json"
+    project = tox_project(
+        {
+            "tox.ini": """
+                [testenv]
+                commands=python probe.py []
+            """,
+            "pyproject.toml": """
+                [build-system]
+                requires = ["setuptools"]
+                build-backend = 'setuptools.build_meta'
+            """,
+            "probe.py": f"""
+                import json
+                import sys
+
+                with open({str(out_path)!r}, 'w') as out:
+                    json.dump(sys.argv, out)
+            """,
+        }
+    )
+
+    outcome = project.run("--", *posargs)  # noqa: SC200
+    pprint(outcome)
+
+    with out_path.open() as result:
+        assert json.load(result) == expected


### PR DESCRIPTION
See #1928

This PR does not fix the bug. It only adds a test for it. Note: this PR currently includes https://github.com/tox-dev/tox/pull/1930 because otherwise CI fails

## Contribution checklist:

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation - N/A
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) - N/A
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog) - will add after I open the PR
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order) - CONTRIBUTORS: No such file or directory
