### PR TITLE
Check base python against env name and raise if differs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,8 +16,8 @@ Features - 4.0.0a7
 - Implemented ``[]`` substitution (alias for ``{posargs}``) - by
   :user:`hexagonrecursion`. (`#1928 <https://github.com/tox-dev/tox/issues/1928>`_)
 - Implement ``[testenv] ignore_outcome`` - "a failing result of this testenv will not make tox fail" - by :user:`hexagonrecursion`. (`#1947 <https://github.com/tox-dev/tox/issues/1947>`_)
-- Inline plugin support via ``tox_.py``. This is loaded where the tox config source is discovered. It's a python file
-  that can contain arbitrary python code, such as definition of a plugin. Eventually we'll add a plugin that allows
+- Inline plugin support via ``tox_.py``. This is loaded where the tox config source is discovered. It's a Python file
+  that can contain arbitrary Python code, such as definition of a plugin. Eventually we'll add a plugin that allows
   succinct declaration/generation of new tox environments - by :user:`gaborbernat`. (`#1963 <https://github.com/tox-dev/tox/issues/1963>`_)
 - Introduce the installer concept, and collect pip installation into a ``pip`` package, also attach to this
   the requirements file parsing which got a major rework - by :user:`gaborbernat`. (`#1991 <https://github.com/tox-dev/tox/issues/1991>`_)
@@ -28,7 +28,7 @@ Bugfixes - 4.0.0a7
 - Environments with a platform mismatch are no longer silently skipped, but properly reported - by :user:`jugmac00`. (`#1926 <https://github.com/tox-dev/tox/issues/1926>`_)
 - Port pip requirements file parser to ``tox`` to achieve full equivalency (such as support for the per requirement
   ``--install-option`` and ``--global-option`` flags) - by :user:`gaborbernat`. (`#1929 <https://github.com/tox-dev/tox/issues/1929>`_)
-- Support for extras with paths for python deps and requirement files - by :user:`gaborbernat`. (`#1933 <https://github.com/tox-dev/tox/issues/1933>`_)
+- Support for extras with paths for Python deps and requirement files - by :user:`gaborbernat`. (`#1933 <https://github.com/tox-dev/tox/issues/1933>`_)
 - Due to a bug ``\{posargs} {posargs}`` used to expand to literal ``{posargs} {posargs}``.
   Now the second ``{posargs}`` is expanded.
   ``\{posargs} {posargs}`` expands to ``{posargs} positional arguments here`` - by :user:`hexagonrecursion`. (`#1956 <https://github.com/tox-dev/tox/issues/1956>`_)
@@ -64,11 +64,11 @@ v4.0.0a6 (2021-02-15)
 
 Features - 4.0.0a6
 ~~~~~~~~~~~~~~~~~~
-- Add basic quickstart implementation (just use pytest with the current python version) - by :user:`gaborbernat`. (`#1829 <https://github.com/tox-dev/tox/issues/1829>`_)
+- Add basic quickstart implementation (just use pytest with the current Python version) - by :user:`gaborbernat`. (`#1829 <https://github.com/tox-dev/tox/issues/1829>`_)
 - Support comments via the ``#`` character within the ini configuration (to force a literal ``#`` use ``\#``) -
   by :user:`gaborbernat`. (`#1831 <https://github.com/tox-dev/tox/issues/1831>`_)
 - Add support for the ``install_command`` settings in the virtual env test environments - by :user:`gaborbernat`. (`#1832 <https://github.com/tox-dev/tox/issues/1832>`_)
-- Add support for the ``package_root`` \ ``setupdir`` (python scoped) configuration that sets the root directory used for
+- Add support for the ``package_root`` \ ``setupdir`` ( Python scoped) configuration that sets the root directory used for
   packaging (the location of the historical ``setup.py`` and modern ``pyproject.toml``). This can be set at root level, or
   at tox environment level (the later takes precedence over the former) - by :user:`gaborbernat`. (`#1838 <https://github.com/tox-dev/tox/issues/1838>`_)
 - Implement support for the ``--installpkg`` CLI flag - by :user:`gaborbernat`. (`#1839 <https://github.com/tox-dev/tox/issues/1839>`_)
