### PR TITLE
Workaround mypy AssertionError

### DIFF
--- a/tests/util/test_pep517.py
+++ b/tests/util/test_pep517.py
@@ -140,10 +140,11 @@ def test_pep517_bad_message(frontend_setuptools: SubprocessFrontend, tmp_path: P
     assert "Backend: incorrect request to backend: bytearray(b'{{')" in err
 
 
-def test_pep517_result_missing(frontend_setuptools: SubprocessFrontend, tmp_path: Path, mocker: MockerFixture) -> None:
-    class _Result(NamedTuple):
-        name: str
+class _Result(NamedTuple):
+    name: str
 
+
+def test_pep517_result_missing(frontend_setuptools: SubprocessFrontend, tmp_path: Path, mocker: MockerFixture) -> None:
     @contextmanager
     def named_temporary_file(prefix: str) -> Iterator[_Result]:
         write = S_IWUSR | S_IWGRP | S_IWOTH


### PR DESCRIPTION
sometimes mypy was failing with:
```py
AssertionError: Cannot find component '_Result@144' for 'tests.util.test_pep517._Result@144'
```
This is due to a bug: https://github.com/python/mypy/issues/7281
I have applied the workaround suggested in the above issue

Full traceback
```py
type run-test: commands[1] | mypy tests
Traceback (most recent call last):
  File "/home/user/tox/.tox/type/bin/mypy", line 8, in <module>
    sys.exit(console_entry())
  File "/home/user/tox/.tox/type/lib/python3.9/site-packages/mypy/__main__.py", line 11, in console_entry
    main(None, sys.stdout, sys.stderr)
  File "mypy/main.py", line 90, in main
  File "mypy/build.py", line 179, in build
  File "mypy/build.py", line 253, in _build
  File "mypy/build.py", line 2638, in dispatch
  File "mypy/build.py", line 2955, in process_graph
  File "mypy/build.py", line 3033, in process_fresh_modules
  File "mypy/build.py", line 1977, in fix_cross_refs
  File "mypy/fixup.py", line 26, in fixup_module
  File "mypy/fixup.py", line 77, in visit_symbol_table
  File "mypy/fixup.py", line 301, in lookup_qualified_stnode
  File "mypy/lookup.py", line 47, in lookup_fully_qualified
AssertionError: Cannot find component '_Result@144' for 'tests.util.test_pep517._Result@144'
ERROR: InvocationError for command /home/user/tox/.tox/type/bin/mypy tests (exited with code 1)
```

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
