### PR TITLE
🐛 Fix the last version+date underline in changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,8 @@ with advance notice in the **Deprecations** section of releases.
 .. towncrier release notes start
 
 v3.24.2 (2021-08-18)
+--------------------
+
 Bugfixes
 ^^^^^^^^
 


### PR DESCRIPTION
The current changelog has invalid syntax with a missing title underline rendering ugly plain text merge of two titles ("version+date" title + "bugfix" title). This patch addresses the immediate problem but I haven't checked what caused it (whether it's automation that is broken or a simple human error).

![tox-broken-changelog-title](https://user-images.githubusercontent.com/578543/130245339-78a98e2e-cda8-4830-8146-49c034ced7a8.png)


I'm not adding a change note because it seems unnecessary in this case.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
