### PR TITLE
Do not modify provisioned envdir when --devenv is specified

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -47,6 +47,7 @@ Ian Stapleton Cordasco
 Igor Duarte Cardoso
 Ilya Kulakov
 Ionel Maries Cristian
+Isaac Pedisich
 Itxaka Serrano
 Jake Windle
 Jannis Leidel

--- a/docs/changelog/2065.bugfix.rst
+++ b/docs/changelog/2065.bugfix.rst
@@ -1,0 +1,1 @@
+``--devenv`` no longer modifies the directory in which the ``.tox`` environment is provisioned - by :user:`isaac-ped`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -595,7 +595,10 @@ def tox_addoption(parser):
     )
 
     def _set_envdir_from_devenv(testenv_config, value):
-        if testenv_config.config.option.devenv is not None and testenv_config.envname != ".tox":
+        if (
+            testenv_config.config.option.devenv is not None
+            and testenv_config.envname != testenv_config.config.provision_tox_env
+        ):
             return py.path.local(testenv_config.config.option.devenv)
         else:
             return value

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -595,7 +595,7 @@ def tox_addoption(parser):
     )
 
     def _set_envdir_from_devenv(testenv_config, value):
-        if testenv_config.config.option.devenv is not None:
+        if testenv_config.config.option.devenv is not None and testenv_config.envname != ".tox":
             return py.path.local(testenv_config.config.option.devenv)
         else:
             return value

--- a/tests/unit/session/test_provision.py
+++ b/tests/unit/session/test_provision.py
@@ -385,3 +385,20 @@ def space_path2url(path):
     if " " not in at_path:
         return at_path
     return urljoin("file:", pathname2url(os.path.abspath(at_path)))
+
+
+def test_provision_does_not_occur_in_devenv(newconfig, next_tox_major):
+    """Adding --devenv should not change the directory where provisioning occurs"""
+    with pytest.raises(MissingRequirement) as context:
+        newconfig(
+            ["--devenv", "my_devenv"],
+            """\
+            [tox]
+            minversion = {}
+            """.format(
+                next_tox_major,
+            ),
+        )
+    config = context.value.config
+    assert config.run_provision is True
+    assert config.envconfigs[".tox"].envdir.basename != "my_devenv"


### PR DESCRIPTION
This change prevents `--devenv` from changing the envdir for the `.tox` environment

Fixes tox-dev/tox#2065

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
