### PR TITLE
Use sysconfig instead of distutils for Python 3.10 compatability

### DIFF
--- a/docs/changelog/2100.misc.rst
+++ b/docs/changelog/2100.misc.rst
@@ -1,0 +1,2 @@
+``tox`` no longer shows deprecation warnings for ``distutils.sysconfig`` on
+Python 3.10 - by :user:`9999years`

--- a/src/tox/helper/get_site_package_dir.py
+++ b/src/tox/helper/get_site_package_dir.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
-import sysconfig
 import json
 import sys
+import sysconfig
 
 data = json.dumps({"dir": sysconfig.get_path("purelib", vars={"base": sys.argv[1]})})
 print(data)

--- a/src/tox/helper/get_site_package_dir.py
+++ b/src/tox/helper/get_site_package_dir.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
-import distutils.sysconfig
+import sysconfig
 import json
 import sys
 
-data = json.dumps({"dir": distutils.sysconfig.get_python_lib(prefix=sys.argv[1])})
+data = json.dumps({"dir": sysconfig.get_path("purelib", vars={"base": sys.argv[1]})})
 print(data)


### PR DESCRIPTION
- `distutils` is deprecated in Python 3.10 and slated for removal in Python 3.12
- `sysconfig` provides the same functionality

This is causing a bunch of warnings when running tox under Python 3.10:

```
> poetry310 run tox -e py310 --recreate
/my-venv-dir/lib/python3.10/site-packages/tox/helper/get_site_package_dir.py:3: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  import distutils.sysconfig
/my-venv-dir/lib/python3.10/site-packages/tox/helper/get_site_package_dir.py:3: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
  import distutils.sysconfig
/my-venv-dir/lib/python3.10/site-packages/tox/helper/get_site_package_dir.py:3: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  import distutils.sysconfig
/my-venv-dir/lib/python3.10/site-packages/tox/helper/get_site_package_dir.py:3: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
  import distutils.sysconfig
.package recreate: my-repo-path/.tox/.package
```