### PR TITLE
`tox -e ALL` now runs all environments as expected

### DIFF
--- a/docs/changelog/2112.bugfix.rst
+++ b/docs/changelog/2112.bugfix.rst
@@ -1,2 +1,1 @@
-Actually run all environments when ``ALL`` is provided
-to the legacy env command - by :user:`jugmac00`.
+Actually run all environments when ``ALL`` is provided to the legacy env command - by :user:`jugmac00`.

--- a/docs/changelog/2112.bugfix.rst
+++ b/docs/changelog/2112.bugfix.rst
@@ -1,0 +1,2 @@
+Actually run all environments when ``ALL`` is provided
+to the legacy env command - by :user:`jugmac00`.

--- a/src/tox/session/common.py
+++ b/src/tox/session/common.py
@@ -8,8 +8,6 @@ class CliEnv:
     def __init__(self, value: Union[None, List[str], str] = None):
         if isinstance(value, str):
             value = StrConvert().to(value, of_type=List[str], kwargs={})
-        self.use_default_list = value is None
-        self.all: bool = value is not None and "ALL" in value
         self._names = value
 
     def __iter__(self) -> Iterator[str]:
@@ -24,13 +22,21 @@ class CliEnv:
         return ",".join(self)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({'' if self.all else repr(self._names)})"
+        return f"{self.__class__.__name__}({'' if self.use_default_list else repr(str(self))})"
 
     def __eq__(self, other: Any) -> bool:
-        return type(self) == type(other) and self.all == other.all and self._names == other._names
+        return type(self) == type(other) and self._names == other._names
 
     def __ne__(self, other: Any) -> bool:
         return not (self == other)
+
+    @property
+    def all(self) -> bool:
+        return "ALL" in self
+
+    @property
+    def use_default_list(self) -> bool:
+        return len(list(self)) == 0
 
 
 def env_list_flag(parser: ArgumentParser, default: Optional[CliEnv] = None) -> None:

--- a/src/tox/session/state.py
+++ b/src/tox/session/state.py
@@ -39,22 +39,19 @@ class State:
 
     def env_list(self, everything: bool = False) -> Iterator[str]:
         fallback_env = "py"
-        if everything:
+        use_env_list: Optional[CliEnv] = getattr(self.options, "env", None)
+        if everything or (use_env_list is not None and use_env_list.all):
             _at = 0
             for _at, env in enumerate(self.conf, start=1):
                 yield env
             if _at == 0:  # if we discovered no other env, inject the default
                 yield fallback_env
             return
-        use_env_list: Optional[CliEnv] = getattr(self.options, "env", None)
-        if use_env_list and "ALL" in use_env_list:
-            use_env_list = CliEnv(list(self.env_list(everything=True)))
-        if use_env_list is None or use_env_list.all:
+        if use_env_list is not None and use_env_list.use_default_list:
             use_env_list = self.conf.core["env_list"]
-        if not use_env_list:
+        if use_env_list is None or bool(use_env_list) is False:
             use_env_list = CliEnv([fallback_env])
-        if use_env_list is not None:  # pragma: no branch # can't happen
-            yield from use_env_list
+        yield from use_env_list
 
     def tox_env(self, name: str) -> RunToxEnv:
         if name in self._pkg_env_discovered:

--- a/src/tox/session/state.py
+++ b/src/tox/session/state.py
@@ -47,6 +47,8 @@ class State:
                 yield fallback_env
             return
         use_env_list: Optional[CliEnv] = getattr(self.options, "env", None)
+        if use_env_list and "ALL" in use_env_list:
+            use_env_list = CliEnv(list(self.env_list(everything=True)))
         if use_env_list is None or use_env_list.all:
             use_env_list = self.conf.core["env_list"]
         if not use_env_list:

