### PR TITLE
🐛📝 Suppress epub unknown MIME warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,6 +90,7 @@ epub_title = project
 epub_author = author
 epub_publisher = author
 epub_copyright = copyright
+suppress_warnings = ["epub.unknown_project_files"]  # Prevent barking at `.ico`
 
 intersphinx_mapping = {"https://docs.python.org/": None}
 


### PR DESCRIPTION
Apparently, RTD builds on master for the last two days fail to build epub with strict warnings enabled and the deployment doesn't get updated. See https://readthedocs.org/projects/tox/builds/. PR builds only build HTML and don't reveal the problem.

This patch should fix that (verified locally).

This is not user-facing so no changelog.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