@@ -78,7 +78,7 @@ Features - 4.0.0a6
 - Add support for the ``pip_pre`` settings for virtual environment based tox environments - by :user:`gaborbernat`. (`#1844 <https://github.com/tox-dev/tox/issues/1844>`_)
 - Add support for the ``platform`` settings in tox test environments - by :user:`gaborbernat`. (`#1845 <https://github.com/tox-dev/tox/issues/1845>`_)
 - Add support for the ``recreate`` settings in tox test environments - by :user:`gaborbernat`. (`#1846 <https://github.com/tox-dev/tox/issues/1846>`_)
-- Allow python test and packaging environments with version 2.7 - by :user:`gaborbernat`. (`#1900 <https://github.com/tox-dev/tox/issues/1900>`_)
+- Allow Python test and packaging environments with version 2.7 - by :user:`gaborbernat`. (`#1900 <https://github.com/tox-dev/tox/issues/1900>`_)
 - Do not construct a requirements file for deps in virtualenv, instead pass content as CLI argument to pip - by
   :user:`gaborbernat`. (`#1906 <https://github.com/tox-dev/tox/issues/1906>`_)
 - Do not display status update environment reports when interrupted or for the final environment ran (because at the
@@ -134,7 +134,7 @@ Bugfixes - 4.0.0a5
 - Support ``=`` separator in requirement file flags, directories as requirements and correctly set the root of the
   requirements file when using the ``--root`` CLI flag to change the root - by :user:`gaborbernat`. (`#1853 <https://github.com/tox-dev/tox/issues/1853>`_)
 - Cleanup local subprocess file handlers when exiting runs (fixes ``ResourceWarning: unclosed file`` errors when running
-  with ``env PYTHONTRACEMALLOC=5 PYTHONDEVMODE=y`` under a python built with ``--with-pydebug``)
+  with ``env PYTHONTRACEMALLOC=5 PYTHONDEVMODE=y`` under a Python built with ``--with-pydebug``)
   - by :user:`gaborbernat`. (`#1857 <https://github.com/tox-dev/tox/issues/1857>`_)
 - Various small bugfixes:
 
@@ -211,15 +211,15 @@ Bugfixes - 4.0.0a3
   - Allow windows paths in substitution set/default (the ``:`` character used to separate substitution arguments may
     also be present in paths on Windows - do not support single capital letter values as substitution arguments) -
     by :user:`gaborbernat`. (`#1784 <https://github.com/tox-dev/tox/issues/1784>`_)
-- Rework how we handle python packaging environments:
+- Rework how we handle Python packaging environments:
 
   - the base packaging environment changed from ``.package`` to ``.pkg``,
   - merged the ``sdist``, ``wheel`` and ``dev`` separate packaging implementations into one, and internally dynamically
     pick the one that's needed,
-  - the base packaging environment always uses the same python environment as tox is installed into,
+  - the base packaging environment always uses the same Python environment as tox is installed into,
   - the base packaging environment is used to get the metadata of the project (via PEP-517) and to build ``sdist`` and
     ``dev`` packages,
-  - for building wheels introduced a new per env configurable option ``wheel_build_env``, if the target python major/minor
+  - for building wheels introduced a new per env configurable option ``wheel_build_env``, if the target Python major/minor
     and implementation for the run tox environment and the base package tox environment matches set this to ``.pkg``,
     otherwise this is ``.pkg-{implementation}{major}{minor}``,
   - internally now packaging environments can create further packaging environments they are responsible of managing,

--- a/docs/changelog/1840.feature.rst
+++ b/docs/changelog/1840.feature.rst
@@ -1,0 +1,2 @@
+Add check to validate the base python names and the environments name do not conflict python spec wise, when they do
+raise error if :ref:`ignore_base_python_conflict` is not set or ``False`` - by :user:`gaborbernat`.

--- a/docs/changelog/1840.feature.rst
+++ b/docs/changelog/1840.feature.rst
@@ -1,2 +1,2 @@
-Add check to validate the base python names and the environments name do not conflict python spec wise, when they do
+Add check to validate the base Python names and the environments name do not conflict Python spec wise, when they do
 raise error if :ref:`ignore_base_python_conflict` is not set or ``False`` - by :user:`gaborbernat`.

