### PR TITLE
Docs: define which files to keep py2 compatible

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -96,6 +96,11 @@ Code style guide
 
 - First and foremost, the linters configured for the project must pass; this generally means following PEP-8 rules,
   as codified by: ``flake8``, ``black``, ``isort``, ``pyupgrade``.
+- The supported Python versions (and the code syntax to use) are listed in the ``setup.cfg`` file
+  in the ``options/python_requires`` entry. However, there are some files that have to be kept compatible
+  with Python 2.7 to allow and test for running Python 2 envs from tox. They are listed in ``.pre-commit-config.yaml``
+  under ``repo: https://github.com/asottile/pyupgrade`` under ``hooks/exclude``.
+  Please do not attempt to modernize them to Python 3.x.
 - Packaging options should be specified within ``setup.cfg``; ``setup.py`` is only kept for editable installs.
 - All code (tests too) must be type annotated as much as required by ``mypy``.
 - We use a line length of 120.

--- a/src/tox/util/pep517/backend.py
+++ b/src/tox/util/pep517/backend.py
@@ -1,4 +1,8 @@
-"""Handles communication on the backend side between frontend and backend"""
+"""Handles communication on the backend side between frontend and backend
+
+Please keep this file Python 2.7 compatible.
+See https://tox.readthedocs.io/en/rewrite/development.html#code-style-guide
+"""
 from __future__ import print_function, unicode_literals
 
 import json

--- a/tests/demo_pkg_inline/build.py
+++ b/tests/demo_pkg_inline/build.py
@@ -1,3 +1,8 @@
+"""
+Please keep this file Python 2.7 compatible.
+See https://tox.readthedocs.io/en/rewrite/development.html#code-style-guide
+"""
+
 import os
 import sys
 import tarfile


### PR DESCRIPTION
Code style tells which Python versions code syntax should be used in which files, referring to the relevant configuration files (single point of truth docs).

Fixes #2013 