### PR TITLE
Fix regex validation for SHA 512 hashes

### DIFF
--- a/docs/changelog/2018.bugfix.rst
+++ b/docs/changelog/2018.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regex validation for SHA 512 hashes - by :user:`jugmac00`.

--- a/src/tox/tox_env/python/pip/req/args.py
+++ b/src/tox/tox_env/python/pip/req/args.py
@@ -49,7 +49,7 @@ def _req_options(parser: ArgumentParser, cli_only: bool) -> None:
         parser.add_argument("--hash", action=AddSortedUniqueAction, type=_validate_hash)
 
 
-_HASH = re.compile(r"sha(256:[a-z0-9]{64}|384:[a-z0-9]{96}|521:[a-z0-9]{128})")
+_HASH = re.compile(r"sha(256:[a-z0-9]{64}|384:[a-z0-9]{96}|512:[a-z0-9]{128})")
 
 
 def _validate_hash(value: str) -> str:

--- a/tests/tox_env/python/pip/req/test_file.py
+++ b/tests/tox_env/python/pip/req/test_file.py
@@ -196,6 +196,16 @@ from tox.tox_env.python.pip.req.file import ParsedRequirement, RequirementsFile
             ],
             id="hash with escaped newline",
         ),
+        pytest.param(
+            "attrs --hash=sha512:7a91e5a3d1a1238525e477385ef5ee6cecdc8f8fcc2a79d1b35a9f57ad15c814"
+            "dada670026f41fdd62e5e10b3fd75d6112704a9521c3df105f0b6f3bb11b128a",
+            {},
+            [
+                "attrs --hash sha512:7a91e5a3d1a1238525e477385ef5ee6cecdc8f8fcc2a79d1b35a9f57ad15c814"
+                "dada670026f41fdd62e5e10b3fd75d6112704a9521c3df105f0b6f3bb11b128a"
+            ],
+            id="sha512 hash is supported",
+        ),
     ],
 )
 def test_req_file(tmp_path: Path, req: str, opts: Dict[str, Any], requirements: List[str]) -> None:


### PR DESCRIPTION
The regex searched for `521` instead of `512`.

Closes #2018

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)