### PR TITLE
Do not fail when commands do not parse with shlex

### DIFF
--- a/docs/changelog/1944.bugfix.rst
+++ b/docs/changelog/1944.bugfix.rst
@@ -1,0 +1,2 @@
+If the command expression fails to parse with shlex fallback to literal pass through of the remaining elements
+- by :user:`gaborbernat`.

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -49,15 +49,17 @@ class StrConvert(Convert[str]):
         is_win = sys.platform == "win32"
         splitter = shlex.shlex(value, posix=not is_win)
         splitter.whitespace_split = True
-        if is_win:  # pragma: win32 cover
-            args: List[str] = []
+        args: List[str] = []
+        pos = 0
+        try:
             for arg in splitter:
-                # on Windows quoted arguments will remain quoted, strip it
-                if len(arg) > 1 and arg[0] == arg[-1] and arg.startswith(("'", '"')):
+                if is_win and len(arg) > 1 and arg[0] == arg[-1] and arg.startswith(("'", '"')):  # pragma: win32 cover
+                    # on Windows quoted arguments will remain quoted, strip it
                     arg = arg[1:-1]
                 args.append(arg)
-        else:
-            args = list(splitter)
+                pos = splitter.instream.tell()
+        except ValueError:
+            args.append(value[pos:])
         return Command(args)
 
     @staticmethod

--- a/tests/config/loader/test_str_convert.py
+++ b/tests/config/loader/test_str_convert.py
@@ -65,3 +65,15 @@ def test_str_convert_ok(raw: str, value: Any, of_type: Type[Any]) -> None:
 def test_str_convert_nok(raw: str, of_type: Type[Any], msg: str, exc_type: Type[Exception]) -> None:
     with pytest.raises(exc_type, match=msg):
         result = StrConvert().to(raw, of_type, {})  # noqa
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("python ' ok", ["python", "' ok"]),
+        ('python " ok', ["python", '" ok']),
+    ],
+)
+def test_invalid_shell_expression(value: str, expected: List[str]) -> None:
+    result = StrConvert().to_command(value).args
+    assert result == expected

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -103,6 +103,7 @@ IGN
 impl
 INET
 insort
+instream
 intersphinx
 isalpha
 isatty


### PR DESCRIPTION
Instead fallback to literal value.

Resolves https://github.com/tox-dev/tox/issues/1944