### PR TITLE
coverage report: enable setting a different `upstream` repository

### DIFF
--- a/docs/changelog/1972.bugfix.rst
+++ b/docs/changelog/1972.bugfix.rst
@@ -1,0 +1,3 @@
+Enable setting a different ``upstream`` repository for the coverage diff report.
+This has been hardcoded to ``upstream/rewrite`` until now.
+by :user:`jugmac00`.

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands =
     coverage report -m
     coverage xml -o {toxworkdir}{/}coverage.xml
     coverage html -d {toxworkdir}{/}htmlcov
-    diff-cover --compare-branch upstream/rewrite {toxworkdir}{/}coverage.xml
+    diff-cover --compare-branch {env:DIFF_AGAINST:upstream/rewrite} {toxworkdir}{/}coverage.xml
 depends =
     py39
     py38


### PR DESCRIPTION
The coverage report was comparing the local branch to
`upstream/rewrite`.

This was hardcoded.

Now, you can change the remote repository by ``DIFF_AGAINST`` env
variable as intended.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)


AFAIK - There is no `CONTRIBUTORS` file in the rewrite branch.