### PR TITLE
Use UTF-8 encoding when parsing pyproject.toml

### DIFF
--- a/src/tox/_pytestplugin.py
+++ b/src/tox/_pytestplugin.py
@@ -491,6 +491,13 @@ def create_files(base, filedefs):
             create_files(base.ensure(key, dir=1), value)
         elif isinstance(value, six.string_types):
             s = textwrap.dedent(value)
+
+            if not isinstance(s, six.text_type):
+                if not isinstance(s, six.binary_type):
+                    s = str(s)
+                else:
+                    s = six.ensure_text(s)
+
             base.join(key).write_text(s, encoding="UTF-8")
 
 

--- a/src/tox/_pytestplugin.py
+++ b/src/tox/_pytestplugin.py
@@ -491,7 +491,7 @@ def create_files(base, filedefs):
             create_files(base.ensure(key, dir=1), value)
         elif isinstance(value, six.string_types):
             s = textwrap.dedent(value)
-            base.join(key).write(s)
+            base.join(key).write_text(s, encoding="UTF-8")
 
 
 @pytest.fixture()

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -302,7 +302,7 @@ def parseconfig(args, plugins=()):
 
 
 def get_py_project_toml(path):
-    with open(str(path)) as file_handler:
+    with open(str(path), encoding="UTF-8") as file_handler:
         config_data = toml.load(file_handler)
         return config_data
 

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import argparse
+import io
 import itertools
 import os
 import random
@@ -302,7 +303,7 @@ def parseconfig(args, plugins=()):
 
 
 def get_py_project_toml(path):
-    with open(str(path), encoding="UTF-8") as file_handler:
+    with io.open(str(path), encoding="UTF-8") as file_handler:
         config_data = toml.load(file_handler)
         return config_data
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import os
 import re
 import sys

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -3557,6 +3557,9 @@ def test_config_via_pyproject_legacy(initproj):
         "config_via_pyproject_legacy-0.5",
         filedefs={
             "pyproject.toml": '''
+                [project]
+                description = "Factory ⸻ A code generator 🏭"
+                authors = [{name = "Łukasz Langa"}]
                 [tool.tox]
                 legacy_tox_ini = """
                 [tox]

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -3557,7 +3557,7 @@ def test_config_via_pyproject_legacy(initproj):
     initproj(
         "config_via_pyproject_legacy-0.5",
         filedefs={
-            "pyproject.toml": '''
+            "pyproject.toml": u'''
                 [project]
                 description = "Factory ⸻ A code generator 🏭"
                 authors = [{name = "Łukasz Langa"}]


### PR DESCRIPTION
Fixes #1908

This avoids a `UnicodeDecodeError` when parsing `pyproject.toml` files containing characters on Windows. These characters may be present in a project's metadata, such as its description or an author's name.

Furthermore, the [TOML specification](https://toml.io/en/v1.0.0#spec) requires files to be encoded in UTF-8.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [X] wrote descriptive pull request text
- [X] added/updated test(s)
- [ ] updated/extended the documentation
- [X] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