--- a/docs/changelog/1975.doc.rst
+++ b/docs/changelog/1975.doc.rst
@@ -1,2 +1,2 @@
-Add a note about having a package with different python requirements than tox and not specifying :ref:`base_python` -
+Add a note about having a package with different Python requirements than tox and not specifying :ref:`base_python` -
 by :user:`gaborbernat`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -103,7 +103,7 @@ Core
    :version_added: 3.2.0
 
    Specify a list of `PEP-508 <https://www.python.org/dev/peps/pep-0508/>`_ compliant dependencies that must be
-   satisfied in the python environment hosting tox when running the tox command. If any of these dependencies are not
+   satisfied in the Python environment hosting tox when running the tox command. If any of these dependencies are not
    satisfied will automatically create a provisioned tox environment that does not have this issue, and run the tox
    command within that environment. See :ref:`provision_tox_env` for more details.
 
@@ -417,10 +417,10 @@ Python
    :default: {package_root}
 
    Name or path to a Python interpreter which will be used for creating the virtual environment, first one found wins.
-   This determines in practice the python for what we'll create a virtual isolated environment. Use this to specify the
-   python version for a tox environment. If not specified, the virtual environments factors (e.g. name part) will be
+   This determines in practice the Python for what we'll create a virtual isolated environment. Use this to specify the
+   Python version for a tox environment. If not specified, the virtual environments factors (e.g. name part) will be
    used to automatically set one. For example, ``py310`` means ``python3.10``, ``py3`` means ``python3`` and ``py``
-   means ``python``. If the name does not match this pattern the same python version tox is installed into will be used.
+   means ``python``. If the name does not match this pattern the same Python version tox is installed into will be used.
 
     .. versionchanged:: 3.1
 
@@ -430,10 +430,10 @@ Python
 
     .. note::
 
-      Leaving this unset will cause an error if the package under test has a different python requires than tox itself
-      and tox is installed into a python that's not supported by the package. For example, if your package requires
-      python 3.9 or later, and you install tox in python 3.8, when you run a tox environment that has left this
-      unspecified tox will use python 3.8 to build and install your package which will fail given it requires 3.9.
+      Leaving this unset will cause an error if the package under test has a different Python requires than tox itself
+      and tox is installed into a Python that's not supported by the package. For example, if your package requires
+      Python 3.9 or later, and you install tox in Python 3.8, when you run a tox environment that has left this
+      unspecified tox will use Python 3.8 to build and install your package which will fail given it requires 3.9.
 
 
 .. conf::
@@ -442,21 +442,21 @@ Python
 
     .. versionadded:: 3.1.0
 
-    tox allows setting the python version for an environment via the :ref:`basepython` setting. If that's not set tox
-    can set a default value from the environment name (e.g. ``py310`` implies Python 3.10). Matching up the python
+    tox allows setting the Python version for an environment via the :ref:`basepython` setting. If that's not set tox
+    can set a default value from the environment name (e.g. ``py310`` implies Python 3.10). Matching up the Python
     version with the environment name has became expected at this point, leading to surprises when some configs don't
     do so. To help with sanity of users a error will be raised whenever the environment name version does not matches
     up with this expectation.
 
     Furthermore, we allow hard enforcing this rule by setting this flag to ``true``. In such cases we ignore the
-    :ref:`base_python` and instead always use the base python implied from the Python name. This allows you to configure
-    :ref:`base_python` in the :ref:`base` section without affecting environments that have implied base python versions.
+    :ref:`base_python` and instead always use the base Python implied from the Python name. This allows you to configure
+    :ref:`base_python` in the :ref:`base` section without affecting environments that have implied base Python versions.
 
 .. conf::
    :keys: env_site_packages_dir, envsitepackagesdir
    :constant:
 
-   The python environments site package - where packages are installed (the purelib folder path).
+   The Python environments site package - where packages are installed (the purelib folder path).
 
 .. conf::
    :keys: env_bin_dir, envbindir
@@ -468,7 +468,7 @@ Python
    :keys: env_python, envpython
    :constant:
 
-   The python executable from within the tox environment.
+   The Python executable from within the tox environment.
 
 Python run
 ~~~~~~~~~~
@@ -476,7 +476,7 @@ Python run
    :keys: deps
    :default: <empty list>
 
-   Name of the python dependencies as specified by `PEP-440`_. Installed into the environment prior to project after
+   Name of the Python dependencies as specified by `PEP-440`_. Installed into the environment prior to project after
    environment creation, but before package installation. All installer commands are executed using the :ref:`tox_root`
    as the current working directory.
 
