### PR TITLE
Replace .format with f-strings

### DIFF
--- a/docs/changelog/2012.bugfix.rst
+++ b/docs/changelog/2012.bugfix.rst
@@ -1,0 +1,1 @@
+Prefer f-strings instead of the str.format method - by :user:`eumiro`.

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -236,7 +236,7 @@ class ToxParser(ArgumentParserWithEnvAndConfig):
 def add_verbosity_flags(parser: ArgumentParser) -> None:
     from tox.report import LEVELS
 
-    level_map = "|".join("{} - {}".format(c, logging.getLevelName(l)) for c, l in sorted(LEVELS.items()))
+    level_map = "|".join(f"{c} - {logging.getLevelName(l)}" for c, l in sorted(LEVELS.items()))
     verbosity_group = parser.add_argument_group("verbosity")
     verbosity_group.description = f"verbosity=verbose-quiet, default {logging.getLevelName(LEVELS[3])}, map {level_map}"
     verbosity = verbosity_group.add_mutually_exclusive_group()

--- a/src/tox/config/of_type.py
+++ b/src/tox/config/of_type.py
@@ -109,7 +109,7 @@ class ConfigDynamicDefinition(ConfigDefinition[T]):
 
     def __repr__(self) -> str:
         values = ((k, v) for k, v in vars(self).items() if k != "post_process" and v is not None)
-        return f"{type(self).__name__}({', '.join('{}={}'.format(k, v) for k,v in values)})"
+        return f"{type(self).__name__}({', '.join(f'{k}={v}' for k, v in values)})"
 
     def __eq__(self, o: Any) -> bool:
         return (

--- a/src/tox/pytest.py
+++ b/src/tox/pytest.py
@@ -151,7 +151,7 @@ class ToxProject:
             elif isinstance(value, str):
                 at_path.write_text(textwrap.dedent(value))
             else:
-                msg = "could not handle {} with content {!r}".format(at_path / key, value)  # pragma: no cover
+                msg = f"could not handle {at_path / key} with content {value!r}"  # pragma: no cover
                 raise TypeError(msg)  # pragma: no cover
 
     def patch_execute(self, handle: Callable[[ExecuteRequest], Optional[int]]) -> MagicMock:

--- a/src/tox/util/spinner.py
+++ b/src/tox/util/spinner.py
@@ -85,7 +85,7 @@ class Spinner:
         text_frame = f"[{len(self._envs)}{total}] {' | '.join(self._envs)}"
         if len(text_frame) > self.max_width - 1:
             text_frame = "{}...".format(text_frame[: self.max_width - 1 - 3])
-        return "{} {}".format(*[(frame, text_frame)][0])
+        return f"{frame} {text_frame}"
 
     def __enter__(self: T) -> T:
         if self.enabled:

--- a/src/tox/util/spinner.py
+++ b/src/tox/util/spinner.py
@@ -1,6 +1,7 @@
 """A minimal non-colored version of https://pypi.org/project/halo, to track list progress"""
 import os
 import sys
+import textwrap
 import threading
 import time
 from collections import OrderedDict
@@ -83,8 +84,7 @@ class Spinner:
         self._frame_index %= len(self.frames)
         total = f"/{self.total}" if self.total is not None else ""
         text_frame = f"[{len(self._envs)}{total}] {' | '.join(self._envs)}"
-        if len(text_frame) > self.max_width - 1:
-            text_frame = "{}...".format(text_frame[: self.max_width - 1 - 3])
+        text_frame = textwrap.shorten(text_frame, width=self.max_width - 1, placeholder="...")
         return f"{frame} {text_frame}"
 
     def __enter__(self: T) -> T:

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -12,7 +12,7 @@ from tox.pytest import MonkeyPatch, ToxProjectCreator
 
 def test_show_config_default_run_env(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
     py_ver = sys.version_info[0:2]
-    name = "py{}{}".format(*py_ver) if platform.python_implementation() == "CPython" else "pypy3"
+    name = f"py{py_ver[0]}{py_ver[1]}" if platform.python_implementation() == "CPython" else "pypy3"
     project = tox_project({"tox.ini": f"[tox]\nenv_list = {name}\n[testenv:{name}]\ncommands={{posargs}}"})
     result = project.run("c", "-e", name, "--core", "--", "magic")
     state = result.state

--- a/tests/util/test_spinner.py
+++ b/tests/util/test_spinner.py
@@ -21,8 +21,8 @@ def test_spinner(capfd: CaptureFixture, monkeypatch: MonkeyPatch) -> None:
         spin.stream.write("\n")
     out, err = capfd.readouterr()
     lines = out.split("\n")
-    expected = [f"\r{spin.CLEAR_LINE}\r{i} [0] " for i in spin.frames] + [
-        f"\r{spin.CLEAR_LINE}\r{spin.frames[0]} [0] ",
+    expected = [f"\r{spin.CLEAR_LINE}\r{i} [0]" for i in spin.frames] + [
+        f"\r{spin.CLEAR_LINE}\r{spin.frames[0]} [0]",
         f"\r{spin.CLEAR_LINE}",
     ]
     assert lines == expected
@@ -63,7 +63,7 @@ def test_spinner_atty(capfd: CaptureFixture, monkeypatch: MonkeyPatch) -> None:
     lines = out.split("\n")
     posix = os.name == "posix"
     expected = [
-        "{}\r{}\r{} [0] ".format("\x1b[?25l" if posix else "", spin.CLEAR_LINE, spin.frames[0]),
+        "{}\r{}\r{} [0]".format("\x1b[?25l" if posix else "", spin.CLEAR_LINE, spin.frames[0]),
         "\r\x1b[K{}".format("\x1b[?25h" if posix else ""),
     ]
     assert lines == expected
@@ -104,7 +104,7 @@ def test_spinner_long_text(capfd: CaptureFixture, monkeypatch: MonkeyPatch) -> N
     out, err = capfd.readouterr()
     assert not err
     expected = [
-        f"\r{spin.CLEAR_LINE}\r{spin.frames[1]} [2] {'a' * 60} | {'b' * 49}...",
+        f"\r{spin.CLEAR_LINE}\r{spin.frames[1]} [2] {'a' * 60} |...",
         f"\r{spin.CLEAR_LINE}",
     ]
     lines = out.split("\n")


### PR DESCRIPTION
Replace most of the `.format` calls with proper f-strings. Left `.format` where backslashes or complex escapes were used.

The second commit shortens the line using explicit `textwrap.shorten` instead of trivial string slicing. This may deliver different results because it cuts off whole words and not individual characters.  

Fixes #2012 