### PR TITLE
♲ Fix the rendering of PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,9 +14,12 @@ much about the checklist - we will help you get started.
       in message body
 - [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
   * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
-  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
+  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
   * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
-  * "sign" fragment with "by :user:`<your username>`"
-  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
+  * "sign" fragment with ```-- by :user:`<your username>`.```
+  * please, use full sentences with correct case and punctuation, for example:
+    ```rst
+    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
+    ```
   * also see [examples](../tree/master/docs/changelog)
 - [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)


### PR DESCRIPTION
Some parts with backticks in the PR template render weirdly. This should fix it. Please, find the template posted (and rendered) as is in the first comment below.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`,`breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with "by :user:`<your username>`"
  * please use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files - by :user:`superuser`."
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
