### PR TITLE
Internal changes to accomodate tox-conda

### DIFF
--- a/docs/changelog/2172.feature.rst
+++ b/docs/changelog/2172.feature.rst
@@ -1,0 +1,3 @@
+Changes to help plugin development: simpler tox env creation argument list, expose python creation directly,
+allow skipping list dependencies install command for pip and executable is only part of the python cache for virtualenv
+- by :user:`gaborbernat`.

--- a/src/tox/session/state.py
+++ b/src/tox/session/state.py
@@ -6,6 +6,7 @@ from tox.journal import Journal
 from tox.plugin import impl
 from tox.report import HandledError, ToxHandler
 from tox.session.common import CliEnv
+from tox.tox_env.api import ToxEnvCreateArgs
 from tox.tox_env.package import PackageToxEnv
 from tox.tox_env.runner import RunToxEnv
 
@@ -87,7 +88,8 @@ class State:
         builder = REGISTER.runner(runner)
         name = env_conf.name
         journal = self.journal.get_env_journal(name)
-        env: RunToxEnv = builder(env_conf, self.conf.core, self.options, journal, self.log_handler)
+        args = ToxEnvCreateArgs(env_conf, self.conf.core, self.options, journal, self.log_handler)
+        env: RunToxEnv = builder(args)
         self._run_env[name] = env
         self._build_package_env(env)
 
@@ -112,7 +114,8 @@ class State:
                 raise HandledError(f"{name} is already defined as a run environment, cannot be packaging too")
             pkg_conf = self.conf.get_env(name, package=True)
             journal = self.journal.get_env_journal(name)
-            pkg_tox_env = package_type(pkg_conf, self.conf.core, self.options, journal, self.log_handler)
+            args = ToxEnvCreateArgs(pkg_conf, self.conf.core, self.options, journal, self.log_handler)
+            pkg_tox_env = package_type(args)
             self._pkg_env[name] = packager, pkg_tox_env
         return pkg_tox_env
 

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, NamedTuple, Optional, Sequence, Tuple, Union, cast
 
 from tox.config.main import Config
 from tox.config.set_env import SetEnv
@@ -20,10 +20,9 @@ from tox.execute.request import ExecuteRequest
 from tox.journal import EnvJournal
 from tox.report import OutErr, ToxHandler
 from tox.tox_env.errors import Recreate, Skip
+from tox.tox_env.info import Info
 from tox.tox_env.installer import Installer
 from tox.util.path import ensure_empty_dir
-
-from .info import Info
 
 if TYPE_CHECKING:
     from tox.config.cli.parser import Parsed
@@ -31,25 +30,29 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
+class ToxEnvCreateArgs(NamedTuple):
+    """Arguments to pass on when creating a tox environment"""
+
+    conf: EnvConfigSet
+    core: CoreConfigSet
+    options: "Parsed"
+    journal: EnvJournal
+    log_handler: ToxHandler
+
+
 class ToxEnv(ABC):
     """A tox environment."""
 
-    def __init__(
-        self, conf: EnvConfigSet, core: CoreConfigSet, options: "Parsed", journal: EnvJournal, log_handler: ToxHandler
-    ) -> None:
+    def __init__(self, create_args: ToxEnvCreateArgs) -> None:
         """Create a new tox environment.
 
-        :param conf: the config set to use for this environment
-        :param core: the core config set
-        :param options: CLI options
-        :param journal: tox environment journal
-        :param log_handler: handler to the tox reporting system
+        :param create_args: tox env create args
         """
-        self.journal: EnvJournal = journal  #: handler to the tox reporting system
-        self.conf: EnvConfigSet = conf  #: the config set to use for this environment
-        self.core: CoreConfigSet = core  #: the core tox config set
-        self.options: Parsed = options  #: CLI options
-        self.log_handler: ToxHandler = log_handler  #: handler to the tox reporting system
+        self.journal: EnvJournal = create_args.journal  #: handler to the tox reporting system
+        self.conf: EnvConfigSet = create_args.conf  #: the config set to use for this environment
+        self.core: CoreConfigSet = create_args.core  #: the core tox config set
+        self.options: Parsed = create_args.options  #: CLI options
+        self.log_handler: ToxHandler = create_args.log_handler  #: handler to the tox reporting system
 
         #: encode the run state of various methods (setup/clean/etc)
         self._run_state = {"setup": False, "clean": False, "teardown": False}

