### PR TITLE
ASCII output for --parallel report lines

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,6 +20,7 @@ Bastien Vallet
 Benoit Pierre
 Bernat Gabor
 Brett Langdon
+Brett Smith
 Bruno Oliveira
 Carl Meyer
 Charles Brunet

--- a/docs/changelog/1421.bugfix.rst
+++ b/docs/changelog/1421.bugfix.rst
@@ -1,0 +1,1 @@
+``--parallel`` reports now show ASCII OK/FAIL/SKIP lines when full Unicode output is not available - by :user:`brettcs`

--- a/src/tox/util/spinner.py
+++ b/src/tox/util/spinner.py
@@ -36,6 +36,9 @@ class Spinner(object):
     CLEAR_LINE = "\033[K"
     max_width = 120
     FRAMES = SpinnerMessage("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", "|-+x*")
+    OK_FLAG = SpinnerMessage("✔ OK", "[ OK ]")
+    FAIL_FLAG = SpinnerMessage("✖ FAIL", "[FAIL]")
+    SKIP_FLAG = SpinnerMessage("⚠ SKIP", "[SKIP]")
 
     def __init__(self, enabled=True, refresh_rate=0.1):
         self.refresh_rate = refresh_rate
@@ -100,13 +103,13 @@ class Spinner(object):
         self._envs[name] = datetime.now()
 
     def succeed(self, key):
-        self.finalize(key, "✔ OK", green=True)
+        self.finalize(key, self.OK_FLAG.for_file(self._file), green=True)
 
     def fail(self, key):
-        self.finalize(key, "✖ FAIL", red=True)
+        self.finalize(key, self.FAIL_FLAG.for_file(self._file), red=True)
 
     def skip(self, key):
-        self.finalize(key, "⚠ SKIP", white=True)
+        self.finalize(key, self.SKIP_FLAG.for_file(self._file), white=True)
 
     def finalize(self, key, status, **kwargs):
         start_at = self._envs[key]

--- a/src/tox/util/spinner.py
+++ b/src/tox/util/spinner.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import threading
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 from datetime import datetime
 
 import py
@@ -19,34 +19,29 @@ if os.name == "nt":
         _fields_ = [("size", ctypes.c_int), ("visible", ctypes.c_byte)]
 
 
-def _file_support_encoding(chars, file):
-    encoding = getattr(file, "encoding", None)
-    if encoding is not None:
-        for char in chars:
-            try:
-                char.encode(encoding)
-            except UnicodeEncodeError:
-                break
+_BaseMessage = namedtuple("_BaseMessage", ["unicode_msg", "ascii_msg"])
+
+
+class SpinnerMessage(_BaseMessage):
+    def for_file(self, file):
+        try:
+            self.unicode_msg.encode(file.encoding)
+        except (AttributeError, TypeError, UnicodeEncodeError):
+            return self.ascii_msg
         else:
-            return True
-    return False
+            return self.unicode_msg
 
 
 class Spinner(object):
     CLEAR_LINE = "\033[K"
     max_width = 120
-    UNICODE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-    ASCII_FRAMES = ["|", "-", "+", "x", "*"]
+    FRAMES = SpinnerMessage("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", "|-+x*")
 
     def __init__(self, enabled=True, refresh_rate=0.1):
         self.refresh_rate = refresh_rate
         self.enabled = enabled
         self._file = sys.stdout
-        self.frames = (
-            self.UNICODE_FRAMES
-            if _file_support_encoding(self.UNICODE_FRAMES, sys.stdout)
-            else self.ASCII_FRAMES
-        )
+        self.frames = self.FRAMES.for_file(self._file)
         self.stream = py.io.TerminalWriter(file=self._file)
         self._envs = OrderedDict()
         self._frame_index = 0


### PR DESCRIPTION
This is a branch to fix #1421 by providing ASCII equivalent messages for the OK/FAIL/SKIP lines that summarize the result for each environment.

I chose strings reminiscent of the sysvinit boot service banners on older Linux distros. If you'd rather use something else, of course it's no problem for anyone else to switch out those strings. The code should continue to work no problem.

Hope this helps!