### PR TITLE
When cleaning dirs clean only their content

### DIFF
--- a/docs/changelog/2139.feature.rst
+++ b/docs/changelog/2139.feature.rst
@@ -1,0 +1,3 @@
+When cleaning directories (for tox environment, ``env_log_dir``, ``env_tmp_dir`` and packaging metadata folders) do not
+delete the directory itself and recreate, but instead just delete its content (this allows the user to cd into it and
+still be in a valid folder after a new run) - by :user:`gaborbernat`.

--- a/src/tox/config/source/legacy_toml.py
+++ b/src/tox/config/source/legacy_toml.py
@@ -11,7 +11,7 @@ class LegacyToml(IniSource):
     def __init__(self, path: Path):
         if path.name != self.FILENAME or not path.exists():
             raise ValueError
-        with path.open() as file_handler:
+        with path.open("rb") as file_handler:
             toml_content = tomli.load(file_handler)
         try:
             content = toml_content["tool"]["tox"]["legacy_tox_ini"]

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -4,7 +4,6 @@ Defines the abstract base traits of a tox environment.
 import logging
 import os
 import re
-import shutil
 import sys
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
@@ -20,6 +19,7 @@ from tox.journal import EnvJournal
 from tox.report import OutErr, ToxHandler
 from tox.tox_env.errors import Recreate, Skip
 from tox.tox_env.installer import Installer
+from tox.util.path import ensure_empty_dir
 
 from .info import Info
 
@@ -261,7 +261,7 @@ class ToxEnv(ABC):
         env_tmp_dir = self.env_tmp_dir
         if env_tmp_dir.exists() and next(env_tmp_dir.iterdir(), None) is not None:
             LOGGER.debug("clear env temp folder %s", env_tmp_dir)
-            shutil.rmtree(env_tmp_dir, ignore_errors=True)
+            ensure_empty_dir(env_tmp_dir)
         env_tmp_dir.mkdir(parents=True, exist_ok=True)
 
     def _clean(self, force: bool = False) -> None:  # noqa: U100
@@ -270,7 +270,7 @@ class ToxEnv(ABC):
         env_dir = self.env_dir
         if env_dir.exists():
             LOGGER.warning("remove tox env folder %s", env_dir)
-            shutil.rmtree(env_dir)
+            ensure_empty_dir(env_dir)
         self.cache.reset()
         self._run_state.update({"setup": False, "clean": True})
 
@@ -390,8 +390,7 @@ class ToxEnv(ABC):
 
     def _log_execute(self, request: ExecuteRequest, status: ExecuteStatus) -> None:
         if self._log_id == 0:  # start with fresh slate on new run
-            shutil.rmtree(self.env_log_dir, ignore_errors=True)
-            self.env_log_dir.mkdir(parents=True, exist_ok=True)
+            ensure_empty_dir(self.env_log_dir)
         self._log_id += 1
         self._write_execute_log(self.name, self.env_log_dir / f"{self._log_id}-{request.run_id}.log", request, status)
 

--- a/src/tox/util/path.py
+++ b/src/tox/util/path.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from shutil import rmtree
+
+
+def ensure_empty_dir(path: Path) -> None:
+    if path.exists():
+        if path.is_dir():
+            for sub_path in path.iterdir():
+                if sub_path.is_dir():
+                    rmtree(sub_path, ignore_errors=True)
+                else:
+                    sub_path.unlink()
+        else:
+            path.unlink()
+            path.mkdir()
+    else:
+        path.mkdir(parents=True)
+
+
+__all__ = [
+    "ensure_empty_dir",
+]

--- a/src/tox/util/pep517/frontend.py
+++ b/src/tox/util/pep517/frontend.py
@@ -1,6 +1,5 @@
 """Build frontend for PEP-517"""
 import json
-import shutil
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from pathlib import Path
@@ -11,6 +10,8 @@ from zipfile import ZipFile
 
 import tomli
 from packaging.requirements import Requirement
+
+from tox.util.path import ensure_empty_dir
 
 _HERE = Path(__file__).parent
 ConfigSettings = Optional[Dict[str, Any]]
@@ -106,7 +107,7 @@ class Frontend(ABC):
     ) -> Tuple[Path, Tuple[Path, ...], str, Optional[str], Tuple[Requirement, ...], bool]:
         py_project_toml = folder / "pyproject.toml"
         if py_project_toml.exists():
-            with py_project_toml.open() as file_handler:
+            with py_project_toml.open("rb") as file_handler:
                 py_project = tomli.load(file_handler)
             build_system = py_project.get("build-system", {})
             if "backend-path" in build_system:
@@ -169,7 +170,7 @@ class Frontend(ABC):
         if metadata_directory == self._root:
             raise RuntimeError(f"the project root and the metadata directory can't be the same {self._root}")
         if metadata_directory.exists():  # start with fresh
-            shutil.rmtree(metadata_directory)
+            ensure_empty_dir(metadata_directory)
         metadata_directory.mkdir(parents=True, exist_ok=True)
         try:
             basename, out, err = self._send(

--- a/tests/util/test_path.py
+++ b/tests/util/test_path.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from tox.util.path import ensure_empty_dir
+
+
+def test_ensure_empty_dir_file(tmp_path: Path) -> None:
+    dest = tmp_path / "a"
+    dest.write_text("")
+    ensure_empty_dir(dest)
+    assert dest.is_dir()
+    assert not list(dest.iterdir())


### PR DESCRIPTION
Instead, only delete their content. This allows the user to cd into these
and them being still valid after a new run.

Resolves https://github.com/tox-dev/tox/pull/2139#issuecomment-893406979