### PR TITLE
Limit required setuptools version to the highest supporting Python2

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -58,6 +58,7 @@ Joshua Hesketh
 Julian Krause
 Jürgen Gmach
 Jurko Gospodnetić
+Konstantin Shemyak
 Krisztian Fekete
 Laszlo Vasko
 Lukasz Balcerzak

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 40.0.4",
+    "setuptools >= 40.0.4, <=44.1.1",
     "setuptools_scm >= 2.0.0, <6",
     "wheel >= 0.29.0",
 ]


### PR DESCRIPTION
Closes #1967 .

No update to tests, documentation or changelog seem needed.
