### PR TITLE
Fix show config when package names are not canonical

### DIFF
--- a/docs/changelog/2103.bugfix.rst
+++ b/docs/changelog/2103.bugfix.rst
@@ -1,0 +1,1 @@
+Fix show config when the package names are not in canonical form - by :user:`gaborbernat`.

--- a/src/tox/session/commands/show_config.py
+++ b/src/tox/session/commands/show_config.py
@@ -2,7 +2,6 @@ import sys
 from collections import OrderedDict
 
 from packaging.requirements import Requirement
-from packaging.utils import canonicalize_name
 from six import StringIO
 from six.moves import configparser
 
@@ -65,16 +64,15 @@ def version_info(parser):
     while to_visit:
         current = to_visit.pop()
         current_dist = importlib_metadata.distribution(current)
-        current_name = canonicalize_name(current_dist.metadata["name"])
+        current_name = current_dist.metadata["name"]
         versions[current_name] = current_dist.version
         if current_dist.requires is not None:
             for require in current_dist.requires:
                 pkg = Requirement(require)
-                pkg_name = canonicalize_name(pkg.name)
                 if (
                     pkg.marker is None or pkg.marker.evaluate({"extra": ""})
-                ) and pkg_name not in versions:
-                    to_visit.add(pkg_name)
+                ) and pkg.name not in versions:
+                    to_visit.add(pkg.name)
     set_section(parser, "tox:versions", versions)
 
 


### PR DESCRIPTION
After landing https://github.com/pypa/virtualenv/pull/2126 I'm getting:

```bash
[2021-07-13T12:54:28.017Z]     current_dist = importlib_metadata.distribution(current)
[2021-07-13T12:54:28.017Z]   File "/opt/bb/lib/python3.9/importlib/metadata.py", line 524, in distribution
[2021-07-13T12:54:28.017Z]     return Distribution.from_name(distribution_name)
[2021-07-13T12:54:28.017Z]   File "/opt/bb/lib/python3.9/importlib/metadata.py", line 187, in from_name
[2021-07-13T12:54:28.017Z]     raise PackageNotFoundError(name)
[2021-07-13T12:54:28.017Z] importlib.metadata.PackageNotFoundError: backports-entry-points-selectable
```