### PR TITLE
Fix when there is no 4th arg passed to build_isolated

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,7 @@ Andrii Soldatenko
 Andrzej Klajnert
 Anthon van der Neuth
 Anthony Sottile
+Antoine Dechaume
 Anudit Nagar
 Ashley Whetter
 Asmund Grammeltwedt

--- a/docs/changelog/2056.bugfix.rst
+++ b/docs/changelog/2056.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a ``tox-conda`` isolation build bug - by :user:`AntoineD`.

--- a/src/tox/helper/build_isolated.py
+++ b/src/tox/helper/build_isolated.py
@@ -29,7 +29,7 @@ def _ensure_module_in_paths(module, paths):
 dist_folder = sys.argv[1]
 backend_spec = sys.argv[2]
 backend_obj = sys.argv[3] if len(sys.argv) >= 4 else None
-backend_paths = sys.argv[4].split(os.path.pathsep) if sys.argv[4] else []
+backend_paths = sys.argv[4].split(os.path.pathsep) if (len(sys.argv) >= 5 and sys.argv[4]) else []
 
 sys.path[:0] = backend_paths
 

--- a/tests/unit/package/builder/test_package_builder_isolated.py
+++ b/tests/unit/package/builder/test_package_builder_isolated.py
@@ -1,8 +1,10 @@
 import os
+import subprocess
 
 import py
 import pytest
 
+import tox.helper
 from tox.package.builder.isolated import get_build_info
 from tox.reporter import _INSTANCE
 
@@ -193,3 +195,10 @@ def test_verbose_isolated_build_in_tree(initproj, mock_venv, cmd):
     assert "running sdist" in result.out, result.out
     assert "running egg_info" in result.out, result.out
     assert "Writing example123-0.5{}setup.cfg".format(os.sep) in result.out, result.out
+
+
+def test_isolated_build_script_args(tmp_path):
+    """Verify that build_isolated.py can be called with only 2 argurments."""
+    # cannot import build_isolated because of its side effects
+    script_path = os.path.join(os.path.dirname(tox.helper.__file__), "build_isolated.py")
+    subprocess.check_call(("python", script_path, str(tmp_path), "setuptools.build_meta"))


### PR DESCRIPTION
This fixes a [tox-conda issue](https://github.com/tox-dev/tox-conda/issues/75) with isolated build.
The command calling `build_isolated.py` is passed to the command `conda run` which seems to remove the empty arguments. Contrary to the 3rd argument, the 4th argument was not checked for existence in `build_isolated.py` before being used.

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [X] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [X] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
