### PR TITLE
Remove redundant character escape in some regexes

### DIFF
--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -61,9 +61,9 @@ SUICIDE_TIMEOUT = 0.0
 INTERRUPT_TIMEOUT = 0.3
 TERMINATE_TIMEOUT = 0.2
 
-_FACTOR_LINE_PATTERN = re.compile(r"^([\w{}\.!,-]+)\:\s+(.+)")
-_ENVSTR_SPLIT_PATTERN = re.compile(r"((?:\{[^}]+\})+)|,")
-_ENVSTR_EXPAND_PATTERN = re.compile(r"\{([^}]+)\}")
+_FACTOR_LINE_PATTERN = re.compile(r"^([\w{}.!,-]+):\s+(.+)")
+_ENVSTR_SPLIT_PATTERN = re.compile(r"((?:{[^}]+})+)|,")
+_ENVSTR_EXPAND_PATTERN = re.compile(r"{([^}]+)}")
 _WHITESPACE_PATTERN = re.compile(r"\s+")
 
 
@@ -1412,7 +1412,7 @@ class ParseIni(object):
         factors = set()
         if section in self._cfg:
             for _, value in self._cfg[section].items():
-                exprs = re.findall(r"^([\w{}\.!,-]+)\:\s+", value, re.M)
+                exprs = re.findall(r"^([\w{}.!,-]+):\s+", value, re.M)
                 factors.update(*mapcat(_split_factor_expr_all, exprs))
         return factors
 
@@ -1536,7 +1536,7 @@ class ParseIni(object):
         The parser will see it as two different sections: [testenv:py36-cov], [testenv:py37-cov]
 
         """
-        factor_re = re.compile(r"\{\s*([\w\s,-]+)\s*\}")
+        factor_re = re.compile(r"{\s*([\w\s,-]+)\s*}")
         split_re = re.compile(r"\s*,\s*")
         to_remove = set()
         for section in list(config.sections):

--- a/src/tox/package/local.py
+++ b/src/tox/package/local.py
@@ -49,7 +49,7 @@ def get_latest_version_of_package(package_spec):
         return candidates[0]
 
 
-_REGEX_FILE_NAME_WITH_VERSION = re.compile(r"[\w_\-\+\.]+-(.*)\.(zip|tar\.gz)")
+_REGEX_FILE_NAME_WITH_VERSION = re.compile(r"[\w_\-+.]+-(.*)\.(zip|tar\.gz)")
 
 
 def get_version_from_filename(basename):

--- a/src/tox/package/local.py
+++ b/src/tox/package/local.py
@@ -49,7 +49,7 @@ def get_latest_version_of_package(package_spec):
         return candidates[0]
 
 
-_REGEX_FILE_NAME_WITH_VERSION = re.compile(r"[\w_\-+.]+-(.*)\.(zip|tar\.gz)")
+_REGEX_FILE_NAME_WITH_VERSION = re.compile(r"[\w_+.-]+-(.*)\.(zip|tar\.gz)")
 
 
 def get_version_from_filename(basename):


### PR DESCRIPTION
I observed that some regexes were hard to read because they had unnecessary escaping, so I cleaned them up.

After that, I run the tests and all passed. Let me know if there's anything you want to discuss. :)