@@ -502,9 +502,9 @@ Python run
    :default: <package_env>-<python-flavor-lowercase><python-version-no-dot>
 
    If :ref:`wheel_build_env` is set to ``wheel`` this will be the tox Python environment in which the wheel will be
-   built. The value is generated to be unique per python flavor and version, and prefixed with :ref:`package_env` value.
+   built. The value is generated to be unique per Python flavor and version, and prefixed with :ref:`package_env` value.
    This is to ensure the target interpreter and the generated wheel will be compatible. If you have a wheel that can be
-   reused across multiple python versions set this value to the same across them (to avoid building a new wheel for
+   reused across multiple Python versions set this value to the same across them (to avoid building a new wheel for
    each one of them).
 
 .. conf::

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -448,10 +448,9 @@ Python
     do so. To help with sanity of users a error will be raised whenever the environment name version does not matches
     up with this expectation.
 
-    Furthermore, we allow hard enforcing this rule (and bypassing the warning) by setting this flag to ``true``. In such
-    cases we ignore the :ref:`base_python` and instead always use the base python implied from the Python name. This
-    allows you to configure :ref:`base_python` in the :ref:`base` section without affecting environments that have
-    implied base python versions.
+    Furthermore, we allow hard enforcing this rule by setting this flag to ``true``. In such cases we ignore the
+    :ref:`base_python` and instead always use the base python implied from the Python name. This allows you to configure
+    :ref:`base_python` in the :ref:`base` section without affecting environments that have implied base python versions.
 
 .. conf::
    :keys: env_site_packages_dir, envsitepackagesdir

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -195,6 +195,25 @@ Core
 
     Indicates where the packaging root file exists (historically setup.py file or pyproject.toml now).
 
+Python
+~~~~~~
+.. conf::
+   :keys: ignore_base_python_conflict, ignore_basepython_conflict
+   :default: True
+
+    .. versionadded:: 3.1.0
+
+    tox allows setting the Python version for an environment via the :ref:`basepython` setting. If that's not set tox
+    can set a default value from the environment name (e.g. ``py310`` implies Python 3.10). Matching up the Python
+    version with the environment name has became expected at this point, leading to surprises when some configs don't
+    do so. To help with sanity of users a error will be raised whenever the environment name version does not matches
+    up with this expectation.
+
+    Furthermore, we allow hard enforcing this rule by setting this flag to ``true``. In such cases we ignore the
+    :ref:`base_python` and instead always use the base Python implied from the Python name. This allows you to configure
+    :ref:`base_python` in the :ref:`base` section without affecting environments that have implied base Python versions.
+
+
 
 tox environment
 ---------------
@@ -434,23 +453,6 @@ Python
       and tox is installed into a Python that's not supported by the package. For example, if your package requires
       Python 3.9 or later, and you install tox in Python 3.8, when you run a tox environment that has left this
       unspecified tox will use Python 3.8 to build and install your package which will fail given it requires 3.9.
-
-
-.. conf::
-   :keys: ignore_base_python_conflict, ignore_basepython_conflict
-   :default: True
-
-    .. versionadded:: 3.1.0
-
-    tox allows setting the Python version for an environment via the :ref:`basepython` setting. If that's not set tox
-    can set a default value from the environment name (e.g. ``py310`` implies Python 3.10). Matching up the Python
-    version with the environment name has became expected at this point, leading to surprises when some configs don't
-    do so. To help with sanity of users a error will be raised whenever the environment name version does not matches
-    up with this expectation.
-
-    Furthermore, we allow hard enforcing this rule by setting this flag to ``true``. In such cases we ignore the
-    :ref:`base_python` and instead always use the base Python implied from the Python name. This allows you to configure
-    :ref:`base_python` in the :ref:`base` section without affecting environments that have implied base Python versions.
 
 .. conf::
    :keys: env_site_packages_dir, envsitepackagesdir

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -56,7 +56,7 @@ class Python(ToxEnv, ABC):
         super().register_config()
 
         def validate_base_python(value: List[str]) -> List[str]:
-            return self._validate_base_python(self.name, value, self.conf["ignore_base_python_conflict"])
+            return self._validate_base_python(self.name, value, self.core["ignore_base_python_conflict"])
 
         self.conf.add_config(
             keys=["base_python", "basepython"],
@@ -65,7 +65,7 @@ class Python(ToxEnv, ABC):
             desc="environment identifier for python, first one found wins",
             post_process=validate_base_python,
         )
-        self.conf.add_config(
+        self.core.add_config(
             keys=["ignore_base_python_conflict", "ignore_basepython_conflict"],
             of_type=bool,
             default=False,

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -54,11 +54,22 @@ class Python(ToxEnv, ABC):
 
     def register_config(self) -> None:
         super().register_config()
+
+        def validate_base_python(value: List[str]) -> List[str]:
+            return self._validate_base_python(self.name, value, self.conf["ignore_base_python_conflict"])
+
         self.conf.add_config(
             keys=["base_python", "basepython"],
             of_type=List[str],
             default=self.default_base_python,
             desc="environment identifier for python, first one found wins",
+            post_process=validate_base_python,
+        )
+        self.conf.add_config(
+            keys=["ignore_base_python_conflict", "ignore_basepython_conflict"],
+            of_type=bool,
+            default=False,
+            desc="do not raise error if the environment name conflicts with base python",
         )
         self.conf.add_constant(
             keys=["env_site_packages_dir", "envsitepackagesdir"],
@@ -107,6 +118,26 @@ class Python(ToxEnv, ABC):
                 raise ValueError(f"conflicting factors {', '.join(candidates)} in {env_name}")
             return next(iter(candidates))
         return None
+
+    @staticmethod
+    def _validate_base_python(env_name: str, base_pythons: List[str], ignore_base_python_conflict: bool) -> List[str]:
+        elements = {env_name}  # match with full env-name
+        elements.update(env_name.split("-"))  # and also any factor
+        for candidate in elements:
+            spec_name = PythonSpec.from_string_spec(candidate)
+            if spec_name.implementation is not None and spec_name.implementation.lower() in ("pypy", "cpython"):
+                for base_python in base_pythons:
+                    spec_base = PythonSpec.from_string_spec(base_python)
+                    if any(
+                        getattr(spec_base, key) != getattr(spec_name, key)
+                        for key in ("implementation", "major", "minor", "micro", "architecture")
+                        if getattr(spec_base, key) is not None and getattr(spec_name, key) is not None
+                    ):
+                        msg = f"env name {env_name} conflicting with base python {base_python}"
+                        if ignore_base_python_conflict:
+                            return [env_name]  # ignore the base python settings
+                        raise Fail(msg)
+        return base_pythons
 
     @abstractmethod
     def env_site_package_dir(self) -> Path:
@@ -172,7 +203,7 @@ class Python(ToxEnv, ABC):
     def base_python(self) -> PythonInfo:
         """Resolve base python"""
         if self._base_python_searched is False:
-            base_pythons = self.conf["base_python"]
+            base_pythons: List[str] = self.conf["base_python"]
             self._base_python_searched = True
             self._base_python = self._get_python(base_pythons)
             if self._base_python is None:

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -120,6 +120,7 @@ class VirtualEnv(Python, ABC):
         self.session.run()
 
     def _get_python(self, base_python: List[str]) -> Optional[PythonInfo]:  # noqa: U100
+        # the base pythons is injected into the virtualenv_env_vars, so we don't need to use it here
         try:
             interpreter = self.creator.interpreter
         except RuntimeError:  # if can't find

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -120,7 +120,7 @@ class VirtualEnv(Python, ABC):
         self.session.run()
 
     def _get_python(self, base_python: List[str]) -> Optional[PythonInfo]:  # noqa: U100
-        # the base pythons is injected into the virtualenv_env_vars, so we don't need to use it here
+        # the base pythons are injected into the virtualenv_env_vars, so we don't need to use it here
         try:
             interpreter = self.creator.interpreter
         except RuntimeError:  # if can't find

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -117,7 +117,7 @@ def test_base_python_env_conflict_show_conf(tox_project: ToxProjectCreator, igno
     py_ver_next = "".join(str(i) for i in (sys.version_info[0], sys.version_info[1] + 2))
     ini = f"[testenv]\npackage=skip\nbase_python=py{py_ver_next}"
     if ignore_conflict is not None:
-        ini += f"\nignore_base_python_conflict={ignore_conflict}"
+        ini += f"\n[tox]\nignore_base_python_conflict={ignore_conflict}"
     project = tox_project({"tox.ini": ini})
     result = project.run("c", "-e", f"py{py_ver}", "-k", "base_python")
     result.assert_success()

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -1,11 +1,12 @@
 import sys
 from pathlib import Path
-from typing import Callable, Tuple
+from typing import Callable, List, Tuple
 
 import pytest
 from pytest_mock import MockerFixture
 
 from tox.pytest import ToxProjectCreator
+from tox.tox_env.errors import Fail
 from tox.tox_env.python.api import Python
 
 
@@ -27,7 +28,7 @@ def test_requirements_txt(tox_project: ToxProjectCreator) -> None:
     assert got_cmd == exp
 
 
-def test_conflicting_base_python() -> None:
+def test_conflicting_base_python_factor() -> None:
     major, minor = sys.version_info[0:2]
     name = f"py{major}{minor}-py{major}{minor-1}"
     with pytest.raises(ValueError, match=f"conflicting factors py{major}{minor}, py{major}{minor-1} in {name}"):
@@ -65,3 +66,61 @@ def test_diff_msg_added_removed_changed() -> None:
 
 def test_diff_msg_no_diff() -> None:
     assert Python._diff_msg({}, {}) == "python "
+
+
+@pytest.mark.parametrize("ignore_base_python_conflict", [True, False])
+@pytest.mark.parametrize(
+    ("env_name", "base_python", "conflict"),
+    [
+        ("magic", ["pypy"], []),
+        ("magic", ["py39"], []),
+        (".pkg", ["py"], []),
+        ("py", ["pypy"], ["pypy"]),
+        ("cpython", ["pypy"], ["pypy"]),
+        ("pypy", ["cpython"], ["cpython"]),
+        ("pypy2", ["pypy3"], ["pypy3"]),
+        ("py3", ["py2"], ["py2"]),
+        ("py38", ["py39"], ["py39"]),
+        ("py38", ["py38", "py39"], ["py39"]),
+        ("py310", ["py38", "py39"], ["py38", "py39"]),
+        ("py3.11.1", ["py3.11.2"], ["py3.11.2"]),
+        ("py3-64", ["py3-32"], ["py3-32"]),
+        ("py310-magic", ["py39"], ["py39"]),
+    ],
+    ids=lambda a: "|".join(a) if isinstance(a, list) else str(a),
+)
+def test_base_python_matches_env_name(
+    env_name: str, base_python: List[str], conflict: List[str], ignore_base_python_conflict: bool
+) -> None:
+    if conflict:
+        if ignore_base_python_conflict:
+            result = Python._validate_base_python(env_name, base_python, ignore_base_python_conflict)
+            assert result == [env_name]
+        else:
+            msg = f"env name {env_name} conflicting with base python {conflict[0]}"
+            with pytest.raises(Fail, match=msg):
+                Python._validate_base_python(env_name, base_python, ignore_base_python_conflict)
+    else:
+        result = Python._validate_base_python(env_name, base_python, ignore_base_python_conflict)
+        assert result is base_python
+
+
+@pytest.mark.parametrize("ignore_base_python_conflict", [True, False, None])
+def test_conflicting_base_python_env_name(tox_project: ToxProjectCreator, ignore_base_python_conflict: bool) -> None:
+    py_ver = "".join(str(i) for i in sys.version_info[0:2])
+    py_ver_next = "".join(str(i) for i in (sys.version_info[0], sys.version_info[1] + 2))
+    ini = f"[testenv]\npackage=skip\nbase_python=py{py_ver_next}"
+    if ignore_base_python_conflict is not None:
+        ini += f"\nignore_base_python_conflict={ignore_base_python_conflict}"
+    project = tox_project({"tox.ini": ini})
+    result = project.run("c", "-e", f"py{py_ver}", "-k", "base_python")
+    result.assert_success()
+    if ignore_base_python_conflict:
+        out = f"[testenv:py{py_ver}]\nbase_python = py{py_ver}\n"
+    else:
+        coma_in_exc = sys.version_info[0:2] <= (3, 6)
+        out = (
+            f"[testenv:py{py_ver}]\nbase_python = # Exception: Fail('env name py{py_ver} conflicting with"
+            f" base python py{py_ver_next}'{',' if coma_in_exc else ''})\n"
+        )
+    result.assert_out_err(out, "")


### PR DESCRIPTION
Resolves https://github.com/tox-dev/tox/issues/1840

Allow enforcing the env name via ignore_base_python_conflict config
value.
