### PR TITLE
Assure listing commands can produce machine readable output

### DIFF
--- a/docs/changelog/2030.bugfix.rst
+++ b/docs/changelog/2030.bugfix.rst
@@ -1,0 +1,3 @@
+``tox --showconfig``, ``-a`` and ``-l`` primary output is no longer affected
+by the logging level. Allows users to add ``-qq`` to make output machine
+parseable output (no pollution from the logging). - by :user:`ssbarnea`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -446,19 +446,21 @@ def tox_addoption(parser):
         "--showconfig",
         action="store_true",
         help="show live configuration (by default all env, with -l only default targets,"
-        " specific via TOXENV/-e)",
+        " specific via TOXENV/-e). Add -qq to ensure is machine-readable",
     )
     parser.add_argument(
         "-l",
         "--listenvs",
         action="store_true",
-        help="show list of test environments (with description if verbose)",
+        help="show list of test environments (with description if verbose),"
+        " combine with -qq to ensure output is machine-readable",
     )
     parser.add_argument(
         "-a",
         "--listenvs-all",
         action="store_true",
-        help="show list of all defined environments (with description if verbose)",
+        help="show list of all defined environments (with description if verbose),"
+        " combine with -qq to ensure output is machine-readable",
     )
     parser.add_argument(
         "-c",

--- a/src/tox/session/__init__.py
+++ b/src/tox/session/__init__.py
@@ -181,7 +181,9 @@ class Session(object):
         reporter.using(
             "tox-{} from {} (pid {})".format(tox.__version__, tox.__file__, os.getpid()),
         )
-        show_description = reporter.has_level(reporter.Verbosity.DEFAULT)
+        # We display description if verbosity was increase but ignoring value
+        # of quiet_level. Needed in order to produce machine readable output.
+        show_description = self.config.option.verbose_level > 0
         if self.config.run_provision:
             provision_tox_venv = self.getvenv(self.config.provision_tox_env)
             return provision_tox(provision_tox_venv, self.config.args)

--- a/src/tox/session/commands/show_config.py
+++ b/src/tox/session/commands/show_config.py
@@ -29,7 +29,10 @@ def show_config(config):
     content = StringIO()
     parser.write(content)
     value = content.getvalue().rstrip()
-    reporter.verbosity0(value)
+    # We are not using the reporter because showconfig result should not be
+    # affected by logging level as its stdout output *is* expected to
+    # be machine parseable.
+    print(value)
 
 
 def tox_envs_info(config, parser):

--- a/src/tox/session/commands/show_env.py
+++ b/src/tox/session/commands/show_env.py
@@ -10,7 +10,7 @@ def show_envs(config, all_envs=False, description=False):
     extra = [e for e in env_conf if e not in ignore] if all_envs else []
 
     if description and default:
-        report.line("default environments:")
+        report.verbosity0("default environments:")
     max_length = max(len(env) for env in (default + extra) or [""])
 
     def report_env(e):
@@ -19,14 +19,17 @@ def show_envs(config, all_envs=False, description=False):
             msg = "{} -> {}".format(e.ljust(max_length), text).strip()
         else:
             msg = e
-        report.line(msg)
+        # Avoiding reporter because that is the result of program execution,
+        # and we do not want to be affected by logging level.
+        print(msg)
 
     for e in default:
         report_env(e)
     if all_envs and extra:
         if description:
+            # breakpoint()
             if default:
-                report.line("")
-            report.line("additional environments:")
+                report.verbosity0("")
+            report.verbosity0("additional environments:")
         for e in extra:
             report_env(e)


### PR DESCRIPTION
* Assures we use print() when displaying output using `-a`, `-l` or `--showconfig`, which are all commands that should not be affected by the currently configured logging level. 
* Documents the fact that `-qq` is needed if user expects to be able to parse output of these commands.
* Not updating the tests because v3 is near its EOL and testing for side-effects that happen when .tox folder does not
  exist would require significant effort (linked bug happened only when tox own env needed to be recreated).

Fixes: #2030