### PR TITLE
Add xfail to the spelling whitelist

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -216,3 +216,4 @@ whl
 win32
 writestr
 xdist
+xfail


### PR DESCRIPTION
Without this pytest.mark.xfail is flagged as a misspelling.

https://github.com/tox-dev/tox/pull/1954#discussion_r586387012
> don't silence error instead add to whitelist https://github.com/tox-dev/tox/blob/rewrite/whitelist.txt

## Contribution checklist:
- [x] wrote descriptive pull request text
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)

I assume adding myself to CONTRIBUTORS on the master branch counts.
<!--
## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.



(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)


- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)

-->