### PR TITLE
Allow building with setuptools_scm 6+

### DIFF
--- a/docs/changelog/1984.misc.rst
+++ b/docs/changelog/1984.misc.rst
@@ -1,0 +1,1 @@
+Enable building tox with ``setuptools_scm`` 6+ by :user:hroncok

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 40.0.4",
-    "setuptools_scm >= 2.0.0, <6",
+    "setuptools_scm >= 2.0.0",
     "wheel >= 0.29.0",
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Once again a new setuptools_scm version is available, 6.
Lets' not change this to `<7` again but allow any future version.
If it breaks in the future, we can adapt.