### PR TITLE
Fail if Specified Interpreter Not Found

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -46,6 +46,7 @@ Igor Duarte Cardoso
 Ilya Kulakov
 Ionel Maries Cristian
 Itxaka Serrano
+Jack Desert
 Jake Windle
 Jannis Leidel
 Jesse Schwartzentruber

--- a/src/tox/interpreters/unix.py
+++ b/src/tox/interpreters/unix.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
+import sys
 
+from tox import reporter
 import tox
 
 from .common import base_discover
@@ -8,12 +10,15 @@ from .via_path import check_with_path
 
 @tox.hookimpl
 def tox_get_python_executable(envconfig):
+    """
+    Return path to specified interpreter.
+    If not available, exit(1).
+    """
     spec, path = base_discover(envconfig)
-    if path is not None:
+
+    if path is None:
+        reporter.error('envname {} not found'.format(envconfig.envname))
+        sys.exit(1)
+    else:
         return path
-    # 3. check if the literal base python
-    candidates = [envconfig.basepython]
-    # 4. check if the un-versioned name is good
-    if spec.name is not None and spec.name != envconfig.basepython:
-        candidates.append(spec.name)
-    return check_with_path(candidates, spec)
+~

--- a/src/tox/interpreters/unix.py
+++ b/src/tox/interpreters/unix.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
+
 import sys
 
-from tox import reporter
 import tox
+from tox import reporter
 
 from .common import base_discover
 from .via_path import check_with_path


### PR DESCRIPTION
Fail if specified interpreter not found.
(Do NOT use basepython as a fallback)

This is intended to remedy these two github issues:

  https://github.com/tox-dev/tox/issues/882
  https://github.com/tox-dev/tox/issues/1484

In particular, when python3.1 is NOT installed on my machine, using this tox.ini:

```
[tox]
envlist = py3.1

[testenv]
deps = pytest
commands = pytest
```

this pull request makes is so that tox fails.

(Without this commit, tox runs pytest using the same python interpreter that was used to invoke tox.
In my opinion it is more helpful to fail than to run tests with a different-than-intended interpreter.)

If this pull request seems generally useful, let me know what it would take to get it accepted. (It broke several tests, for example.) 
