### PR TITLE
Fix #1928

### DIFF
--- a/docs/changelog/1928.feature.rst
+++ b/docs/changelog/1928.feature.rst
@@ -1,0 +1,1 @@
+Implemented [] substitution (same as {posargs}). This preserves backward compatibility with tox3 that also substitutes [].

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -9,10 +9,9 @@ from tox.config.types import Command
 from tox.config.set_env import SetEnv
 from tox.config.source.tox_ini import ToxIni
 
-# TODO
+
 # ConfigError = tox.exception.ConfigError
-class ConfigError(Exception):
-    pass
+ConfigError = TypeError
 
 
 @pytest.fixture
@@ -49,11 +48,11 @@ def test_get_list(get_option: Any) -> None:
     value = get_option(
         """
         [testenv]
-        allowlist_externals = []
+        extras = []
         """,
-        "allowlist_externals",
+        "extras",
     )
-    assert value == ["[]"]
+    assert list(value) == ["[]"]
 
 
 def test_dict_setenv(get_option: Any) -> None:
@@ -81,16 +80,15 @@ def test_get_float(get_option: Any) -> None:
         )
 
 
-@pytest.mark.xfail(raises=AssertionError)
 def test_get_bool(get_option: Any) -> None:
     """[] is not substituted in options of type bool"""
     with pytest.raises(ConfigError):
         get_option(
             """
             [testenv]
-            ignore_outcome = []
+            skip_install = []
             """,
-            "ignore_outcome",
+            "skip_install",
         )
 
 

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -68,6 +68,7 @@ def test_dict_setenv(get_option: Any) -> None:
     assert value["FOO"] == "[]"
 
 
+@pytest.mark.xfail(raises=KeyError, reason="interrupt_timeout is not implemented in tox4")
 def test_get_float(get_option: Any) -> None:
     """[] is not substituted in options of type float"""
     with pytest.raises(ConfigError):

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -1,9 +1,15 @@
+from typing import Any
+
 import pytest
 