--- a/src/tox/tox_env/package.py
+++ b/src/tox/tox_env/package.py
@@ -4,17 +4,12 @@ A tox environment that can build packages.
 from abc import ABC, abstractmethod
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Generator, List, Optional, Set, Tuple, cast
+from typing import Any, Generator, List, Optional, Set, Tuple, cast
 
 from tox.config.main import Config
-from tox.config.sets import CoreConfigSet, EnvConfigSet
-from tox.journal import EnvJournal
-from tox.report import ToxHandler
+from tox.config.sets import EnvConfigSet
 
-from .api import ToxEnv
-
-if TYPE_CHECKING:
-    from tox.config.cli.parser import Parsed
+from .api import ToxEnv, ToxEnvCreateArgs
 
 
 class Package:
@@ -31,10 +26,8 @@ class PathPackage(Package):
 
 
 class PackageToxEnv(ToxEnv, ABC):
-    def __init__(
-        self, conf: EnvConfigSet, core: CoreConfigSet, options: "Parsed", journal: EnvJournal, log_handler: ToxHandler
-    ) -> None:
-        super().__init__(conf, core, options, journal, log_handler)
+    def __init__(self, create_args: ToxEnvCreateArgs) -> None:
+        super().__init__(create_args)
         self._envs: Set[str] = set()
         self._lock = Lock()
 

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -20,6 +20,10 @@ from tox.tox_env.python.pip.req_file import PythonDeps
 class Pip(Installer[Python]):
     """Pip is a python installer that can install packages as defined by PEP-508 and PEP-517"""
 
+    def __init__(self, tox_env: Python, with_list_deps: bool = True) -> None:
+        self._with_list_deps = with_list_deps
+        super().__init__(tox_env)
+
     def _register_config(self) -> None:
         self._env.conf.add_config(
             keys=["pip_pre"],
@@ -32,14 +36,15 @@ class Pip(Installer[Python]):
             of_type=Command,
             default=self.default_install_command,
             post_process=self.post_process_install_command,
-            desc="install the latest available pre-release (alpha/beta/rc) of dependencies without a specified version",
+            desc="command used to install packages",
         )
-        self._env.conf.add_config(
-            keys=["list_dependencies_command"],
-            of_type=Command,
-            default=Command(["python", "-m", "pip", "freeze", "--all"]),
-            desc="install the latest available pre-release (alpha/beta/rc) of dependencies without a specified version",
-        )
+        if self._with_list_deps:  # pragma: no branch
+            self._env.conf.add_config(
+                keys=["list_dependencies_command"],
+                of_type=Command,
+                default=Command(["python", "-m", "pip", "freeze", "--all"]),
+                desc="command used to list isntalled packages",
+            )
 
     def default_install_command(self, conf: Config, env_name: Optional[str]) -> Command:  # noqa
         isolated_flag = "-E" if self._env.base_python.version_info.major == 2 else "-I"

--- a/src/tox/tox_env/python/runner.py
+++ b/src/tox/tox_env/python/runner.py
@@ -5,25 +5,21 @@ from abc import ABC
 from pathlib import Path
 from typing import Iterator, List, Optional, Set, Tuple
 
-from tox.config.cli.parser import Parsed
 from tox.config.main import Config
-from tox.config.sets import CoreConfigSet, EnvConfigSet
-from tox.journal import EnvJournal
-from tox.report import HandledError, ToxHandler
+from tox.report import HandledError
 from tox.tox_env.errors import Skip
 from tox.tox_env.package import Package, PathPackage
 from tox.tox_env.python.package import PythonPackageToxEnv
 from tox.tox_env.python.pip.req_file import PythonDeps
 
+from ..api import ToxEnvCreateArgs
 from ..runner import RunToxEnv
 from .api import Python
 
 
 class PythonRun(Python, RunToxEnv, ABC):
-    def __init__(
-        self, conf: EnvConfigSet, core: CoreConfigSet, options: Parsed, journal: EnvJournal, log_handler: ToxHandler
-    ):
-        super().__init__(conf, core, options, journal, log_handler)
+    def __init__(self, create_args: ToxEnvCreateArgs) -> None:
+        super().__init__(create_args)
 
     def register_config(self) -> None:
         super().register_config()
@@ -117,7 +113,9 @@ class PythonRun(Python, RunToxEnv, ABC):
 
     def _setup_env(self) -> None:
         super()._setup_env()
