### PR TITLE
Let tox run fail when all envs are skipped

### DIFF
--- a/docs/changelog/2195.feature.rst
+++ b/docs/changelog/2195.feature.rst
@@ -1,0 +1,1 @@
+Let tox run fail when all envs are skipped -- by :user:`jugmac00`.

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -144,9 +144,10 @@ def report(start: float, runs: List[ToxEnvRunResult], is_colored: bool) -> int:
     def _print(color_: int, message: str) -> None:
         print(f"{color_ if is_colored else ''}{message}{Fore.RESET if is_colored else ''}")
 
-    all_good = True
+    successful, skipped = [], []
     for run in runs:
-        all_good &= run.code == Outcome.OK or run.ignore_outcome
+        successful.append(run.code == Outcome.OK or run.ignore_outcome)
+        skipped.append(run.skipped)
         duration_individual = [o.elapsed for o in run.outcomes]
         extra = f"+cmd[{','.join(f'{i:.2f}' for i in duration_individual)}]" if duration_individual else ""
         setup = run.duration - sum(duration_individual)
@@ -155,6 +156,7 @@ def report(start: float, runs: List[ToxEnvRunResult], is_colored: bool) -> int:
         _print(color, out)
 
     duration = time.monotonic() - start
+    all_good = all(successful) and not all(skipped)
     if all_good:
         _print(Fore.GREEN, f"  congratulations :) ({duration:.2f} seconds)")
         return Outcome.OK

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -410,7 +410,7 @@ def test_platform_does_not_match_package_env(tox_project: ToxProjectCreator, dem
     ini = "[testenv]\npackage=wheel\n[testenv:.pkg]\nplatform=wrong_platform"
     proj = tox_project({"tox.ini": ini, "pyproject.toml": toml, "build.py": build})
     result = proj.run("r", "-e", "a,b")
-    result.assert_success()
+    result.assert_failed()  # tox run fails as all envs are skipped
     assert "a: SKIP" in result.out
     assert "b: SKIP" in result.out
     msg = f"skipped because platform {sys.platform} does not match wrong_platform for package environment .pkg"


### PR DESCRIPTION
fixes #2195

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)