### PR TITLE
fix replacement of sections with dash

### DIFF
--- a/docs/changelog/1985.bugfix.rst
+++ b/docs/changelog/1985.bugfix.rst
@@ -1,0 +1,2 @@
+Enable replacements (a.k.a section substitions) for section names containing a dash in sections
+without the ``testenv:`` prefix - by :user:`jugmac00`, :user:`obestwalter`, :user:`eumiro`.

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -89,7 +89,7 @@ def _replace_match(
 
 _REPLACE_REF = re.compile(
     rf"""
-    (\[(?P<full_env>{BASE_TEST_ENV}(:(?P<env>[^]]+))?|(?P<section>\w+))\])? # env/section
+    (\[(?P<full_env>{BASE_TEST_ENV}(:(?P<env>[^]]+))?|(?P<section>[-\w]+))\])? # env/section
     (?P<key>[a-zA-Z0-9_]+) # key
     (:(?P<default>.*))? # default value
 """,

--- a/tests/config/loader/ini/replace/test_replace_tox_env.py
+++ b/tests/config/loader/ini/replace/test_replace_tox_env.py
@@ -154,13 +154,13 @@ def test_replace_from_tox_other_tox_section_same_name(tox_ini_conf: ToxIniCreato
 
 
 @pytest.mark.parametrize(
-    "env_name, exp",
-    (
+    ("env_name", "exp"),
+    [
         ("testenv:foobar", "1"),
         ("testenv:foo-bar", "1"),
         ("foo-bar", "1"),
         ("foobar", "1"),
-    ),
+    ],
 )
 def test_replace_valid_section_names(tox_ini_conf: ToxIniCreator, env_name: str, exp: str) -> None:
     conf_a = tox_ini_conf(f"[{env_name}]\na={exp}\n[testenv:a]\nx = {{[{env_name}]a}}").get_env("a")

--- a/tests/config/loader/ini/replace/test_replace_tox_env.py
+++ b/tests/config/loader/ini/replace/test_replace_tox_env.py
@@ -154,7 +154,7 @@ def test_replace_from_tox_other_tox_section_same_name(tox_ini_conf: ToxIniCreato
 
 
 @pytest.mark.parametrize(
-    "envname, exp",
+    "env_name, exp",
     (
         ("testenv:foobar", "1"),
         ("testenv:foo-bar", "1"),
@@ -162,7 +162,7 @@ def test_replace_from_tox_other_tox_section_same_name(tox_ini_conf: ToxIniCreato
         ("foobar", "1"),
     ),
 )
-def test_replace_valid_section_names(tox_ini_conf: ToxIniCreator, envname, exp) -> None:
-    conf_a = tox_ini_conf(f"[{envname}]\na={exp}\n[testenv:a]\nx = {{[{envname}]a}}").get_env("a")
+def test_replace_valid_section_names(tox_ini_conf: ToxIniCreator, env_name: str, exp: str) -> None:
+    conf_a = tox_ini_conf(f"[{env_name}]\na={exp}\n[testenv:a]\nx = {{[{env_name}]a}}").get_env("a")
     conf_a.add_config(keys="x", of_type=str, default="o", desc="o")
     assert conf_a["x"] == exp

--- a/tests/config/loader/ini/replace/test_replace_tox_env.py
+++ b/tests/config/loader/ini/replace/test_replace_tox_env.py
@@ -151,3 +151,18 @@ def test_replace_from_tox_other_tox_section_same_name(tox_ini_conf: ToxIniCreato
     conf_a = tox_ini_conf("[testenv:a]\nx={[testenv:b]c}\nc=d\n[testenv:b]}").get_env("a")
     conf_a.add_config(keys="x", of_type=str, default="", desc="d")
     assert conf_a["x"] == "{[testenv:b]c}"
+
+
+@pytest.mark.parametrize(
+    "envname, exp",
+    (
+        ("testenv:foobar", "1"),
+        ("testenv:foo-bar", "1"),
+        ("foo-bar", "1"),
+        ("foobar", "1"),
+    ),
+)
+def test_replace_valid_section_names(tox_ini_conf: ToxIniCreator, envname, exp) -> None:
+    conf_a = tox_ini_conf(f"[{envname}]\na={exp}\n[testenv:a]\nx = {{[{envname}]a}}").get_env("a")
+    conf_a.add_config(keys="x", of_type=str, default="o", desc="o")
+    assert conf_a["x"] == exp


### PR DESCRIPTION
closes #1985 - also accepting a dash as a part of statically defined environment names

Co-authored-by: Jürgen Gmach <juergen.gmach@googlemail.com>
Co-authored-by: Miroslav Šedivý <eumiro@gmail.com>