-        # install deps
+        self._install_deps()
+
+    def _install_deps(self) -> None:
         requirements_file: PythonDeps = self.conf["deps"]
         self.installer.install(requirements_file, PythonRun.__name__, "deps")
 

--- a/src/tox/tox_env/python/virtual_env/package/api.py
+++ b/src/tox/tox_env/python/virtual_env/package/api.py
@@ -10,14 +10,12 @@ from cachetools import cached
 from packaging.markers import Variable
 from packaging.requirements import Requirement
 
-from tox.config.cli.parser import Parsed
-from tox.config.sets import CoreConfigSet, EnvConfigSet
+from tox.config.sets import EnvConfigSet
 from tox.execute.api import ExecuteStatus
 from tox.execute.pep517_backend import LocalSubProcessPep517Executor
 from tox.execute.request import StdinSource
-from tox.journal import EnvJournal
 from tox.plugin import impl
-from tox.report import ToxHandler
+from tox.tox_env.api import ToxEnvCreateArgs
 from tox.tox_env.errors import Fail
 from tox.tox_env.package import Package
 from tox.tox_env.python.package import DevLegacyPackage, PythonPackageToxEnv, SdistPackage, WheelPackage
@@ -74,10 +72,8 @@ class ToxCmdStatus(CmdStatus):
 class Pep517VirtualEnvPackage(PythonPackageToxEnv, VirtualEnv, Frontend):
     """local file system python virtual environment via the virtualenv package"""
 
-    def __init__(
-        self, conf: EnvConfigSet, core: CoreConfigSet, options: Parsed, journal: EnvJournal, log_handler: ToxHandler
-    ) -> None:
-        VirtualEnv.__init__(self, conf, core, options, journal, log_handler)
+    def __init__(self, create_args: ToxEnvCreateArgs) -> None:
+        VirtualEnv.__init__(self, create_args)
         root: Path = self.conf["package_root"]
         Frontend.__init__(self, *Frontend.create_args_from_folder(root))
 

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -4,27 +4,20 @@ import re
 from abc import ABC, abstractmethod
 from hashlib import sha256
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Tuple, cast
+from typing import Any, Dict, Iterable, Iterator, List, Tuple, cast
 
-from tox.config.sets import CoreConfigSet, EnvConfigSet
 from tox.config.types import Command, EnvList
 from tox.journal import EnvJournal
-from tox.report import ToxHandler
 
-from .api import ToxEnv
+from .api import ToxEnv, ToxEnvCreateArgs
 from .package import Package, PackageToxEnv, PathPackage
-
-if TYPE_CHECKING:
-    from tox.config.cli.parser import Parsed
 
 
 class RunToxEnv(ToxEnv, ABC):
-    def __init__(
-        self, conf: EnvConfigSet, core: CoreConfigSet, options: "Parsed", journal: EnvJournal, log_handler: ToxHandler
-    ) -> None:
+    def __init__(self, create_args: ToxEnvCreateArgs) -> None:
         self._package_envs: Dict[str, PackageToxEnv] = {}
         self._packages: List[Package] = []
-        super().__init__(conf, core, options, journal, log_handler)
+        super().__init__(create_args)
 
     def register_config(self) -> None:
         def ensure_one_line(value: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,13 +87,12 @@ def patch_prev_py(mocker: MockerFixture) -> Callable[[bool], Tuple[str, str]]:
                 raw[1] -= 1  # type: ignore[operator]
             ver_info = VersionInfo(*raw)  # type: ignore[arg-type]
             return PythonInfo(
-                executable=Path(sys.executable),
                 implementation=impl,
                 version_info=ver_info,
                 version="",
                 is_64=True,
                 platform=sys.platform,
-                extra_version_info=None,
+                extra={"executable": Path(sys.executable)},
             )
 
         mocker.patch.object(VirtualEnv, "_get_python", get_python)


### PR DESCRIPTION
- introduce ToxEnvCreateArgs to simplify tox env interface
- allow skipping the list dependencies configuration for pip installer
- expose python environment creation directly via ensure_python_env
- executable should only be part of the python cache for virtual
  environments (moved it in PythonInfo to extra info set)

Signed-off-by: Bernát Gábor <gaborjbernat@gmail.com>

New tox-conda under https://github.com/gaborbernat/tox-conda/tree/v2/src/tox_conda