### PR TITLE
Fix test_replace_pos_args_empty_sys_argv

### DIFF
--- a/tests/config/loader/ini/replace/test_replace_posargs.py
+++ b/tests/config/loader/ini/replace/test_replace_posargs.py
@@ -11,7 +11,7 @@ def test_replace_pos_args_none_sys_argv(replace_one: ReplaceOne) -> None:
 
 
 def test_replace_pos_args_empty_sys_argv(replace_one: ReplaceOne) -> None:
-    result = replace_one("{posargs}", None)
+    result = replace_one("{posargs}", [])
     assert result == ""
 
 


### PR DESCRIPTION
`test_replace_pos_args_empty_sys_argv` was identical to `test_replace_pos_args_none_sys_argv` I assume this is not intentional. This PR changes `test_replace_pos_args_empty_sys_argv` to test `pos_args=[]` instead of `pos_args=None`

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation - N/A
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) - N/A
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog) - too minor
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order) - CONTRIBUTORS: No such file or directory