-import tox
+
+# TODO
+# ConfigError = tox.exception.ConfigError
+class ConfigError(Exception):
+    pass
 
 
-def test_get_path(get_option):
+def test_get_path(get_option: Any) -> None:
     """[] is not substituted in options of type path"""
     value = get_option(
         """
@@ -15,7 +21,7 @@ def test_get_path(get_option):
     assert str(value)[-2:] == "[]"
 
 
-def test_get_list(get_option):
+def test_get_list(get_option: Any) -> None:
     """[] is not substituted in options of type list"""
     value = get_option(
         """
@@ -27,7 +33,7 @@ def test_get_list(get_option):
     assert value == ["[]"]
 
 
-def test_dict_setenv(get_option):
+def test_dict_setenv(get_option: Any) -> None:
     """[] is not substituted in options of type dict_setenv"""
     value = get_option(
         """
@@ -40,9 +46,9 @@ def test_dict_setenv(get_option):
     assert value["FOO"] == "[]"
 
 
-def test_get_float(get_option):
+def test_get_float(get_option: Any) -> None:
     """[] is not substituted in options of type float"""
-    with pytest.raises(tox.exception.ConfigError):
+    with pytest.raises(ConfigError):
         get_option(
             """
             [testenv]
@@ -52,9 +58,9 @@ def test_get_float(get_option):
         )
 
 
-def test_get_bool(get_option):
+def test_get_bool(get_option: Any) -> None:
     """[] is not substituted in options of type bool"""
-    with pytest.raises(tox.exception.ConfigError):
+    with pytest.raises(ConfigError):
         get_option(
             """
             [testenv]
@@ -64,7 +70,7 @@ def test_get_bool(get_option):
         )
 
 
-def test_get_argv_list(get_option):
+def test_get_argv_list(get_option: Any) -> None:
     """[] is substituted in options of type argvlist"""
     value = get_option(
         """
@@ -76,7 +82,7 @@ def test_get_argv_list(get_option):
     assert value == [["foo"]]
 
 
-def test_get_argv_list_nonempty(get_option):
+def test_get_argv_list_nonempty(get_option: Any) -> None:
     """[] is substituted in options of type argvlist"""
     value = get_option(
         """
@@ -89,7 +95,7 @@ def test_get_argv_list_nonempty(get_option):
     assert value == [["foo", "bar"]]
 
 
-def test_get_argv(get_option):
+def test_get_argv(get_option: Any) -> None:
     """[] is substituted in options of type argv"""
     value = get_option(
         """
@@ -102,7 +108,7 @@ def test_get_argv(get_option):
     assert value == ["foo", "bar"]
 
 
-def test_get_argv_install_command(get_option):
+def test_get_argv_install_command(get_option: Any) -> None:
     """[] is substituted in options of type argv_install_command"""
     value = get_option(
         """
@@ -115,7 +121,7 @@ def test_get_argv_install_command(get_option):
     assert value == ["foo", "bar", "{packages}"]
 
 
-def test_get_string(get_option):
+def test_get_string(get_option: Any) -> None:
     """[] is not substituted in options of type string"""
     value = get_option(
         """
@@ -136,7 +142,7 @@ def test_get_string(get_option):
         ("[]{envname}", "barpython"),  # noqa: SC100 {envname} and [] are two separate words
     ],
 )
-def test_examples(value, result, get_option):
+def test_examples(value: str, result: str, get_option: Any) -> None:
     got = get_option(
         """
         [testenv]
@@ -149,7 +155,7 @@ def test_examples(value, result, get_option):
     assert got == ["foo", result]
 
 
-def test_no_substitutions_inside_pos_args(get_option):
+def test_no_substitutions_inside_pos_args(get_option: Any) -> None:
     got = get_option(
         """
         [testenv]
@@ -161,7 +167,7 @@ def test_no_substitutions_inside_pos_args(get_option):
     assert got == ["foo", "{envname}"]
 
 
-def test_no_pos_args_inside_substitutions(get_option, monkeypatch):
+def test_no_pos_args_inside_substitutions(get_option: Any, monkeypatch: Any) -> None:
     monkeypatch.setenv("BAZ", "[]")
     got = get_option(
         """

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -1,0 +1,179 @@
+import pytest
+
+import tox
+
+
+def test_getpath(get_option):
+    """[] is not substituted in options of type path"""
+    changedir = get_option(
+        """
+        [testenv]
+        changedir = []
+        """,
+        "changedir",
+    )
+    assert str(changedir)[-2:] == "[]"
+
+
+def test_getlist(get_option):
+    """[] is not substituted in options of type list"""
+    value = get_option(
+        """
+        [testenv]
+        allowlist_externals = []
+        """,
+        "allowlist_externals",
+    )
+    assert value == ["[]"]
+
+
+def test_getdict(get_option):
+    """[] is not substituted in options of type dict"""
+    # TODO
+
+
+def test_dict_setenv(get_option):
+    """[] is not substituted in options of type dict_setenv"""
+    value = get_option(
+        """
+        [testenv]
+        setenv =
+          FOO = []
+        """,
+        "setenv",
+    )
+    assert value["FOO"] == "[]"
+
+
+def test_getfloat(get_option):
+    """[] is not substituted in options of type float"""
+    with pytest.raises(tox.exception.ConfigError):
+        get_option(
+            """
+            [testenv]
+            interrupt_timeout = []
+            """,
+            "interrupt_timeout",
+        )
+
+
+def test_getbool(get_option):
+    """[] is not substituted in options of type bool"""
+    with pytest.raises(tox.exception.ConfigError):
+        get_option(
+            """
+            [testenv]
+            ignore_outcome = []
+            """,
+            "ignore_outcome",
+        )
+
+
+def test_getargvlist(get_option):
+    """[] is substituted in options of type argvlist"""
+    value = get_option(
+        """
+        [testenv]
+        commands = foo []
+        """,
+        "commands",
+    )
+    assert value == [["foo"]]
+
+
+def test_getargvlist_nonempty(get_option):
+    """[] is substituted in options of type argvlist"""
+    value = get_option(
+        """
+        [testenv]
+        commands = foo []
+        """,
+        "commands",
+        ["bar"],
+    )
+    assert value == [["foo", "bar"]]
+
+
+def test_getargv(get_option):
+    """[] is substituted in options of type argv"""
+    value = get_option(
+        """
+        [testenv]
+        list_dependencies_command = foo []
+        """,
+        "list_dependencies_command",
+        ["bar"],
+    )
+    assert value == ["foo", "bar"]
+
+
+def test_getargv_install_command(get_option):
+    """[] is substituted in options of type argv_install_command"""
+    value = get_option(
+        """
+        [testenv]
+        install_command = foo [] {packages}
+        """,
+        "install_command",
+        ["bar"],
+    )
+    assert value == ["foo", "bar", "{packages}"]
+
+
+def test_getstring(get_option):
+    """[] is not substituted in options of type string"""
+    value = get_option(
+        """
+        [testenv]
+        description = []
+        """,
+        "description",
+    )
+    assert value == "[]"
+
+
+@pytest.mark.parametrize(
+    ("value", "result"),
+    [
+        ("x[]", "x[]"),  # no substitution inside a word
+        ("[]x", "[]x"),  # no substitution inside a word
+        ("{envname}[]", "pythonbar"),  # {envname} and [] are two separate words
+        ("[]{envname}", "barpython"),  # {envname} and [] are two separate words
+    ],
+)
+def test_examples(value, result, get_option):
+    got = get_option(
+        """
+        [testenv]
+        list_dependencies_command = foo %s
+        """
+        % value,
+        "list_dependencies_command",
+        ["bar"],
+    )
+    assert got == ["foo", result]
+
+
+def test_no_substitutions_inside_pos_args(get_option):
+    got = get_option(
+        """
+        [testenv]
+        list_dependencies_command = foo []
+        """,
+        "list_dependencies_command",
+        ["{envname}"],
+    )
+    assert got == ["foo", "{envname}"]
+
+
+def test_no_posargs_inside_substitutions(get_option, monkeypatch):
+    monkeypatch.setenv("BAZ", "[]")
+    got = get_option(
+        """
+        [testenv]
+        list_dependencies_command = foo {env:BAZ}
+        """,
+        "list_dependencies_command",
+        ["bar"],
+    )
+    assert got == ["foo", "[]"]

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -1,12 +1,35 @@
 from typing import Any
+from pathlib import Path
 
 import pytest
 
+from tox.tox_env.python.virtual_env.runner import VirtualEnvRunner
+from tox.config.main import Config
+from tox.config.types import Command
+from tox.config.set_env import SetEnv
+from tox.config.source.tox_ini import ToxIni
 
 # TODO
 # ConfigError = tox.exception.ConfigError
 class ConfigError(Exception):
     pass
+
+
+@pytest.fixture
+def get_option(tmp_path: Path) -> Any:
+    def do(tox_ini: str, option_name: str, pos_args: list[str] = ()) -> Any:
+        tox_ini_file = tmp_path / "tox.ini"
+        tox_ini_file.write_text(tox_ini)
+        tox_ini = ToxIni(tox_ini_file)
+        config = Config(tox_ini, overrides=[], root=tmp_path, pos_args=pos_args, work_dir=tmp_path)
+        env = VirtualEnvRunner(config.get_env("python"), config.core, None, None, None)
+        value = env.conf[option_name]
+        if isinstance(value, Command):
+            return value.args
+        if isinstance(value, SetEnv):
+            return value._raw
+        return value
+    return do
 
 
 def test_get_path(get_option: Any) -> None:
@@ -58,6 +81,7 @@ def test_get_float(get_option: Any) -> None:
         )
 
 
+@pytest.mark.xfail(raises=AssertionError)
 def test_get_bool(get_option: Any) -> None:
     """[] is not substituted in options of type bool"""
     with pytest.raises(ConfigError):
@@ -70,6 +94,7 @@ def test_get_bool(get_option: Any) -> None:
         )
 
 
+@pytest.mark.xfail(raises=AssertionError)
 def test_get_argv_list(get_option: Any) -> None:
     """[] is substituted in options of type argvlist"""
     value = get_option(
@@ -82,6 +107,7 @@ def test_get_argv_list(get_option: Any) -> None:
     assert value == [["foo"]]
 
 
+@pytest.mark.xfail(raises=AssertionError)
 def test_get_argv_list_nonempty(get_option: Any) -> None:
     """[] is substituted in options of type argvlist"""
     value = get_option(
@@ -95,6 +121,7 @@ def test_get_argv_list_nonempty(get_option: Any) -> None:
     assert value == [["foo", "bar"]]
 
 
+@pytest.mark.xfail(raises=AssertionError)
 def test_get_argv(get_option: Any) -> None:
     """[] is substituted in options of type argv"""
     value = get_option(
@@ -108,6 +135,7 @@ def test_get_argv(get_option: Any) -> None:
     assert value == ["foo", "bar"]
 
 
+@pytest.mark.xfail(raises=AssertionError)
 def test_get_argv_install_command(get_option: Any) -> None:
     """[] is substituted in options of type argv_install_command"""
     value = get_option(
@@ -138,8 +166,8 @@ def test_get_string(get_option: Any) -> None:
     [
         ("x[]", "x[]"),  # no substitution inside a word
         ("[]x", "[]x"),  # no substitution inside a word
-        ("{envname}[]", "pythonbar"),  # noqa: SC100 {envname} and [] are two separate words
-        ("[]{envname}", "barpython"),  # noqa: SC100 {envname} and [] are two separate words
+        pytest.param("{envname}[]", "pythonbar", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC100 {envname} and [] are two separate words
+        pytest.param("[]{envname}", "barpython", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC100 {envname} and [] are two separate words
     ],
 )
 def test_examples(value: str, result: str, get_option: Any) -> None:
@@ -155,6 +183,7 @@ def test_examples(value: str, result: str, get_option: Any) -> None:
     assert got == ["foo", result]
 
 
+@pytest.mark.xfail(raises=AssertionError)
 def test_no_substitutions_inside_pos_args(get_option: Any) -> None:
     got = get_option(
         """

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -13,7 +13,7 @@ from tox.tox_env.python.virtual_env.runner import VirtualEnvRunner
 ConfigError = TypeError
 
 
-@pytest.fixture
+@pytest.fixture()
 def get_option(tmp_path: Path) -> Any:
     def do(tox_ini: str, option_name: str, pos_args: list[str] = ()) -> Any:
         tox_ini_file = tmp_path / "tox.ini"
@@ -68,7 +68,7 @@ def test_dict_setenv(get_option: Any) -> None:
     assert value["FOO"] == "[]"
 
 
-@pytest.mark.xfail(raises=KeyError, reason="interrupt_timeout is not implemented in tox4")
+@pytest.mark.xfail(raises=KeyError, reason="interrupt_timeout is not implemented in tox4")  # noqa: SC200
 def test_get_float(get_option: Any) -> None:
     """[] is not substituted in options of type float"""
     with pytest.raises(ConfigError):
@@ -93,7 +93,7 @@ def test_get_bool(get_option: Any) -> None:
         )
 
 
-@pytest.mark.xfail(raises=AssertionError)
+@pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
 def test_get_argv_list(get_option: Any) -> None:
     """[] is substituted in options of type argvlist"""
     value = get_option(
@@ -106,7 +106,7 @@ def test_get_argv_list(get_option: Any) -> None:
     assert value == [["foo"]]
 
 
-@pytest.mark.xfail(raises=AssertionError)
+@pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
 def test_get_argv_list_nonempty(get_option: Any) -> None:
     """[] is substituted in options of type argvlist"""
     value = get_option(
@@ -120,7 +120,7 @@ def test_get_argv_list_nonempty(get_option: Any) -> None:
     assert value == [["foo", "bar"]]
 
 
-@pytest.mark.xfail(raises=AssertionError)
+@pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
 def test_get_argv(get_option: Any) -> None:
     """[] is substituted in options of type argv"""
     value = get_option(
@@ -134,7 +134,7 @@ def test_get_argv(get_option: Any) -> None:
     assert value == ["foo", "bar"]
 
 
-@pytest.mark.xfail(raises=AssertionError)
+@pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
 def test_get_argv_install_command(get_option: Any) -> None:
     """[] is substituted in options of type argv_install_command"""
     value = get_option(
@@ -166,11 +166,11 @@ def test_get_string(get_option: Any) -> None:
         ("x[]", "x[]"),  # no substitution inside a word
         ("[]x", "[]x"),  # no substitution inside a word
         pytest.param(
-            "{envname}[]", "pythonbar", marks=pytest.mark.xfail(raises=AssertionError)
+            "{envname}[]", "pythonbar", marks=pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
         ),  # noqa: SC100 {envname} and [] are two separate words
         pytest.param(
-            "[]{envname}", "barpython", marks=pytest.mark.xfail(raises=AssertionError)
-        ),  # noqa: SC100 {envname} and [] are two separate words
+            "[]{envname}", "barpython", marks=pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
+        ),  # noqa: SC100, SC200 {envname} and [] are two separate words
     ],
 )
 def test_examples(value: str, result: str, get_option: Any) -> None:
@@ -186,7 +186,7 @@ def test_examples(value: str, result: str, get_option: Any) -> None:
     assert got == ["foo", result]
 
 
-@pytest.mark.xfail(raises=AssertionError)
+@pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
 def test_no_substitutions_inside_pos_args(get_option: Any) -> None:
     got = get_option(
         """

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, List
 
 import pytest
 
@@ -15,12 +15,15 @@ ConfigError = TypeError
 
 @pytest.fixture()
 def get_option(tmp_path: Path) -> Any:
-    def do(tox_ini: str, option_name: str, pos_args: list[str] = ()) -> Any:
+    def do(tox_ini: str, option_name: str, pos_args: List[str] = []) -> Any:
         tox_ini_file = tmp_path / "tox.ini"
         tox_ini_file.write_text(tox_ini)
-        tox_ini = ToxIni(tox_ini_file)
-        config = Config(tox_ini, overrides=[], root=tmp_path, pos_args=pos_args, work_dir=tmp_path)
-        env = VirtualEnvRunner(config.get_env("python"), config.core, None, None, None)
+        ini = ToxIni(tox_ini_file)
+        config = Config(ini, overrides=[], root=tmp_path, pos_args=pos_args, work_dir=tmp_path)
+        options: Any = None
+        journal: Any = None
+        log_handler: Any = None
+        env = VirtualEnvRunner(config.get_env("python"), config.core, options, journal, log_handler)
         value = env.conf[option_name]
         if isinstance(value, Command):
             return value.args

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Optional
 
 import pytest
 
@@ -15,7 +15,9 @@ ConfigError = TypeError
 
 @pytest.fixture()
 def get_option(tmp_path: Path) -> Any:
-    def do(tox_ini: str, option_name: str, pos_args: List[str] = []) -> Any:
+    def do(tox_ini: str, option_name: str, pos_args: Optional[List[str]] = None) -> Any:
+        if not pos_args:
+            pos_args = []
         tox_ini_file = tmp_path / "tox.ini"
         tox_ini_file.write_text(tox_ini)
         ini = ToxIni(tox_ini_file)

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -1,14 +1,13 @@
-from typing import Any
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from tox.tox_env.python.virtual_env.runner import VirtualEnvRunner
 from tox.config.main import Config
-from tox.config.types import Command
 from tox.config.set_env import SetEnv
 from tox.config.source.tox_ini import ToxIni
-
+from tox.config.types import Command
+from tox.tox_env.python.virtual_env.runner import VirtualEnvRunner
 
 # ConfigError = tox.exception.ConfigError
 ConfigError = TypeError
@@ -28,6 +27,7 @@ def get_option(tmp_path: Path) -> Any:
         if isinstance(value, SetEnv):
             return value._raw
         return value
+
     return do
 
 
@@ -165,8 +165,12 @@ def test_get_string(get_option: Any) -> None:
     [
         ("x[]", "x[]"),  # no substitution inside a word
         ("[]x", "[]x"),  # no substitution inside a word
-        pytest.param("{envname}[]", "pythonbar", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC100 {envname} and [] are two separate words
-        pytest.param("[]{envname}", "barpython", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC100 {envname} and [] are two separate words
+        pytest.param(
+            "{envname}[]", "pythonbar", marks=pytest.mark.xfail(raises=AssertionError)
+        ),  # noqa: SC100 {envname} and [] are two separate words
+        pytest.param(
+            "[]{envname}", "barpython", marks=pytest.mark.xfail(raises=AssertionError)
+        ),  # noqa: SC100 {envname} and [] are two separate words
     ],
 )
 def test_examples(value: str, result: str, get_option: Any) -> None:

--- a/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
+++ b/tests/config/loader/ini/replace/test_replace_bracket_pos_args.py
@@ -3,19 +3,19 @@ import pytest
 import tox
 
 
-def test_getpath(get_option):
+def test_get_path(get_option):
     """[] is not substituted in options of type path"""
-    changedir = get_option(
+    value = get_option(
         """
         [testenv]
         changedir = []
         """,
         "changedir",
     )
-    assert str(changedir)[-2:] == "[]"
+    assert str(value)[-2:] == "[]"
 
 
-def test_getlist(get_option):
+def test_get_list(get_option):
     """[] is not substituted in options of type list"""
     value = get_option(
         """
@@ -25,11 +25,6 @@ def test_getlist(get_option):
         "allowlist_externals",
     )
     assert value == ["[]"]
-
-
-def test_getdict(get_option):
-    """[] is not substituted in options of type dict"""
-    # TODO
 
 
 def test_dict_setenv(get_option):
@@ -45,7 +40,7 @@ def test_dict_setenv(get_option):
     assert value["FOO"] == "[]"
 
 
-def test_getfloat(get_option):
+def test_get_float(get_option):
     """[] is not substituted in options of type float"""
     with pytest.raises(tox.exception.ConfigError):
         get_option(
@@ -57,7 +52,7 @@ def test_getfloat(get_option):
         )
 
 
-def test_getbool(get_option):
+def test_get_bool(get_option):
     """[] is not substituted in options of type bool"""
     with pytest.raises(tox.exception.ConfigError):
         get_option(
@@ -69,7 +64,7 @@ def test_getbool(get_option):
         )
 
 
-def test_getargvlist(get_option):
+def test_get_argv_list(get_option):
     """[] is substituted in options of type argvlist"""
     value = get_option(
         """
@@ -81,7 +76,7 @@ def test_getargvlist(get_option):
     assert value == [["foo"]]
 
 
-def test_getargvlist_nonempty(get_option):
+def test_get_argv_list_nonempty(get_option):
     """[] is substituted in options of type argvlist"""
     value = get_option(
         """
@@ -94,7 +89,7 @@ def test_getargvlist_nonempty(get_option):
     assert value == [["foo", "bar"]]
 
 
-def test_getargv(get_option):
+def test_get_argv(get_option):
     """[] is substituted in options of type argv"""
     value = get_option(
         """
@@ -107,7 +102,7 @@ def test_getargv(get_option):
     assert value == ["foo", "bar"]
 
 
-def test_getargv_install_command(get_option):
+def test_get_argv_install_command(get_option):
     """[] is substituted in options of type argv_install_command"""
     value = get_option(
         """
@@ -120,7 +115,7 @@ def test_getargv_install_command(get_option):
     assert value == ["foo", "bar", "{packages}"]
 
 
-def test_getstring(get_option):
+def test_get_string(get_option):
     """[] is not substituted in options of type string"""
     value = get_option(
         """
@@ -137,8 +132,8 @@ def test_getstring(get_option):
     [
         ("x[]", "x[]"),  # no substitution inside a word
         ("[]x", "[]x"),  # no substitution inside a word
-        ("{envname}[]", "pythonbar"),  # {envname} and [] are two separate words
-        ("[]{envname}", "barpython"),  # {envname} and [] are two separate words
+        ("{envname}[]", "pythonbar"),  # noqa: SC100 {envname} and [] are two separate words
+        ("[]{envname}", "barpython"),  # noqa: SC100 {envname} and [] are two separate words
     ],
 )
 def test_examples(value, result, get_option):
@@ -166,7 +161,7 @@ def test_no_substitutions_inside_pos_args(get_option):
     assert got == ["foo", "{envname}"]
 
 
-def test_no_posargs_inside_substitutions(get_option, monkeypatch):
+def test_no_pos_args_inside_substitutions(get_option, monkeypatch):
     monkeypatch.setenv("BAZ", "[]")
     got = get_option(
         """


### PR DESCRIPTION
I'm working on a fix for #1928. So far I have only added the unit tests. The failing tests are marked via `@pytest.mark.xfail`. The tests are a port of #1942 onto the rewrite branch. My goal is to eventually use the same tests on both branches abstracting out the differences using a fixture.

The next item I'll work on is implementing the substitution for the rewrite branch.

<!--

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
-->