### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ For now reach out to [Bernat Gabor](https://github.com/gaborbernat/) directly.
 
 Contributions are welcome, though expect a lot of rough edges at this early point of development. See
 [contributing](https://github.com/tox-dev/tox/blob/master/CONTRIBUTING.rst) and our
-[Contributor Covenant Code of Conduct](https://github.com/tox-dev/tox/blob/master/CODE_OF_CONDUCT.md). Currently the
-[code](https://github.com/tox-dev/tox) and the [issues](https://github.com/tox-dev/tox/issues) are hosted on Github. The
+[Contributor Covenant Code of Conduct](https://github.com/tox-dev/tox/blob/master/CODE_OF_CONDUCT.md). Currently, the
+[code](https://github.com/tox-dev/tox) and the [issues](https://github.com/tox-dev/tox/issues) are hosted on GitHub. The
 project is licensed under [MIT](https://github.com/tox-dev/tox/blob/master/LICENSE).

--- a/src/tox/pytest.py
+++ b/src/tox/pytest.py
@@ -501,7 +501,7 @@ class IndexServer:
                     for _ in stdout:
                         pass
 
-                # important to keep draining the stdout, otherwise once the buffer is full Windows blocks the processg s
+                # important to keep draining the stdout, otherwise once the buffer is full Windows blocks the process
                 self._stdout_drain = Thread(target=_keep_draining, name="tox-test-stdout-drain")
                 self._stdout_drain.start()
                 break

--- a/tests/journal/test_main_journal.py
+++ b/tests/journal/test_main_journal.py
@@ -24,7 +24,7 @@ def test_journal_enabled_default(base_info: Dict[str, Any]) -> None:
     assert journal.content == base_info
 
 
-def test_journal_disabed_default() -> None:
+def test_journal_disabled_default() -> None:
     journal = Journal(enabled=False)
     assert bool(journal) is False
     assert journal.content == {}

--- a/tests/tox_env/python/test_python_runner.py
+++ b/tests/tox_env/python/test_python_runner.py
@@ -74,7 +74,7 @@ def test_journal_multiple_wheel_file(tmp_path: Path) -> None:
     }
 
 
-def test_journal_packge_dir(tmp_path: Path) -> None:
+def test_journal_package_dir(tmp_path: Path) -> None:
     journal = EnvJournal(enabled=True, name="a")
 
     PythonRun._handle_journal_package(journal, [PathPackage(tmp_path)])

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -59,7 +59,6 @@ devenv
 DEVNULL
 devpi
 dirname
-disabed
 divmod
 docutils
 DOTALL
@@ -146,7 +145,6 @@ nox
 num
 objtype
 ov
-packge
 param
 parsers
 pathlib
@@ -164,7 +162,6 @@ prepend
 prereleases
 prj
 proc
-processg
 prog
 proj
 psutil


### PR DESCRIPTION
Fixed some typos in the docs, comments, and test function names.

Some of these misspelled words were previously accidentally added to the `whitelist.txt` file to satisfy `flake8-spellcheck`. Cleaned them up as well.