--- a/tests/session/cmd/test_legacy.py
+++ b/tests/session/cmd/test_legacy.py
@@ -89,3 +89,29 @@ def test_legacy_run_sequential(tox_project: ToxProjectCreator, mocker: MockerFix
     tox_project({"tox.ini": ""}).run("le", "-e", "py")
 
     assert run_sequential.call_count == 1
+
+
+def test_ensure_all_environments_are_executed(tox_project: ToxProjectCreator) -> None:
+    ini = """
+    [tox]
+    env_list = aaa
+    [testenv]
+    [testenv:bbb]
+    description = not in env_list
+    """
+    setup_py = """
+    from setuptools import setup
+    setup(
+        name='a',
+        version='1.0',
+        install_requires=['setuptools>44'],
+    )
+    """
+    outcome = tox_project(
+        {
+            "tox.ini": ini,
+            "setup.py": setup_py,
+        }
+    ).run("le", "-e", "ALL")
+    assert "aaa: OK" in outcome.out
+    assert "bbb: OK" in outcome.out

--- a/tests/session/cmd/test_legacy.py
+++ b/tests/session/cmd/test_legacy.py
@@ -89,29 +89,3 @@ def test_legacy_run_sequential(tox_project: ToxProjectCreator, mocker: MockerFix
     tox_project({"tox.ini": ""}).run("le", "-e", "py")
 
     assert run_sequential.call_count == 1
-
-
-def test_ensure_all_environments_are_executed(tox_project: ToxProjectCreator) -> None:
-    ini = """
-    [tox]
-    env_list = aaa
-    [testenv]
-    [testenv:bbb]
-    description = not in env_list
-    """
-    setup_py = """
-    from setuptools import setup
-    setup(
-        name='a',
-        version='1.0',
-        install_requires=['setuptools>44'],
-    )
-    """
-    outcome = tox_project(
-        {
-            "tox.ini": ini,
-            "setup.py": setup_py,
-        }
-    ).run("le", "-e", "ALL")
-    assert "aaa: OK" in outcome.out
-    assert "bbb: OK" in outcome.out

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -411,3 +411,10 @@ def test_platform_does_not_match_package_env(tox_project: ToxProjectCreator, dem
     msg = f"skipped because platform {sys.platform} does not match wrong_platform for package environment .pkg"
     assert f"a: {msg}" in result.out
     assert f"b: {msg}" in result.out
+
+
+def test_sequential_run_all(tox_project: ToxProjectCreator) -> None:
+    ini = "[tox]\nenv_list=a\n[testenv]\npackage=skip\n[testenv:b]"
+    outcome = tox_project({"tox.ini": ini}).run("r", "-e", "ALL")
+    assert "a: OK" in outcome.out
+    assert "b: OK" in outcome.out

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -136,12 +136,12 @@ def test_show_config_pkg_env_skip(
 
 def test_show_config_select_only(tox_project: ToxProjectCreator) -> None:
     project = tox_project({"tox.ini": "[tox]\nenv_list=\n a\n b"})
-    result = project.run("c", "-e", "b,.pkg")
+    result = project.run("c", "-e", ".pkg,b,.pkg")
     result.assert_success()
     parser = ConfigParser()
     parser.read_string(result.out)
-    sections = set(parser.sections())
-    assert sections == {"testenv:.pkg", "testenv:b"}
+    sections = list(parser.sections())
+    assert sections == ["testenv:.pkg", "testenv:b"]
 
 
 def test_show_config_alias(tox_project: ToxProjectCreator) -> None:

--- a/tests/session/test_session_common.py
+++ b/tests/session/test_session_common.py
@@ -6,18 +6,14 @@ from tox.session.common import CliEnv
 @pytest.mark.parametrize(
     ("val", "exp"),
     [
-        (CliEnv(["a", "b"]), "CliEnv(['a', 'b'])"),
-        (CliEnv(["ALL", "b"]), "CliEnv()"),
-        (CliEnv([]), "CliEnv([])"),
+        (CliEnv(["a", "b"]), "CliEnv('a,b')"),
+        (CliEnv(["ALL", "b"]), "CliEnv('ALL')"),
+        (CliEnv([]), "CliEnv()"),
+        (CliEnv(), "CliEnv()"),
     ],
 )
 def test_cli_env_repr(val: CliEnv, exp: str) -> None:
     assert repr(val) == exp
-
-
-def test_cli_env_repr_all() -> None:
-    env = CliEnv(["ALL", "b"])
-    assert repr(env) == "CliEnv()"
 
 
 @pytest.mark.parametrize(
@@ -25,7 +21,8 @@ def test_cli_env_repr_all() -> None:
     [
         (CliEnv(["a", "b"]), "a,b"),
         (CliEnv(["ALL", "b"]), "ALL"),
-        (CliEnv([]), ""),
+        (CliEnv([]), "<env_list>"),
+        (CliEnv(), "<env_list>"),
     ],
 )
 def test_cli_env_str(val: CliEnv, exp: str) -> None:


### PR DESCRIPTION
This fixes #2112.

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)