### PR TITLE
Use `{env}/bin` instead of `{env}/Scripts` when Python is from MSYS2 on Windows.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -48,6 +48,7 @@ Ionel Maries Cristian
 Itxaka Serrano
 Jake Windle
 Jannis Leidel
+Jesse Schwartzentruber
 Joachim Brandon LeBlanc
 Johannes Christ
 John Mark Vandenberg

--- a/docs/changelog/1982.bugfix.rst
+++ b/docs/changelog/1982.bugfix.rst
@@ -1,0 +1,3 @@
+Distinguish between normal Windows Python and MSYS2 Python when looking for
+virtualenv executable path.  Adds os.sep to :class:`InterpreterInfo`
+- by :user:`jschwartzentruber`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1054,6 +1054,11 @@ class TestenvConfig:
             or tox.INFO.IS_WIN is False
             or self.python_info.implementation == "Jython"
             or (
+                # this combination is MSYS2
+                tox.INFO.IS_WIN
+                and self.python_info.os_sep == "/"
+            )
+            or (
                 tox.INFO.IS_WIN
                 and self.python_info.implementation == "PyPy"
                 and self.python_info.extra_version_info < (7, 3, 1)

--- a/src/tox/helper/get_version.py
+++ b/src/tox/helper/get_version.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+import os
 import platform
 import sys
 
@@ -11,6 +12,7 @@ info = {
     "version": sys.version,
     "is_64": sys.maxsize > 2 ** 32,
     "sysplatform": sys.platform,
+    "os_sep": os.sep,
     "extra_version_info": getattr(sys, "pypy_version_info", None),
 }
 info_as_dump = json.dumps(info)

--- a/src/tox/interpreters/__init__.py
+++ b/src/tox/interpreters/__init__.py
@@ -103,6 +103,7 @@ class InterpreterInfo:
         version_info,
         sysplatform,
         is_64,
+        os_sep,
         extra_version_info,
     ):
         self.implementation = implementation
@@ -111,6 +112,7 @@ class InterpreterInfo:
         self.version_info = version_info
         self.sysplatform = sysplatform
         self.is_64 = is_64
+        self.os_sep = os_sep
         self.extra_version_info = extra_version_info
 
     def __str__(self):

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1469,6 +1469,7 @@ class TestConfigTestEnv:
         if bp == "jython":
             assert envconfig.envpython == envconfig.envbindir.join(bp)
 
+    @pytest.mark.skipif(tox.INFO.IS_PYPY, reason="only applies to CPython")
     @pytest.mark.parametrize("sep, bindir", [("\\", "Scripts"), ("/", "bin")])
     def test_envbindir_win(self, newconfig, monkeypatch, sep, bindir):
         monkeypatch.setattr(tox.INFO, "IS_WIN", True)

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1469,6 +1469,22 @@ class TestConfigTestEnv:
         if bp == "jython":
             assert envconfig.envpython == envconfig.envbindir.join(bp)
 
+    @pytest.mark.parametrize("sep, bindir", [("\\", "Scripts"), ("/", "bin")])
+    def test_envbindir_win(self, newconfig, monkeypatch, sep, bindir):
+        monkeypatch.setattr(tox.INFO, "IS_WIN", True)
+        config = newconfig(
+            """
+            [testenv]
+            basepython=python
+        """,
+        )
+        assert len(config.envconfigs) == 1
+        envconfig = config.envconfigs["python"]
+        envconfig.python_info.os_sep = sep  # force os.sep result
+        # on win32 with msys2, virtualenv uses "bin" for python
+        assert envconfig.envbindir.basename == bindir
+        assert envconfig.envpython == envconfig.envbindir.join("python")
+
     @pytest.mark.parametrize("plat", ["win32", "linux2"])
     def test_passenv_as_multiline_list(self, newconfig, monkeypatch, plat):
         monkeypatch.setattr(tox.INFO, "IS_WIN", plat == "win32")

--- a/tests/unit/interpreters/test_interpreters.py
+++ b/tests/unit/interpreters/test_interpreters.py
@@ -192,7 +192,9 @@ class TestInterpreterInfo:
         version_info="my-version-info",
         sysplatform="my-sys-platform",
     ):
-        return InterpreterInfo(implementation, executable, version_info, sysplatform, True, None)
+        return InterpreterInfo(
+            implementation, executable, version_info, sysplatform, True, "/", None
+        )
 
     def test_data(self):
         x = self.info("larry", "moe", "shemp", "curly")


### PR DESCRIPTION
MSYS2 prefers a Linux filesystem layout, but is otherwise a native Windows interpreter.

This was causing warnings like:

```
WARNING: test command found but not installed in testenv
  cmd: C:/Users/User/Desktop/msys64-JHtqq6ULSEu38CxK8FxfLQ/mingw64/bin/python.EXE
  env: C:/Users/User/source/repos/fuzzfetch/.tox/py38
Maybe you forgot to specify a dependency? See also the allowlist_externals envconfig setting.
```

... despite the fact that `C:/Users/User/source/repos/fuzzfetch/.tox/py38/bin/python.exe` did exist.

Fixes #1982.