### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -59,6 +59,7 @@ Joshua Hesketh
 Julian Krause
 Jürgen Gmach
 Jurko Gospodnetić
+Karthikeyan Singaravelan
 Krisztian Fekete
 Laszlo Vasko
 Lukasz Balcerzak

--- a/src/tox/util/spinner.py
+++ b/src/tox/util/spinner.py
@@ -84,7 +84,7 @@ class Spinner(object):
         self.render_frame()
         self._stop_spinner = threading.Event()
         self._spinner_thread = threading.Thread(target=self.render)
-        self._spinner_thread.setDaemon(True)
+        self._spinner_thread.daemon = True
         self._spinner_thread.start()
         return self
 


### PR DESCRIPTION
## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [ ] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
