### PR TITLE
Support for bracket styled posargs

### DIFF
--- a/docs/changelog/1928.feature.rst
+++ b/docs/changelog/1928.feature.rst
@@ -1,1 +1,2 @@
-Implemented [] substitution (alias for {posargs})
+Implemented ``[]`` substitution (alias for ``{posargs}``) - by
+:user:`hexagonrecursion`.

--- a/docs/changelog/1928.feature.rst
+++ b/docs/changelog/1928.feature.rst
@@ -1,0 +1,1 @@
+Implemented [] substitution (alias for {posargs})

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -26,13 +26,9 @@ def replace(conf: "Config", name: Optional[str], loader: "IniLoader", value: str
     # perform all non-escaped replaces
     start, end = 0, 0
     while True:
-        start, end, match = find_replace_part(value, start, end)
-        if not match:
+        start, end, to_replace = find_replace_part(value, start, end)
+        if to_replace is None:
             break
-        if value[start : end + 1] == "[]":
-            to_replace = "posargs"
-        else:
-            to_replace = value[start + 1 : end]
         replaced = _replace_match(conf, name, loader, to_replace, chain.copy())
         if replaced is None:
             # if we cannot replace, keep what was there, and continue looking for additional replaces following
@@ -41,7 +37,7 @@ def replace(conf: "Config", name: Optional[str], loader: "IniLoader", value: str
             start = end = end + 1
             continue
         new_value = value[:start] + replaced + value[end + 1 :]
-        start, end = 0, 0  # if we performed a replace start over
+        start, end = 0, 0  # if we performed a replacement start over
         if new_value == value:  # if we're not making progress stop (circular reference?)
             break
         value = new_value
@@ -53,32 +49,24 @@ def replace(conf: "Config", name: Optional[str], loader: "IniLoader", value: str
     return value
 
 
-def find_replace_part(value: str, start: int, end: int) -> Tuple[int, int, bool]:
-    brackets = find_brackets(value, end)
-    braces = find_braces(value, start, end)
-
-    # If neither matches, report failure
-    # If only one matches, return it
-    # If both match, return leftmost
-    if not brackets[-1]:
-        return braces
-    if not braces[-1]:
-        return brackets
-    if brackets[0] < braces[0]:
-        return brackets
-    else:
-        return braces
+def find_replace_part(value: str, start: int, end: int) -> Tuple[int, int, Optional[str]]:
+    bracket_at = find_brackets(value, end)
+    if bracket_at != -1:
+        return bracket_at, bracket_at + 1, "posargs"  # brackets is an alias for positional arguments
+    start, end, match = find_braces(value, start, end)
+    return start, end, (value[start + 1 : end] if match else None)
 
 
-def find_brackets(value: str, end: int) -> Tuple[int, int, bool]:
+def find_brackets(value: str, end: int) -> int:
     while True:
         pos = value.find("[]", end)
         if pos == -1:
-            return -1, -1, False
+            break
         if pos >= 1 and value[pos - 1] == "\\":  # the opened bracket is escaped
             end = pos + 1
             continue
-        return pos, pos + 1, True
+        break
+    return pos
 
 
 def find_braces(value: str, start: int, end: int) -> Tuple[int, int, bool]:

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -45,6 +45,8 @@ def replace(conf: "Config", name: Optional[str], loader: "IniLoader", value: str
     # remove escape sequences
     value = value.replace("\\{", "{")
     value = value.replace("\\}", "}")
+    value = value.replace("\\[", "[")
+    value = value.replace("\\]", "]")
     return value
 
 

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -29,7 +29,10 @@ def replace(conf: "Config", name: Optional[str], loader: "IniLoader", value: str
         start, end, match = find_replace_part(value, start, end)
         if not match:
             break
-        to_replace = value[start + 1 : end]
+        if value[start : end + 1] == "[]":
+            to_replace = "posargs"
+        else:
+            to_replace = value[start + 1 : end]
         replaced = _replace_match(conf, name, loader, to_replace, chain.copy())
         if replaced is None:
             # if we cannot replace, keep what was there, and continue looking for additional replaces following

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -51,6 +51,34 @@ def replace(conf: "Config", name: Optional[str], loader: "IniLoader", value: str
 
 
 def find_replace_part(value: str, start: int, end: int) -> Tuple[int, int, bool]:
+    brackets = find_brackets(value, end)
+    braces = find_braces(value, start, end)
+
+    # If neither matches, report failure
+    # If only one matches, return it
+    # If both match, return leftmost
+    if not brackets[-1]:
+        return braces
+    if not braces[-1]:
+        return brackets
+    if brackets[0] < braces[0]:
+        return brackets
+    else:
+        return braces
+
+
+def find_brackets(value: str, end: int) -> Tuple[int, int, bool]:
+    while True:
+        pos = value.find("[]", end)
+        if pos == -1:
+            return -1, -1, False
+        if pos >= 1 and value[pos - 1] == "\\":  # the opened bracket is escaped
+            end = pos + 1
+            continue
+        return pos, pos + 1, True
+
+
+def find_braces(value: str, start: int, end: int) -> Tuple[int, int, bool]:
     match = False
     while end != -1:
         end = value.find("}", end)

--- a/tests/config/loader/ini/replace/test_replace_posargs.py
+++ b/tests/config/loader/ini/replace/test_replace_posargs.py
@@ -13,8 +13,11 @@ def test_replace_pos_args_none_sys_argv(syntax: str, replace_one: ReplaceOne) ->
     assert result == ""
 
 
-def test_replace_pos_args_empty_sys_argv(replace_one: ReplaceOne) -> None:
-    result = replace_one("{posargs}", [])
+@pytest.mark.parametrize(
+    "syntax", ["{posargs}", pytest.param("[]", marks=pytest.mark.xfail(raises=AssertionError))]  # noqa: SC200
+)
+def test_replace_pos_args_empty_sys_argv(syntax: str, replace_one: ReplaceOne) -> None:
+    result = replace_one(syntax, [])
     assert result == ""
 
 

--- a/tests/config/loader/ini/replace/test_replace_posargs.py
+++ b/tests/config/loader/ini/replace/test_replace_posargs.py
@@ -62,3 +62,16 @@ def test_replace_pos_args_escaped(replace_one: ReplaceOne, value: str) -> None:
     result = replace_one(value, None)
     outcome = value.replace("\\", "")
     assert result == outcome
+
+
+@pytest.mark.parametrize(
+    ("value", "result"),
+    [
+        ("[]{posargs}", "foofoo"),
+        ("{posargs}[]", "foofoo"),
+    ],
+)
+def test_replace_mixed_brackets_and_braces(replace_one: ReplaceOne, value: str, result: str) -> None:
+    """If we have a factor that is not specified within the core env-list then that's also an environment"""
+    outcome = replace_one(value, ["foo"])
+    assert result == outcome

--- a/tests/config/loader/ini/replace/test_replace_posargs.py
+++ b/tests/config/loader/ini/replace/test_replace_posargs.py
@@ -59,9 +59,9 @@ def test_replace_pos_args_default(replace_one: ReplaceOne, value: str, result: s
         "\\{posargs\\}",
         "{\\{posargs}",
         "{\\{posargs}{}",
-        pytest.param("\\[]", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC200
-        pytest.param("[\\]", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC200
-        pytest.param("\\[\\]", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC200
+        "\\[]",
+        "[\\]",
+        "\\[\\]",
     ],
 )
 def test_replace_pos_args_escaped(replace_one: ReplaceOne, value: str) -> None:

--- a/tests/config/loader/ini/replace/test_replace_posargs.py
+++ b/tests/config/loader/ini/replace/test_replace_posargs.py
@@ -59,9 +59,12 @@ def test_replace_pos_args_default(replace_one: ReplaceOne, value: str, result: s
         "\\{posargs\\}",
         "{\\{posargs}",
         "{\\{posargs}{}",
+        pytest.param("\\[]", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC200
+        pytest.param("[\\]", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC200
+        pytest.param("\\[\\]", marks=pytest.mark.xfail(raises=AssertionError)),  # noqa: SC200
     ],
 )
 def test_replace_pos_args_escaped(replace_one: ReplaceOne, value: str) -> None:
     result = replace_one(value, None)
-    outcome = value.replace("\\{", "{").replace("\\}", "}")
+    outcome = value.replace("\\", "")
     assert result == outcome

--- a/tests/config/loader/ini/replace/test_replace_posargs.py
+++ b/tests/config/loader/ini/replace/test_replace_posargs.py
@@ -23,8 +23,9 @@ def test_replace_pos_args_extra_sys_argv(syntax: str, replace_one: ReplaceOne) -
     assert result == f"{sys.executable} magic"
 
 
-def test_replace_pos_args(replace_one: ReplaceOne) -> None:
-    result = replace_one("{posargs}", ["ok", "what", " yes "])
+@pytest.mark.parametrize("syntax", ["{posargs}", "[]"])
+def test_replace_pos_args(syntax: str, replace_one: ReplaceOne) -> None:
+    result = replace_one(syntax, ["ok", "what", " yes "])
     quote = '"' if sys.platform == "win32" else "'"
     assert result == f"ok what {quote} yes {quote}"
 
@@ -34,8 +35,8 @@ def test_replace_pos_args(replace_one: ReplaceOne) -> None:
     [
         ("magic", "magic"),
         ("magic:colon", "magic:colon"),
-        ("magic\n b:c", "magic\nb:c"),  # unescaped newline keeps the newline
-        ("magi\\\n c:d", "magic:d"),  # escaped newline merges the lines
+        ("magic\n b:c", "magic\nb:c"),  # an unescaped newline keeps the newline
+        ("magi\\\n c:d", "magic:d"),  # an escaped newline merges the lines
         ("\\{a\\}", "{a}"),  # escaped curly braces
     ],
 )
@@ -67,11 +68,10 @@ def test_replace_pos_args_escaped(replace_one: ReplaceOne, value: str) -> None:
 @pytest.mark.parametrize(
     ("value", "result"),
     [
-        ("[]{posargs}", "foofoo"),
-        ("{posargs}[]", "foofoo"),
+        ("[]-{posargs}", "foo-foo"),
+        ("{posargs}-[]", "foo-foo"),
     ],
 )
 def test_replace_mixed_brackets_and_braces(replace_one: ReplaceOne, value: str, result: str) -> None:
-    """If we have a factor that is not specified within the core env-list then that's also an environment"""
     outcome = replace_one(value, ["foo"])
     assert result == outcome

--- a/tests/config/loader/ini/replace/test_replace_posargs.py
+++ b/tests/config/loader/ini/replace/test_replace_posargs.py
@@ -5,25 +5,19 @@ import pytest
 from tests.config.loader.ini.replace.conftest import ReplaceOne
 
 
-@pytest.mark.parametrize(
-    "syntax", ["{posargs}", pytest.param("[]", marks=pytest.mark.xfail(raises=AssertionError))]  # noqa: SC200
-)
+@pytest.mark.parametrize("syntax", ["{posargs}", "[]"])
 def test_replace_pos_args_none_sys_argv(syntax: str, replace_one: ReplaceOne) -> None:
     result = replace_one(syntax, None)
     assert result == ""
 
 
-@pytest.mark.parametrize(
-    "syntax", ["{posargs}", pytest.param("[]", marks=pytest.mark.xfail(raises=AssertionError))]  # noqa: SC200
-)
+@pytest.mark.parametrize("syntax", ["{posargs}", "[]"])
 def test_replace_pos_args_empty_sys_argv(syntax: str, replace_one: ReplaceOne) -> None:
     result = replace_one(syntax, [])
     assert result == ""
 
 
-@pytest.mark.parametrize(
-    "syntax", ["{posargs}", pytest.param("[]", marks=pytest.mark.xfail(raises=AssertionError))]  # noqa: SC200
-)
+@pytest.mark.parametrize("syntax", ["{posargs}", "[]"])
 def test_replace_pos_args_extra_sys_argv(syntax: str, replace_one: ReplaceOne) -> None:
     result = replace_one(syntax, [sys.executable, "magic"])
     assert result == f"{sys.executable} magic"

--- a/tests/config/loader/ini/replace/test_replace_posargs.py
+++ b/tests/config/loader/ini/replace/test_replace_posargs.py
@@ -21,8 +21,11 @@ def test_replace_pos_args_empty_sys_argv(syntax: str, replace_one: ReplaceOne) -
     assert result == ""
 
 
-def test_replace_pos_args_extra_sys_argv(replace_one: ReplaceOne) -> None:
-    result = replace_one("{posargs}", [sys.executable, "magic"])
+@pytest.mark.parametrize(
+    "syntax", ["{posargs}", pytest.param("[]", marks=pytest.mark.xfail(raises=AssertionError))]  # noqa: SC200
+)
+def test_replace_pos_args_extra_sys_argv(syntax: str, replace_one: ReplaceOne) -> None:
+    result = replace_one(syntax, [sys.executable, "magic"])
     assert result == f"{sys.executable} magic"
 
 

--- a/tests/config/loader/ini/replace/test_replace_posargs.py
+++ b/tests/config/loader/ini/replace/test_replace_posargs.py
@@ -5,8 +5,11 @@ import pytest
 from tests.config.loader.ini.replace.conftest import ReplaceOne
 
 
-def test_replace_pos_args_none_sys_argv(replace_one: ReplaceOne) -> None:
-    result = replace_one("{posargs}", None)
+@pytest.mark.parametrize(
+    "syntax", ["{posargs}", pytest.param("[]", marks=pytest.mark.xfail(raises=AssertionError))]  # noqa: SC200
+)
+def test_replace_pos_args_none_sys_argv(syntax: str, replace_one: ReplaceOne) -> None:
+    result = replace_one(syntax, None)
     assert result == ""
 
 


### PR DESCRIPTION
Fixes #1928
In #1950 me and @gaborbernat have discussed how the `[]` substitution should behave in tox4. In this PR I'll implement the changes.

- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [X] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [x] added the tests
- [x] implemented the syntax

I assume adding myself to `CONTRIBUTORS` on the master branch counts.

<!--
## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
-->