### PR TITLE
📝 Make Sphinx strict about broken references

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,4 @@ python:
 sphinx:
   builder: html
   configuration: docs/conf.py
+  fail_on_warning: true

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -72,7 +72,7 @@ Bugfixes
 ^^^^^^^^
 
 - Distinguish between normal Windows Python and MSYS2 Python when looking for
-  virtualenv executable path.  Adds os.sep to :class:`InterpreterInfo`
+  virtualenv executable path.  Adds os.sep to :class:`~tox.interpreters.InterpreterInfo`
   - by :user:`jschwartzentruber`
   `#1982 <https://github.com/tox-dev/tox/issues/1982>`_
 - Fix a ``tox-conda`` isolation build bug - by :user:`AntoineD`.

--- a/docs/changelog/2168.misc.rst
+++ b/docs/changelog/2168.misc.rst
@@ -1,0 +1,1 @@
+Started enforcing valid references in Sphinx docs -- :user:`webknjaz`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,3 +129,8 @@ extlinks = {
     "pull": ("https://github.com/tox-dev/tox/pull/%s", "p"),
     "user": ("https://github.com/%s", "@"),
 }
+
+nitpicky = True
+nitpick_ignore = [
+    ("py:class", "tox.interpreters.InterpreterInfo"),
+]

--- a/docs/example/basic.rst
+++ b/docs/example/basic.rst
@@ -212,7 +212,7 @@ Further customizing installation
 By default tox uses `pip`_ to install packages, both the
 package-under-test and any dependencies you specify in ``tox.ini``.
 You can fully customize tox's install-command through the
-testenv-specific :conf:`install_command=ARGV` setting.
+testenv-specific :conf:`install_command = ARGV <install_command>` setting.
 For instance, to use pip's ``--find-links`` and ``--no-index`` options to specify
 an alternative source for your dependencies:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,7 +137,7 @@ Current features
 * :doc:`plugin system <plugins>` to modify tox execution with simple hooks.
 
 * uses pip_ and setuptools_ by default.  Support for configuring the installer command
-  through :conf:`install_command=ARGV`.
+  through :conf:`install_command = ARGV <install_command>`.
 
 * **cross-Python compatible**: CPython-2.7, 3.5 and higher, Jython and pypy_.
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
 description = invoke sphinx-build to build the HTML docs
 basepython = python3.8
 extras = docs
-commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" --color -W --keep-going -n -bhtml {posargs}
            python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
 
 [testenv:package_description]


### PR DESCRIPTION
I noticed that the current Sphinx setup doesn't care about broken references. As a result, a few have slipped in, over time. This patch helps make sure that this won't happen again.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
