### PR TITLE
Update documentation about changelog entries for trivial changes

### DIFF
--- a/docs/changelog/2007.doc.rst
+++ b/docs/changelog/2007.doc.rst
@@ -1,0 +1,1 @@
+Update documentation about changelog entries for trivial changes - by :user:`jugmac00`.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -163,10 +163,12 @@ pull request. If needed, project maintainers can manually trigger a restart of a
 Changelog entries
 ~~~~~~~~~~~~~~~~~
 
-The ``changelog.rst`` file is managed using :pypi:`towncrier` and all non trivial changes must be accompanied by a
+The ``changelog.rst`` file is managed using :pypi:`towncrier` and all changes must be accompanied by a
 changelog entry. To add an entry to the changelog, first you need to have created an issue describing the
 change you want to make. A  pull request itself *may* function as such, but it is preferred to have a dedicated issue
 (for example, in case the PR ends up rejected due to code quality reasons).
+
+There is no need to create an issue for trivial changes, e.g. for typo fixes.
 
 Once you have an issue or pull request, you take the number and you create a file inside of the ``docs/changelog``
 directory named after that issue number with an extension of:


### PR DESCRIPTION
This fixes #2007

Part of the #2007 was already fixed by #2006, ie the paragraph about how
to create pseudo towncrier snippets was removed.

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
