### PR TITLE
📝 Document when `{tty}` was added

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1071,7 +1071,7 @@ Features
 - While running tox invokes various commands (such as building the package, pip installing dependencies and so on), these were printed in case they failed as Python arrays. Changed the representation to a shell command, allowing the users to quickly replicate/debug the failure on their own - by :user:`gaborbernat` (`#851 <https://github.com/tox-dev/tox/issues/851>`_)
 - skip missing interpreters value from the config file can now be overridden via the ``--skip-missing-interpreters`` cli flag - by :user:`gaborbernat` (`#903 <https://github.com/tox-dev/tox/issues/903>`_)
 - keep additional environments config order when listing them - by :user:`gaborbernat` (`#921 <https://github.com/tox-dev/tox/issues/921>`_)
-- allow injecting config value inside the ini file dependent of the fact that we're connected to an interactive shell or not  - by :user:`gaborbernat` (`#947 <https://github.com/tox-dev/tox/issues/947>`_)
+- allow injecting config value inside the ini file dependent of the fact that we're connected to an interactive shell or not via exposing a ``{tty}`` substitution - by :user:`gaborbernat` (`#947 <https://github.com/tox-dev/tox/issues/947>`_)
 - do not build sdist if skip install is specified for the envs to be run - by :user:`gaborbernat` (`#974 <https://github.com/tox-dev/tox/issues/974>`_)
 - when verbosity level increases above two start passing through verbosity flags to pip - by :user:`gaborbernat` (`#982 <https://github.com/tox-dev/tox/issues/982>`_)
 - when discovering the interpreter to use check if the tox host Python matches and use that if so - by :user:`gaborbernat` (`#994 <https://github.com/tox-dev/tox/issues/994>`_)

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -789,6 +789,8 @@ the above example is roughly equivalent to
 Interactive shell substitution
 ++++++++++++++++++++++++++++++
 
+.. versionadded:: 3.4.0
+
 It's possible to inject a config value only when tox is running in interactive shell (standard input)::
 
     {tty:ON_VALUE:OFF_VALUE}


### PR DESCRIPTION
I used the `{tty}` substitution in a `tox.ini` of one project and the minimum version set was ancient (~1.5) so I wanted to find out when it was introduced and both places where I'd expect this info weren't helpful.

I tracked it down to v3.4.0 via `git blame`, of course. But I think it'd be useful to actually have it in the Sphinx docs. So here you go. No change note because it's unnecessary here.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
