### PR TITLE
Produce runtime error when common skipdist typo is found in config

### DIFF
--- a/docs/changelog/2093.bugfix.rst
+++ b/docs/changelog/2093.bugfix.rst
@@ -1,0 +1,1 @@
+Detect typo ``skipdist`` in config and suggest use of ``skipsdist`` - by :user:`ssbarnea`.

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1306,6 +1306,10 @@ class ParseIni(object):
             for name in config.envlist
         )
 
+        if reader.getstring("skipdist", None) is not None:
+            raise tox.exception.ConfigError(
+                "Found use of 'skipdist', correct it to 'skipsdist' or remove it."
+            )
         config.skipsdist = reader.getbool("skipsdist", all_develop)
 
         if config.option.devenv is not None:


### PR DESCRIPTION
Avoids a very common mistake when writing tox config, use of skipdist
instead of skipsdist.

This should help tox users wonder why tox misbehaves when they were
supposed to skip installing the source dist.

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
