### PR TITLE
Fix misformed title in changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,8 @@ with advance notice in the **Deprecations** section of releases.
 .. towncrier release notes start
 
 v3.24.0 (2021-07-14)
+--------------------
+
 Bugfixes
 ^^^^^^^^
 


### PR DESCRIPTION
The title of the last release in the changelog is not well rendered because it is not underlined .
