### PR TITLE
venv: do not prepend a truncated shebang interpreter

### DIFF
--- a/docs/changelog/2208.bugfix.rst
+++ b/docs/changelog/2208.bugfix.rst
@@ -1,0 +1,2 @@
+Prevent tox from using a truncated interpreter when using
+``TOX_LIMITED_SHEBANG`` -- by :user:`jdknight`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1097,9 +1097,9 @@ Handle interpreter directives with long lengths
 For systems supporting executable text files (scripts with a shebang), the
 system will attempt to parse the interpreter directive to determine the program
 to execute on the target text file. When ``tox`` prepares a virtual environment
-in a file container which has a large length (e.x. using Jenkins Pipelines), the
+in a file container which has a large length (e.g. using Jenkins Pipelines), the
 system might not be able to invoke shebang scripts which define interpreters
-beyond system limits (e.x. Linux as a limit of 128; ``BINPRM_BUF_SIZE``). To
+beyond system limits (e.g. Linux has a limit of 128; ``BINPRM_BUF_SIZE``). To
 workaround an environment which suffers from an interpreter directive limit, a
 user can bypass the system's interpreter parser by defining the
 ``TOX_LIMITED_SHEBANG`` environment variable before invoking ``tox``::

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -675,7 +675,7 @@ def prepend_shebang_interpreter(args):
     #
     # When preparing virtual environments in a file container which has large
     # length, the system might not be able to invoke shebang scripts which
-    # define interpreters beyond system limits (e.x. Linux as a limit of 128;
+    # define interpreters beyond system limits (e.g. Linux has a limit of 128;
     # BINPRM_BUF_SIZE). This method can be used to check if the executable is
     # a script containing a shebang line. If so, extract the interpreter (and
     # possible optional argument) and prepend the values to the provided

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -19,6 +19,9 @@ from tox.util.path import ensure_empty_dir
 
 from .config import DepConfig
 
+#: maximum parsed shebang interpreter length (see: prepend_shebang_interpreter)
+MAXINTERP = 2048
+
 
 class CreationConfig:
     def __init__(
@@ -682,8 +685,9 @@ def prepend_shebang_interpreter(args):
     try:
         with open(args[0], "rb") as f:
             if f.read(1) == b"#" and f.read(1) == b"!":
-                MAXINTERP = 2048
-                interp = f.readline(MAXINTERP).rstrip().decode("UTF-8")
+                interp = f.readline(MAXINTERP + 1).rstrip().decode("UTF-8")
+                if len(interp) > MAXINTERP:  # avoid a truncated interpreter
+                    return args
                 interp_args = interp.split(None, 1)[:2]
                 return interp_args + args
     except (UnicodeDecodeError, IOError):

--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -9,6 +9,7 @@ import tox
 from tox.interpreters import NoInterpreterInfo
 from tox.session.commands.run.sequential import installpkg, runtestenv
 from tox.venv import (
+    MAXINTERP,
     CreationConfig,
     VirtualEnv,
     getdigest,
@@ -1147,6 +1148,18 @@ def test_tox_testenv_interpret_shebang_long_example(tmpdir):
     ]
 
     assert args == expected + base_args
+
+
+@pytest.mark.skipif("sys.platform == 'win32'", reason="no shebang on Windows")
+def test_tox_testenv_interpret_shebang_skip_truncated(tmpdir):
+    testfile = tmpdir.join("check_shebang_truncation.py")
+    original_args = [str(testfile), "arg1", "arg2", "arg3"]
+
+    # interpreter (too long example)
+    testfile.write("#!" + ("x" * (MAXINTERP + 1)))
+    args = prepend_shebang_interpreter(original_args)
+
+    assert args == original_args
 
 
 @pytest.mark.parametrize("download", [True, False, None])


### PR DESCRIPTION
When a user invokes a `tox` call with `TOX_LIMITED_SHEBANG` set, any shebang-based scripts will have their interpreter's extracted and explicitly executed. An issue with the initial implementation is that if the configured interpreter is truncated to a path of another executable, the wrong executable can be invoked instead (see also \[1\]\[2\]). To prevent this, an extra byte is read to ensure the length of the extracted interpreter is within the configured limit (`MAXINTERP`); otherwise the call will know the interpreter has been truncated and will fallback onto the original argument list.

\[1\]: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/fs/binfmt_script.c?id=8099b047ecc431518b9bb6bdbba3549bbecdc343
\[2\]: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/fs/binfmt_script.c?id=b5372fe5dc84235dbe04998efdede3c4daa866a9