### PR TITLE
Fix usedevelop without setup.py

### DIFF
--- a/docs/changelog/2197.bugfix.rst
+++ b/docs/changelog/2197.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue when using usedevelop with a project that has no setup.py -- by :user:`AntoineD`.

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -7,6 +7,7 @@ import sys
 from itertools import chain
 
 import py
+import setuptools
 
 import tox
 from tox import reporter
@@ -323,20 +324,27 @@ class VirtualEnv(object):
     def _needs_reinstall(self, setupdir, action):
         setup_py = setupdir.join("setup.py")
         setup_cfg = setupdir.join("setup.cfg")
-        args = [self.envconfig.envpython, str(setup_py), "--name"]
         env = self._get_os_environ()
-        output = action.popen(
-            args,
-            cwd=setupdir,
-            redirect=False,
-            returnout=True,
-            env=env,
-            capture_err=False,
-        )
-        name = next(
-            (i for i in output.split("\n") if i and not i.startswith("pydev debugger:")),
-            "",
-        )
+
+        if setup_py.exists():
+            args = [self.envconfig.envpython, str(setup_py), "--name"]
+            output = action.popen(
+                args,
+                cwd=setupdir,
+                redirect=False,
+                returnout=True,
+                env=env,
+                capture_err=False,
+            )
+            name = next(
+                (i for i in output.split("\n") if i and not i.startswith("pydev debugger:")),
+                "",
+            )
+        else:
+            dist = setuptools.Distribution()
+            dist.parse_config_files()
+            name = dist.metadata.name
+
         args = [
             self.envconfig.envpython,
             "-c",

--- a/tests/unit/test_z_cmdline.py
+++ b/tests/unit/test_z_cmdline.py
@@ -727,6 +727,38 @@ def test_test_usedevelop(cmd, initproj, src_root, skipsdist):
     assert "develop-inst-nodeps" in result.out
 
 
+def test_usedevelop_with_setup_cfg_no_setup_py(cmd, initproj):
+    """Verify that an env with usedevelop enabled, no setup.py and a setup.cfg
+    can survive more than one tox execution."""
+    name = "example123-spameggs"
+    initproj(
+        (name, "0.5"),
+        filedefs={
+            "tox.ini": """
+            [testenv]
+            usedevelop=True
+            """,
+            "setup.cfg": """
+            [metadata]
+            name={}
+            [options]
+            package_dir =
+                =.
+            packages = find:
+            [options.packages.find]
+            where = .
+            """.format(
+                name
+            ),
+        },
+        add_missing_setup_py=False,
+    )
+    result = cmd("-v")
+    result.assert_success()
+    result = cmd("-v")
+    result.assert_success()
+
+
 def test_warning_emitted(cmd, initproj):
     initproj(
         "spam-0.0.1",


### PR DESCRIPTION
Fix #2197 

I was able to check the fix on an external project but unfortunately the new test does not work when the `cmd` fixture is called the second time (error at teardown).
Please let me know how to fix this test or feel free to change it.