### PR TITLE
remove wrong example from documentation

### DIFF
--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -133,13 +133,6 @@ or
 .. code-block:: ini
 
     [testenv]
-    deps = -cconstraints.txt
-
-or
-
-.. code-block:: ini
-
-    [testenv]
     deps =
         -rrequirements.txt
         -cconstraints.txt


### PR DESCRIPTION
It does not work to only provide constraints, as they only apply to
specified dependencies.