### PR TITLE
Explain how CLI verbosity level gets determined

### DIFF
--- a/docs/changelog/2005.doc.rst
+++ b/docs/changelog/2005.doc.rst
@@ -1,0 +1,1 @@
+Explain how ``-v`` and ``-q`` flags play together to determine CLI verbosity level - by :user:`jugmac00`.

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -236,9 +236,12 @@ class ToxParser(ArgumentParserWithEnvAndConfig):
 def add_verbosity_flags(parser: ArgumentParser) -> None:
     from tox.report import LEVELS
 
-    level_map = "|".join(f"{c} - {logging.getLevelName(l)}" for c, l in sorted(LEVELS.items()))
+    level_map = "|".join(f"{c}={logging.getLevelName(l)}" for c, l in sorted(LEVELS.items()))
     verbosity_group = parser.add_argument_group("verbosity")
-    verbosity_group.description = f"verbosity=verbose-quiet, default {logging.getLevelName(LEVELS[3])}, map {level_map}"
+    verbosity_group.description = (
+        f"every -v increases, every -q decreases verbosity level, "
+        f"default {logging.getLevelName(LEVELS[3])}, map {level_map}"
+    )
     verbosity = verbosity_group.add_mutually_exclusive_group()
     verbosity.add_argument(
         "-v", "--verbose", action="count", dest="verbose", help="increase verbosity", default=DEFAULT_VERBOSITY


### PR DESCRIPTION
This fixes #2005

Before this change it was not entirely obvious from the description, that you can use more than one `-v` and `-q` flag.
See #2005 for more context.

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [ x added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
