### PR TITLE
Replace `chain.from_iterable` with double comprehensions

### DIFF
--- a/src/tox/config/loader/ini/factor.py
+++ b/src/tox/config/loader/ini/factor.py
@@ -2,14 +2,12 @@
 Expand tox factor expressions to tox environment list.
 """
 import re
-from itertools import chain, groupby, product
+from itertools import groupby, product
 from typing import Iterator, List, Optional, Tuple
 
 
 def filter_for_env(value: str, name: Optional[str]) -> str:
-    current = (
-        set(chain.from_iterable([(i for i, _ in a) for a in find_factor_groups(name)])) if name is not None else set()
-    )
+    current = set() if name is None else {i for a in find_factor_groups(name) for i, _ in a}
     overall = []
     for factors, content in expand_factors(value):
         if factors is None:

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -1,7 +1,6 @@
 """Convert string configuration values to tox python configuration objects."""
 import shlex
 import sys
-from itertools import chain
 from pathlib import Path
 from typing import Any, Iterator, List, Tuple, Type
 
@@ -64,7 +63,8 @@ class StrConvert(Convert[str]):
     def to_env_list(value: str) -> EnvList:
         from tox.config.loader.ini.factor import extend_factors
 
-        elements = list(chain.from_iterable(extend_factors(expr) for expr in value.split("\n")))
+        elements = [elem for expr in value.split("\n") for elem in extend_factors(expr)]
+
         return EnvList(elements)
 
     TRUTHFUL_VALUES = {"true", "1", "yes", "on"}

--- a/src/tox/config/source/ini.py
+++ b/src/tox/config/source/ini.py
@@ -1,7 +1,6 @@
 """Load """
 from abc import ABC
 from configparser import ConfigParser
-from itertools import chain
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set
 
@@ -109,7 +108,7 @@ class IniSource(Source, ABC):
                 if not is_base_section:
                     yield name
                 if known_factors is None:
-                    known_factors = set(chain.from_iterable(e.split("-") for e in explicit))
+                    known_factors = {factor for e in explicit for factor in e.split("-")}
                 yield from self._discover_from_section(section, known_factors)
 
     def _discover_from_section(self, section: str, known_factors: Set[str]) -> Iterator[str]:

--- a/tests/pytest_/test_init.py
+++ b/tests/pytest_/test_init.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from itertools import chain, combinations
+from itertools import combinations
 from pathlib import Path
 from textwrap import dedent
 from typing import List, Sequence
@@ -35,7 +35,7 @@ def test_tox_project_base(tmp_path: Path, tox_project: ToxProjectCreator) -> Non
     assert project.structure
 
 
-COMB = list(chain.from_iterable(combinations(["DIFF", "MISS", "EXTRA"], i) for i in range(4)))
+COMB = [comb for i in range(4) for comb in combinations(["DIFF", "MISS", "EXTRA"], i)]
 
 
 @pytest.mark.parametrize("ops", COMB, ids=["-".join(i) for i in COMB])


### PR DESCRIPTION
This is just a follow-up of an off-record discussion with @jugmac00 about `itertools.chain.from_iterable`.

Maybe you'll like the double comprehensions syntax more.
