### PR TITLE
Add a check for broken use of :user: in RST

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,6 @@ repos:
       - id: changelogs-user-role
         name: changelog files have a non-broken :user:`name` role
         language: pygrep
-        entry: >-
-          :user:([^`]+`?|`[^`]+[\s,])
+        entry: :user:([^`]+`?|`[^`]+[\s,])
         pass_filenames: true
         types: [file, rst]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,28 @@ repos:
         exclude: >-
           ^docs/changelog/(\d+\.(bugfix|feature|deprecation|breaking|doc|misc).rst|README.rst|template.jinja2)
         files: ^docs/changelog/
+      - id: changelogs-user-role
+        name: changelog files have a non-broken :user:`name` role
+        language: system
+        entry: >-
+          sh -c '
+          rc=0;
+          for f in "$@";
+          do
+          if ! >/dev/null grep ":user:" -- "${f}";
+          then
+          continue;
+          fi;
+          grep ":user:" -- "${f}"
+          | sed "s/.*\(:user:[^ .,]\+\).*$/\1/"
+          | >/dev/null grep -v "^:user:\`[^ \`]\+\`";
+          if [ "$?" -eq 0 ];
+          then
+          rc=1;
+          2>&1 echo ":user: RST role syntax is broken in '${f}'...";
+          fi;
+          done;
+          exit $rc
+          '
+        pass_filenames: true
+        types: [file, rst]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,26 +66,8 @@ repos:
         files: ^docs/changelog/
       - id: changelogs-user-role
         name: changelog files have a non-broken :user:`name` role
-        language: system
+        language: pygrep
         entry: >-
-          sh -c '
-          rc=0;
-          for f in "$@";
-          do
-          if ! >/dev/null grep ":user:" -- "${f}";
-          then
-          continue;
-          fi;
-          grep ":user:" -- "${f}"
-          | sed "s/.*\(:user:[^ .,]\+\).*$/\1/"
-          | >/dev/null grep -v "^:user:\`[^ \`]\+\`";
-          if [ "$?" -eq 0 ];
-          then
-          rc=1;
-          2>&1 echo ":user: RST role syntax is broken in '${f}'...";
-          fi;
-          done;
-          exit $rc
-          '
+          :user:([^`]+`?|`[^`]+[\s,])
         pass_filenames: true
         types: [file, rst]


### PR DESCRIPTION
This change attempts to improve the linting of the `:user:` role in RST files.

Ref https://github.com/tox-dev/tox/pull/1984#discussion_r605646689