### PR TITLE
Fix typos, modernize and simplify some code

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ``tox``
 
-Thank you for your interest in contributing to virtualenv! There are many ways to contribute, and we appreciate all of them.
+Thank you for your interest in contributing to ``tox``! There are many ways to contribute, and we appreciate all of them.
 As a reminder, all contributors are expected to follow our [Code of Conduct][coc].
 
 [coc]: https://www.pypa.io/en/latest/code-of-conduct/
@@ -8,4 +8,4 @@ As a reminder, all contributors are expected to follow our [Code of Conduct][coc
 ## Development Documentation
 
 Our [development documentation](http://tox.readthedocs.org/en/latest/development.html#development) contains details on
-how to get started with contributing to ``virtualenv``, and details of our development processes.
+how to get started with contributing to ``tox``, and details of our development processes.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -98,7 +98,7 @@ Code style guide
   as codified by: ``flake8``, ``black``, ``isort``, ``pyupgrade``.
 - Packaging options should be specified within ``setup.cfg``, ``setup.py`` is only kept for editable installs.
 - All code (tests too) must be type annotated as much as required by ``mypy``.
-- We use a ling length of 120.
+- We use a line length of 120.
 - Exception messages should only be capitalized (and ended with a period/exclamation mark) if they are multi-sentenced,
   which should be avoided. Otherwise, use statements that start with lowercase.
 - All function (including test) names must follow PEP-8, so they must be fully snake cased. All classes are upper

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 via pipx
 --------
 
-:pypi:`tox` is a CLI tool that needs a Python interpreter to run. The tool requires first to have ``Python 3.5+``
+:pypi:`tox` is a CLI tool that needs a Python interpreter to run. The tool requires first to have ``Python 3.6+``
 interpreter the best is to use :pypi:`pipx` to install tox into an isolated environment. This has the added
 benefit that later you'll be able to upgrade tox without affecting other parts of the system.
 
@@ -68,8 +68,8 @@ Python and OS Compatibility
 
 tox works with the following Python interpreter implementations:
 
-- `CPython <https://www.python.org/>`_ versions 3.5, 3.6, 3.7, 3.8
-- `PyPy <https://pypy.org/>`_ 3.5+.
+- `CPython <https://www.python.org/>`_ versions 3.6, 3.7, 3.8, 3.9
+- `PyPy <https://pypy.org/>`_ 3.6+.
 
 This means tox works on the latest patch version of each of these minor versions. Previous patch versions are
 supported on a best effort approach. We support all platforms ``virtualenv`` supports.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -67,13 +67,13 @@ tox roughly follows the following phases:
 
    2. **install** (optional): install the environment dependencies specified inside the ``deps`` configuration
    section, and then the earlier packaged source distribution. By default ``pip`` is used to install packages, however
-   one can customise this via ``install_command``. Note ``pip`` will not update project dependencies (specified
+   one can customize this via ``install_command``. Note ``pip`` will not update project dependencies (specified
    either in the ``install_requires`` or the ``extras`` section of the ``setup.py``) if any version already exists in
    the virtual environment; therefore we recommend to recreate your environments whenever your project dependencies
    change.
 
    3. **commands**: run the specified commands in the specified order. Whenever the exit code of any of them is not
-   zero stop, and mark the environment failed. Note, starting a command with a single dash character means ignore exit
+   zero, stop and mark the environment failed. Note, starting a command with a single dash character means ignore exit
    code.
 
 6. **report** print out a report of outcomes for each tox environment:
@@ -89,7 +89,7 @@ tox roughly follows the following phases:
 
 tox will take care of environment isolation for you: it will strip away all operating system environment variables not
 specified via ``passenv``. Furthermore, it will also alter the ``PATH`` variable so that your commands resolve
-within the current active tox environment. In general all executables in the path are available in ``commands``, but
+within the current active tox environment. In general, all executables in the path are available in ``commands``, but
 tox will emit a warning if it was not explicitly allowed via ``whitelist_externals``.
 
 Current features

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -105,7 +105,7 @@ Current features
 * ``plugin system`` to modify tox execution with simple hooks.
 * uses :pypi:`pip` and :pypi:`setuptools` by default. Support for configuring the installer command through
   ``install_command``.
-* **cross-Python compatible**: CPython-3.5 and higher, pypy 3.6+ and higher.
+* **cross-Python compatible**: CPython-3.6 and higher, pypy 3.6+ and higher.
 * **cross-platform**: Windows and Unix style environments
 * **integrates with continuous integration servers** like Jenkins (formerly known as Hudson) and helps you to avoid
   boilerplatish and platform-specific build-step hacks.

--- a/src/new.md
+++ b/src/new.md
@@ -1,6 +1,6 @@
 # External facing
 
-0. `Python 3.5+` only.
+0. `Python 3.6+` only.
 1. Lazy configuration - everything is materialized only when needed (don't ever generate data that will not be used -
    general speed improvement)
 2. built-in wheel build support - no longer generates sdist only

--- a/src/tox/config/loader/api.py
+++ b/src/tox/config/loader/api.py
@@ -16,14 +16,10 @@ if TYPE_CHECKING:
 
 class Override:
     def __init__(self, value: str) -> None:
-        split_at = value.find("=")
-        if split_at == -1:
+        key, equal, self.value = value.partition("=")
+        if not equal:
             raise ArgumentTypeError(f"override {value} has no = sign in it")
-        key = value[:split_at]
-        ns_at = key.find(".")
-        self.namespace = "" if ns_at == -1 else key[:ns_at]
-        self.key = key[ns_at + 1 :]
-        self.value = value[split_at + 1 :]
+        self.namespace, _, self.key = key.rpartition(".")
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}('{self}')"

--- a/src/tox/config/loader/ini/factor.py
+++ b/src/tox/config/loader/ini/factor.py
@@ -19,11 +19,7 @@ def filter_for_env(value: str, name: Optional[str]) -> str:
                 overall.append(content)
         else:
             for group in factors:
-                for a_name, negate in group:
-                    contains = a_name in current
-                    if not ((contains is True and negate is False) or (contains is False and negate is True)):
-                        break
-                else:
+                if all((a_name in current) ^ negate for a_name, negate in group):
                     overall.append(content)
     result = "\n".join(overall)
     return result

--- a/src/tox/report.py
+++ b/src/tox/report.py
@@ -167,8 +167,8 @@ class ToxHandler(logging.StreamHandler):
         # shorten the pathname to start from within the site-packages folder
         record.env_name = "root" if self._local.name is None else self._local.name  # type: ignore[attr-defined]
         basename = os.path.dirname(record.pathname)
-        sys_path_match = sorted((p for p in sys.path if basename.startswith(p)), key=len, reverse=True)
-        record.pathname = record.pathname[len(sys_path_match[0]) + 1 :]
+        len_sys_path_match = max(len(p) for p in sys.path if basename.startswith(p))
+        record.pathname = record.pathname[len_sys_path_match + 1 :]
 
         if record.levelno >= logging.ERROR:
             return self.error_formatter.format(record)

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -331,7 +331,6 @@ def _handle_one_run_done(result: ToxEnvRunResult, spinner: ToxSpinner, state: St
 def ready_to_run_envs(state: State, to_run: List[str], completed: Set[str]) -> Iterator[List[str]]:
     """Generate tox environments ready to run"""
     order, todo = run_order(state, to_run)
-    at = 0
     while order:
         ready_to_run: List[str] = []
         new_order: List[str] = []
@@ -340,7 +339,6 @@ def ready_to_run_envs(state: State, to_run: List[str], completed: Set[str]) -> I
                 new_order.append(env)
             else:
                 ready_to_run.append(env)
-            at += 1
         order = new_order
         yield ready_to_run
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -164,6 +164,7 @@ replacer
 Replacer
 req
 rfind
+rpartition
 rreq
 rtd
 runpy


### PR DESCRIPTION
A few independent commits for the tox4 rewrite in five commits:

1. fix some typos
2. push minimal required Python version from 3.5 to 3.6
3. simplify code to parse string into smaller parts (here the flake8 CI checker dislikes `str.rpartition` and thinks it's a typo)
4. simplify a nested condition
5. remove one unused variable 