### PR TITLE
Add support for os path separator substitution in ini files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.1
+    rev: v2.23.3
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]

--- a/docs/changelog/2125.feature.rst
+++ b/docs/changelog/2125.feature.rst
@@ -1,0 +1,1 @@
+Add support for ``{:}`` substitution in ini files as placeholder for the OS path separator - by :user:`gaborbernat`.

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -76,6 +76,8 @@ def _replace_match(
     of_type, *args = ARGS_GROUP.split(value)
     if of_type == "/":
         replace_value: Optional[str] = os.sep
+    elif of_type == "" and args == [""]:
+        replace_value = os.pathsep
     elif of_type == "env":
         replace_value = replace_env(conf, current_env, args, chain)
     elif of_type == "tty":

--- a/tests/config/loader/ini/replace/test_replace_os_pathsep.py
+++ b/tests/config/loader/ini/replace/test_replace_os_pathsep.py
@@ -1,0 +1,8 @@
+import os
+
+from tests.config.loader.ini.replace.conftest import ReplaceOne
+
+
+def test_replace_os_pathsep(replace_one: ReplaceOne) -> None:
+    result = replace_one("{:}")
+    assert result == os.pathsep


### PR DESCRIPTION
Resolves https://github.com/tox-dev/tox/issues/2125

Signed-off-by: Bernát Gábor <gaborjbernat@gmail.com>
