### PR TITLE
Use correct syntax for Sphinx roles

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -636,7 +636,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
     .. versionadded:: 3.15.2
 
     When an interrupt is sent via Ctrl+C or the tox process is killed with a SIGTERM,
-    a SIGINT is sent to all foreground processes. The :conf:``suicide_timeout`` gives
+    a SIGINT is sent to all foreground processes. The :conf:`suicide_timeout` gives
     the running process time to cleanup and exit before receiving (in some cases, a duplicate) SIGINT from
     tox.
 
@@ -645,17 +645,17 @@ Complete list of settings that you can put into ``testenv*`` sections:
     .. versionadded:: 3.15.0
 
     When tox is interrupted, it propagates the signal to the child process
-    after :conf:``suicide_timeout`` seconds. If the process still hasn't exited
-    after :conf:``interrupt_timeout`` seconds, its sends a SIGTERM.
+    after :conf:`suicide_timeout` seconds. If the process still hasn't exited
+    after :conf:`interrupt_timeout` seconds, its sends a SIGTERM.
 
 .. conf:: terminate_timeout ^ float ^ 0.2
 
     .. versionadded:: 3.15.0
 
-    When tox is interrupted, after waiting :conf:``interrupt_timeout`` seconds,
+    When tox is interrupted, after waiting :conf:`interrupt_timeout` seconds,
     it propagates the signal to the child process, waits
-    :conf:``interrupt_timeout`` seconds, sends it a SIGTERM, waits
-    :conf:``terminate_timeout`` seconds, and sends it a SIGKILL if it hasn't
+    :conf:`interrupt_timeout` seconds, sends it a SIGTERM, waits
+    :conf:`terminate_timeout` seconds, and sends it a SIGKILL if it hasn't
     exited.
 
 Substitutions


### PR DESCRIPTION
The current syntax doesn't render properly: 
![image](https://user-images.githubusercontent.com/8050853/120895847-bdc02b00-c616-11eb-9212-c3801a955665.png)

Sphinx is treating the text in double backticks as being code and leaves the role name as-is.


## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
