### PR TITLE
Support for ignore_outcome

### DIFF
--- a/docs/changelog/1947.feature.rst
+++ b/docs/changelog/1947.feature.rst
@@ -1,0 +1,1 @@
+Implement ``[testenv] ignore_outcome`` - "a failing result of this testenv will not make tox fail" - by :user:`hexagonrecursion`.

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -137,39 +137,38 @@ def env_run_create_flags(parser: ArgumentParser, mode: str) -> None:
 
 
 def report(start: float, runs: List[ToxEnvRunResult], is_colored: bool) -> int:
-    def _print(color: int, message: str) -> None:
-        print(f"{color if is_colored else ''}{message}{Fore.RESET if is_colored else ''}")
+    def _print(color_: int, message: str) -> None:
+        print(f"{color_ if is_colored else ''}{message}{Fore.RESET if is_colored else ''}")
 
-    end = time.monotonic()
+    all_good = True
     for run in runs:
-        if run.code != Outcome.OK and run.ignore_outcome:
-            msg = f"IGNORED FAIL code {run.code}"
-            color = Fore.YELLOW
-        elif run.code != Outcome.OK:
-            assert not run.ignore_outcome
-            msg = f"FAIL code {run.code}"
-            color = Fore.RED
-        elif run.skipped:
-            assert run.code == Outcome.OK
-            msg = "SKIP"
-            color = Fore.YELLOW
-        else:
-            assert run.code == Outcome.OK
-            assert not run.skipped
-            msg = "OK"
-            color = Fore.GREEN
+        all_good &= run.code == Outcome.OK or run.ignore_outcome
         duration_individual = [o.elapsed for o in run.outcomes]
         extra = f"+cmd[{','.join(f'{i:.2f}' for i in duration_individual)}]" if len(duration_individual) else ""
         setup = run.duration - sum(duration_individual)
+        msg, color = _get_outcome_message(run)
         out = f"  {run.name}: {msg} ({run.duration:.2f}{f'=setup[{setup:.2f}]{extra}' if extra else ''} seconds)"
         _print(color, out)
-    duration = end - start
-    if all(run.code == Outcome.OK or run.ignore_outcome for run in runs):
+
+    duration = time.monotonic() - start
+    if all_good:
         _print(Fore.GREEN, f"  congratulations :) ({duration:.2f} seconds)")
         return Outcome.OK
+    _print(Fore.RED, f"  evaluation failed :( ({duration:.2f} seconds)")
+    return runs[0].code if len(runs) == 1 else -1
+
+
+def _get_outcome_message(run: ToxEnvRunResult) -> Tuple[str, int]:
+    if run.skipped:
+        msg, color = "SKIP", Fore.YELLOW
+    elif run.code == Outcome.OK:
+        msg, color = "OK", Fore.GREEN
     else:
-        _print(Fore.RED, f"  evaluation failed :( ({duration:.2f} seconds)")
-        return runs[0].code if len(runs) == 1 else -1
+        if run.ignore_outcome:
+            msg, color = f"IGNORED FAIL code {run.code}", Fore.YELLOW
+        else:
+            msg, color = f"FAIL code {run.code}", Fore.RED
+    return msg, color
 
 
 logger = logging.getLogger(__name__)

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -141,18 +141,30 @@ def report(start: float, runs: List[ToxEnvRunResult], is_colored: bool) -> int:
         print(f"{color if is_colored else ''}{message}{Fore.RESET if is_colored else ''}")
 
     end = time.monotonic()
-    all_ok = True
     for run in runs:
-        ok = run.code == Outcome.OK
-        msg = ("SKIP" if run.skipped else "OK") if ok else f"FAIL code {run.code}"
+        if run.code != Outcome.OK and run.ignore_outcome:
+            msg = f"IGNORED FAIL code {run.code}"
+            color = Fore.YELLOW
+        elif run.code != Outcome.OK:
+            assert not run.ignore_outcome
+            msg = f"FAIL code {run.code}"
+            color = Fore.RED
+        elif run.skipped:
+            assert run.code == Outcome.OK
+            msg = "SKIP"
+            color = Fore.YELLOW
+        else:
+            assert run.code == Outcome.OK
+            assert not run.skipped
+            msg = "OK"
+            color = Fore.GREEN
         duration_individual = [o.elapsed for o in run.outcomes]
         extra = f"+cmd[{','.join(f'{i:.2f}' for i in duration_individual)}]" if len(duration_individual) else ""
         setup = run.duration - sum(duration_individual)
         out = f"  {run.name}: {msg} ({run.duration:.2f}{f'=setup[{setup:.2f}]{extra}' if extra else ''} seconds)"
-        _print((Fore.YELLOW if run.skipped else Fore.GREEN) if ok else Fore.RED, out)
-        all_ok = ok and all_ok
+        _print(color, out)
     duration = end - start
-    if all_ok:
+    if all(run.code == Outcome.OK or run.ignore_outcome for run in runs):
         _print(Fore.GREEN, f"  congratulations :) ({duration:.2f} seconds)")
         return Outcome.OK
     else:

--- a/src/tox/session/cmd/run/single.py
+++ b/src/tox/session/cmd/run/single.py
@@ -21,6 +21,7 @@ class ToxEnvRunResult(NamedTuple):
     code: int
     outcomes: List[Outcome]
     duration: float
+    ignore_outcome: bool = False
 
 
 def run_one(tox_env: RunToxEnv, recreate: bool, no_test: bool, suspend_display: bool) -> ToxEnvRunResult:
