### PR TITLE
Remove dependency on unused fixtures

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ Alexander Loechel
 Alexander Schepanovski
 Alexandre Conrad
 Allan Feldman
+Andrey Bienkowski
 Andrii Soldatenko
 Andrzej Klajnert
 Anthon van der Neuth

--- a/tests/unit/config/test_config_parallel.py
+++ b/tests/unit/config/test_config_parallel.py
@@ -38,7 +38,7 @@ def test_parallel_number_negative(newconfig, capsys):
     assert "value must be positive" in err
 
 
-def test_depends(newconfig, capsys):
+def test_depends(newconfig):
     config = newconfig(
         """\
         [tox]
@@ -49,7 +49,7 @@ def test_depends(newconfig, capsys):
     assert config.envconfigs["py"].depends == ("py37", "py36")
 
 
-def test_depends_multi_row_facotr(newconfig, capsys):
+def test_depends_multi_row_facotr(newconfig):
     config = newconfig(
         """\
         [tox]
@@ -61,7 +61,7 @@ def test_depends_multi_row_facotr(newconfig, capsys):
     assert config.envconfigs["py"].depends == ("py37", "py36-a", "py36-b")
 
 
-def test_depends_factor(newconfig, capsys):
+def test_depends_factor(newconfig):
     config = newconfig(
         """\
         [tox]


### PR DESCRIPTION
I have noticed 3 tests that depend on the `capsys` fixture, but don't use it

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:
- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation - N/A
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) - N/A
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog) - too minor
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
