### PR TITLE
Alow backend build system to omit `get_requires_for_build_sdist` hook

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -99,6 +99,7 @@ Philip Thiem
 Pierre-Jean Campigotto
 Pierre-Luc Tessier Gagné
 Prakhar Gurunani
+Rahul Bangar
 Ronald Evers
 Ronny Pfannschmidt
 Ryuichi Ohori

--- a/docs/changelog/2130.bugfix.rst
+++ b/docs/changelog/2130.bugfix.rst
@@ -1,0 +1,1 @@
+``get_requires_for_build_sdist`` hook (PEP 517) is assumed to return an empty list if left unimplemented by the backend build system - by :user:`oczkoisse`

--- a/src/tox/helper/build_requires.py
+++ b/src/tox/helper/build_requires.py
@@ -12,6 +12,13 @@ backend = __import__(backend_spec, fromlist=["_trash"])
 if backend_obj:
     backend = getattr(backend, backend_obj)
 
-for_build_requires = backend.get_requires_for_build_sdist(None)
+try:
+    for_build_requires = backend.get_requires_for_build_sdist(None)
+except AttributeError:
+    # PEP 517 states that get_requires_for_build_sdist is optional for a build
+    # backend object. When the backend object omits it, the default
+    # implementation must be equivalent to return []
+    for_build_requires = []
+
 output = json.dumps(for_build_requires)
 print(output)

--- a/tests/unit/package/builder/test_package_builder_isolated.py
+++ b/tests/unit/package/builder/test_package_builder_isolated.py
@@ -218,7 +218,6 @@ def test_isolated_build_backend_missing_hook(initproj, cmd):
     initproj(
         (name, version),
         filedefs={
-            # pyproject.toml with enscons as backend
             "pyproject.toml": """
             [build-system]
             requires = ["pytoml>=0.1", "enscons==0.26.0"]

--- a/tests/unit/package/builder/test_package_builder_isolated.py
+++ b/tests/unit/package/builder/test_package_builder_isolated.py
@@ -202,3 +202,72 @@ def test_isolated_build_script_args(tmp_path):
     # cannot import build_isolated because of its side effects
     script_path = os.path.join(os.path.dirname(tox.helper.__file__), "build_isolated.py")
     subprocess.check_call(("python", script_path, str(tmp_path), "setuptools.build_meta"))
+
+
+def test_isolated_build_backend_missing_hook(initproj, cmd):
+    """Verify that tox works with a backend missing optional hooks
+
+    PEP 517 allows backends to omit get_requires_for_build_sdist hook, in which
+    case a default implementation that returns an empty list should be assumed
+    instead of raising an error.
+    """
+    name = "ensconsproj"
+    version = "0.1"
+    src_root = "src"
+
+    initproj(
+        (name, version),
+        filedefs={
+            # pyproject.toml with enscons as backend
+            "pyproject.toml": """
+            [build-system]
+            requires = ["pytoml>=0.1", "enscons==0.26.0"]
+            build-backend = "enscons.api"
+
+            [tool.enscons]
+            name = "{name}"
+            version = "{version}"
+            description = "Example enscons project"
+            license = "MIT"
+            packages = ["{name}"]
+            src_root = "{src_root}"
+            """.format(
+                name=name, version=version, src_root=src_root
+            ),
+            "tox.ini": """
+            [tox]
+            isolated_build = true
+            """,
+            "SConstruct": """
+            import enscons
+
+            env = Environment(
+                tools=["default", "packaging", enscons.generate],
+                PACKAGE_METADATA=dict(
+                    name = "{name}",
+                    version = "{version}"
+                ),
+                WHEEL_TAG="py2.py3-none-any"
+            )
+
+            py_source = env.Glob("src/{name}/*.py")
+
+            purelib = env.Whl("purelib", py_source, root="{src_root}")
+            whl = env.WhlFile(purelib)
+
+            sdist = env.SDist(source=FindSourceFiles() + ["PKG-INFO"])
+            env.NoClean(sdist)
+            env.Alias("sdist", sdist)
+
+            develop = env.Command("#DEVELOP", enscons.egg_info_targets(env), enscons.develop)
+            env.Alias("develop", develop)
+
+            env.Default(whl, sdist)
+            """.format(
+                name=name, version=version, src_root=src_root
+            ),
+        },
+    )
+
+    result = cmd("--sdistonly", "-v", "-v", "-e", "py")
+    assert "scons: done building targets" in result.out, result.out


### PR DESCRIPTION
Fixes #2130. Briefly, PEP 517 permits some optional hooks for a backend build system. In particular, if `get_requires_for_build_sdist` hook is not implemented by the backend, a default implementation that returns an empty list must be assumed. This fix should allow [enscons](https://github.com/dholth/enscons) (a build system based on [SCons](https://scons.org/)) to work with `tox` when isolated build option is enabled.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
