### PR TITLE
Make ConfigSet ABC and add contains to Loader

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.3
+    rev: v2.25.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 21.8b0
     hooks:
       - id: black
         args:
@@ -44,11 +44,11 @@ repos:
       - id: tox-ini-fmt
         args: [ "-p", "fix" ]
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.10.0
+    rev: v1.11.0
     hooks:
       - id: blacken-docs
         additional_dependencies:
-          - black==21.7b0
+          - black==21.8b0
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:
@@ -67,7 +67,7 @@ repos:
       - id: flake8
         additional_dependencies:
         - flake8-bugbear==21.4.3
-        - flake8-comprehensions==3.5
+        - flake8-comprehensions==3.6.1
         - flake8-pytest-style==1.5
         - flake8-spellcheck==0.24
         - flake8-unused-arguments==0.0.6

--- a/docs/changelog/2209.bugfix.rst
+++ b/docs/changelog/2209.bugfix.rst
@@ -1,0 +1,2 @@
+Do not allow constructing ``ConfigSet`` directly and implement ``__contains__`` for ``Loader`` -- by
+:user:`gaborbernat`.

--- a/src/tox/config/loader/api.py
+++ b/src/tox/config/loader/api.py
@@ -77,6 +77,9 @@ class Loader(Convert[T]):
     def __repr__(self) -> str:
         return f"{type(self).__name__}"
 
+    def __contains__(self, item: str) -> bool:
+        return item in self.found_keys()
+
     def load(
         self,
         key: str,
@@ -91,8 +94,10 @@ class Loader(Convert[T]):
 
         :param key: the key under it lives
         :param of_type: the type to convert to
+        :param kwargs: keyword arguments to forward
         :param conf: the configuration object of this tox session (needed to manifest the value)
         :param env_name: env name
+        :param chain: a chain of lookups
         :return: the converted type
         """
         if key in self.overrides:

--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 V = TypeVar("V")
 
 
-class ConfigSet:
+class ConfigSet(ABC):
     """A set of configuration that belong together (such as a tox environment settings, core tox settings)"""
 
     def __init__(self, conf: "Config"):
@@ -118,8 +119,9 @@ class ConfigSet:
         return config_definition.__call__(self._conf, self.loaders, self.name, chain)
 
     @property
+    @abstractmethod
     def name(self) -> Optional[str]:
-        return None
+        raise NotImplementedError
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(loaders={self.loaders!r})"
@@ -196,6 +198,10 @@ class CoreConfigSet(ConfigSet):
 
     def _on_duplicate_conf(self, key: str, definition: ConfigDefinition[V]) -> None:  # noqa: U100
         pass  # core definitions may be defined multiple times as long as all their options match, first defined wins
+
+    @property
+    def name(self) -> Optional[str]:
+        return None
 
 
 class EnvConfigSet(ConfigSet):

--- a/tests/config/loader/test_memory_loader.py
+++ b/tests/config/loader/test_memory_loader.py
@@ -45,3 +45,9 @@ def test_memory_loader(value: Any, of_type: Type[Any]) -> None:
 def test_memory_found_keys() -> None:
     loader = MemoryLoader(a=1, c=2)
     assert loader.found_keys() == {"a", "c"}
+
+
+def test_memory_loader_contains() -> None:
+    loader = MemoryLoader(a=1)
+    assert "a" in loader
+    assert "b" not in loader


### PR DESCRIPTION
The ConfigSet should be always specialized via subclassing. The contains
is a quality of life imporvement for plugins. Also bumped the tools
while at it.

Signed-off-by: Bernát Gábor <gaborjbernat@gmail.com>
