### PR TITLE
fix setenv usages in documentation examples

### DIFF
--- a/docs/changelog/1999.doc.rst
+++ b/docs/changelog/1999.doc.rst
@@ -1,2 +1,2 @@
-Examples in documentation use ``setenv`` correctly (in ``[testenv]`` sections, not in ``[tox]``).
+Update examples in the documentation to use ``setenv`` in the ``[testenv]`` sections, not wrongly in the ``[tox]`` main section.
 - by :user:`AndreyNautilus`

--- a/docs/changelog/1999.doc.rst
+++ b/docs/changelog/1999.doc.rst
@@ -1,0 +1,2 @@
+Examples in documentation use ``setenv`` correctly (in ``[testenv]`` sections, not in ``[tox]``).
+- by :user:`AndreyNautilus`

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -209,7 +209,7 @@ our index server at ``https://mypypiserver.org`` URL.
 
   Using an extra PyPI index for installing private packages may cause security issues.
   For example, if ``mypackage`` is registered with the default PyPI index, pip will install ``mypackage``
-  from default PyPI index, not from custom one.
+  from the default PyPI index, not from the custom one.
 
 Further customizing installation
 ---------------------------------

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -172,7 +172,7 @@ This variable can be also set in ``tox.ini``:
 
 .. code-block:: ini
 
-    [tox]
+    [testenv]
     setenv =
         PIP_INDEX_URL = https://pypi.my-alternative-index.org
 
@@ -180,7 +180,7 @@ Alternatively, a configuration where ``PIP_INDEX_URL`` could be overriden from e
 
 .. code-block:: ini
 
-    [tox]
+    [testenv]
     setenv =
         PIP_INDEX_URL = {env:PIP_INDEX_URL:https://pypi.my-alternative-index.org}
 
@@ -192,11 +192,9 @@ multiple PyPI servers, using ``PIP_EXTRA_INDEX_URL`` environment variable:
 
 .. code-block:: ini
 
-    [tox]
+    [testenv]
     setenv =
         PIP_EXTRA_INDEX_URL = https://mypypiserver.org
-
-    [testenv]
     deps =
         # docutils will be installed directly from PyPI
         docutils
@@ -204,8 +202,14 @@ multiple PyPI servers, using ``PIP_EXTRA_INDEX_URL`` environment variable:
         mypackage
 
 This configuration will install ``docutils`` from the default
-Python PYPI server and will install the ``mypackage`` from
+Python PyPI server and will install the ``mypackage`` from
 our index server at ``https://mypypiserver.org`` URL.
+
+.. warning::
+
+  Using an extra PyPI index as a fallback for installing private packages may cause security issues.
+  For example, if ``mypackage`` is registered in the default PyPI index, PIP will install ``mypackage``
+  from default PyPI index, not from custom one.
 
 Further customizing installation
 ---------------------------------

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -207,7 +207,7 @@ our index server at ``https://mypypiserver.org`` URL.
 
 .. warning::
 
-  Using an extra PyPI index as a fallback for installing private packages may cause security issues.
+  Using an extra PyPI index for installing private packages may cause security issues.
   For example, if ``mypackage`` is registered in the default PyPI index, PIP will install ``mypackage``
   from default PyPI index, not from custom one.
 

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -208,7 +208,7 @@ our index server at ``https://mypypiserver.org`` URL.
 .. warning::
 
   Using an extra PyPI index for installing private packages may cause security issues.
-  For example, if ``mypackage`` is registered in the default PyPI index, PIP will install ``mypackage``
+  For example, if ``mypackage`` is registered with the default PyPI index, pip will install ``mypackage``
   from default PyPI index, not from custom one.
 
 Further customizing installation


### PR DESCRIPTION
## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
