### PR TITLE
Add LC_ALL to implicit tox passenv

### DIFF
--- a/docs/changelog/2162.bugfix.rst
+++ b/docs/changelog/2162.bugfix.rst
@@ -1,0 +1,1 @@
+include ``LC_ALL`` to implicit list of passenv variables - by :user:`ssbarnea`

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -770,6 +770,7 @@ def tox_addoption(parser):
             "CURL_CA_BUNDLE",
             "LANG",
             "LANGUAGE",
+            "LC_ALL",
             "LD_LIBRARY_PATH",
             "PATH",
             "PIP_INDEX_URL",


### PR DESCRIPTION
This is needed because LANG by itself is not enough to help newer pip from failing on py36. Forcing tox users to manually alter not only their system configuration but also their tox.ini files to avoid that bug is not quite desired. As we already pass `LANG` and `LANGUAGE` I see not reason why we should not do the same for `LC_ALL` too.

Related: https://github.com/pypa/pip/issues/10219

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