@@ -29,7 +30,8 @@ def run_one(tox_env: RunToxEnv, recreate: bool, no_test: bool, suspend_display: 
     with tox_env.display_context(suspend_display):
         skipped, code, outcomes = _evaluate(tox_env, recreate, no_test)
     duration = time.monotonic() - start_one
-    return ToxEnvRunResult(name, skipped, code, outcomes, duration)
+    ignore_outcome: bool = tox_env.conf["ignore_outcome"]
+    return ToxEnvRunResult(name, skipped, code, outcomes, duration, ignore_outcome)
 
 
 def _evaluate(tox_env: RunToxEnv, recreate: bool, no_test: bool) -> Tuple[bool, int, List[Outcome]]:

--- a/src/tox/session/cmd/run/single.py
+++ b/src/tox/session/cmd/run/single.py
@@ -30,8 +30,7 @@ def run_one(tox_env: RunToxEnv, recreate: bool, no_test: bool, suspend_display: 
     with tox_env.display_context(suspend_display):
         skipped, code, outcomes = _evaluate(tox_env, recreate, no_test)
     duration = time.monotonic() - start_one
-    ignore_outcome: bool = tox_env.conf["ignore_outcome"]
-    return ToxEnvRunResult(name, skipped, code, outcomes, duration, ignore_outcome)
+    return ToxEnvRunResult(name, skipped, code, outcomes, duration, tox_env.conf["ignore_outcome"])
 
 
 def _evaluate(tox_env: RunToxEnv, recreate: bool, no_test: bool) -> Tuple[bool, int, List[Outcome]]:

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -78,8 +78,7 @@ class RunToxEnv(ToxEnv, ABC):
             keys=["ignore_outcome"],
             of_type=bool,
             default=False,
-            desc="if set to true a failing result of this testenv will not make tox fail, "
-            "only a warning will be produced",
+            desc="if set to true a failing result of this testenv will not make tox fail (instead just warn)",
         )
         self.has_package = self.add_package_conf()
 

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -74,6 +74,13 @@ class RunToxEnv(ToxEnv, ABC):
             default=False,
             desc="when executing the commands keep going even if a sub-command exits with non-zero exit code",
         )
+        self.conf.add_config(
+            keys=["ignore_outcome"],
+            of_type=bool,
+            default=False,
+            desc="if set to true a failing result of this testenv will not make tox fail, "
+            "only a warning will be produced",
+        )
         self.has_package = self.add_package_conf()
 
     def setup(self) -> None:

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -442,7 +442,6 @@ def test_commands_ignore_errors(tox_project: ToxProjectCreator, pre: int, main: 
     assert "commands_post[0]" in result.out
 
 
-@pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
 def test_ignore_outcome(tox_project: ToxProjectCreator) -> None:
     project = tox_project(
         {
@@ -459,3 +458,6 @@ def test_ignore_outcome(tox_project: ToxProjectCreator) -> None:
     result = project.run("r")
     print(result)
     result.assert_success()
+    reports = result.out.splitlines()[-2:]
+    assert Matches(r"  py: IGNORED FAIL code 1 \(.*=setup\[.*\]\+cmd\[.*\] seconds\)") == reports[-2]
+    assert Matches(r"  congratulations :\) \(.* seconds\)") == reports[-1]

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -440,3 +440,22 @@ def test_commands_ignore_errors(tox_project: ToxProjectCreator, pre: int, main: 
     assert "commands_pre[0]" in result.out
     assert "commands[0]" in result.out
     assert "commands_post[0]" in result.out
+
+
+@pytest.mark.xfail(raises=AssertionError)  # noqa: SC200
+def test_ignore_outcome(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.ini": """
+            [tox]
+            no_package = true
+
+            [testenv]
+            commands = python -c 'exit(1)'
+            ignore_outcome = true
+            """
+        }
+    )
+    result = project.run("r")
+    print(result)
+    result.assert_success()

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -443,21 +443,12 @@ def test_commands_ignore_errors(tox_project: ToxProjectCreator, pre: int, main: 
 
 
 def test_ignore_outcome(tox_project: ToxProjectCreator) -> None:
-    project = tox_project(
-        {
-            "tox.ini": """
-            [tox]
-            no_package = true
-
-            [testenv]
-            commands = python -c 'exit(1)'
-            ignore_outcome = true
-            """
-        }
-    )
+    ini = "[tox]\nno_package=true\n[testenv]\ncommands=python -c 'exit(1)'\nignore_outcome=true"
+    project = tox_project({"tox.ini": ini})
     result = project.run("r")
-    print(result)
+
     result.assert_success()
-    reports = result.out.splitlines()[-2:]
-    assert Matches(r"  py: IGNORED FAIL code 1 \(.*=setup\[.*\]\+cmd\[.*\] seconds\)") == reports[-2]
-    assert Matches(r"  congratulations :\) \(.* seconds\)") == reports[-1]
+    reports = result.out.splitlines()
+
+    assert Matches(r"  py: IGNORED FAIL code 1 .*") == reports[-2]
+    assert Matches(r"  congratulations :\) .*") == reports[-1]


### PR DESCRIPTION
Fix #1947

This PR adds an option: `[testenv] ignore_outcome` - "a failing result of this testenv will not make tox fail"

tox3 has this option. tox4 should too for backward compatibility.

## Contribution checklist:

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
