### PR TITLE
Fix list/depends cmd creates package env as run env

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.26.0
+    rev: v2.27.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]

--- a/docs/changelog/2234.bugfix.rst
+++ b/docs/changelog/2234.bugfix.rst
@@ -1,0 +1,2 @@
+Fix list/depends commands can create tox package environment as runtime environment and display an error message
+- by :user:`gaborbernat`.

--- a/src/tox/execute/local_sub_process/__init__.py
+++ b/src/tox/execute/local_sub_process/__init__.py
@@ -63,7 +63,8 @@ class LocalSubprocessExecuteStatus(ExecuteStatus):
             msg = "requested interrupt of %d from %d, activate in %.2f"
             logging.warning(msg, to_pid, host_pid, self.options.suicide_timeout)
             if self.wait(self.options.suicide_timeout) is None:  # still alive -> INT
-                if sys.platform != "win32":  # on Windows everyone in the same process group, so they got the message
+                # on Windows everyone in the same process group, so they got the message
+                if sys.platform != "win32":  # pragma: win32 cover
                     msg = "send signal %s to %d from %d with timeout %.2f"
                     logging.warning(msg, f"SIGINT({SIG_INTERRUPT})", to_pid, host_pid, self.options.interrupt_timeout)
                     self._process.send_signal(SIG_INTERRUPT)

--- a/src/tox/session/cmd/depends.py
+++ b/src/tox/session/cmd/depends.py
@@ -17,7 +17,7 @@ def tox_add_option(parser: ToxParser) -> None:
 
 
 def depends(state: State) -> int:
-    to_run_list = list(state.conf.env_list(everything=True))
+    to_run_list = list(state.all_run_envs(with_skip=False))
     order, todo = run_order(state, to_run_list)
     print(f"Execution order: {', '.join(order)}")
 
@@ -25,8 +25,6 @@ def depends(state: State) -> int:
     deps["ALL"] = to_run_list
 
     def _handle(at: int, env: str) -> None:
-        if env not in order and env != "ALL":  # skipped envs
-            return
         print("   " * at, end="")
         print(env, end="")
         if env != "ALL":

--- a/src/tox/session/cmd/list_env.py
+++ b/src/tox/session/cmd/list_env.py
@@ -18,9 +18,8 @@ def list_env(state: State) -> int:
     option = state.options
 
     default = core["env_list"]  # this should be something not affected by env-vars :-|
-    ignore = {core["provision_tox_env"]}.union(default)
 
-    extra = [] if option.list_default_only else [e for e in state.conf.env_list(everything=True) if e not in ignore]
+    extra = [] if option.list_default_only else [e for e in state.all_run_envs(with_skip=True) if e not in default]
 
     if not option.list_no_description and default:
         print("default environments:")
@@ -28,22 +27,24 @@ def list_env(state: State) -> int:
 
     def report_env(name: str) -> None:
         if not option.list_no_description:
-            text = state.tox_env(name).conf["description"]
+            tox_env = state.tox_env(name)
+            text = tox_env.conf["description"]
             if not text.strip():
                 text = "[no description]"
             text = text.replace("\n", " ")
-            msg = f"{e.ljust(max_length)} -> {text}".strip()
+            msg = f"{env.ljust(max_length)} -> {text}".strip()
         else:
-            msg = e
+            msg = env
         print(msg)
 
-    for e in default:
-        report_env(e)
+    for env in default:
+        report_env(env)
+
     if not option.list_default_only and extra:
         if not option.list_no_description:
             if default:
                 print("")
             print("additional environments:")
-        for e in extra:
-            report_env(e)
+        for env in extra:
+            report_env(env)
     return 0

--- a/src/tox/tox_env/python/runner.py
+++ b/src/tox/tox_env/python/runner.py
@@ -66,7 +66,7 @@ class PythonRun(Python, RunToxEnv, ABC):
         if develop_mode:
             self.conf.add_constant(["package"], desc, "dev-legacy")
         else:
-            self.conf.add_config(keys="package", of_type=str, default="sdist", desc=desc)
+            self.conf.add_config(keys="package", of_type=str, default=self.default_pkg_type, desc=desc)
         pkg_type = self.pkg_type
 
         if pkg_type == "skip":
@@ -108,6 +108,10 @@ class PythonRun(Python, RunToxEnv, ABC):
             desc="extras to install of the target package",
         )
         return True
+
+    @property
+    def default_pkg_type(self) -> str:
+        return "sdist"
 
     @property
     def pkg_type(self) -> str:

--- a/src/tox/tox_env/python/virtual_env/runner.py
+++ b/src/tox/tox_env/python/virtual_env/runner.py
@@ -22,13 +22,14 @@ class VirtualEnvRunner(VirtualEnv, PythonRun):
         return "virtualenv-pep-517"
 
     @property
-    def has_package_by_default(self) -> bool:
+    def default_pkg_type(self) -> str:
         tox_root: Path = self.core["tox_root"]
-        return (
-            getattr(self.options, "install_pkg", None) is not None
-            or (tox_root / "pyproject.toml").exists()
-            or (tox_root / "setup.py").exists()
-        )
+        if not (
+            any((tox_root / i).exists() for i in ("pyproject.toml", "setup.py", "setup.cfg"))
+            or getattr(self.options, "install_pkg", None) is not None
+        ):
+            return "skip"
+        return super().default_pkg_type
 
 
 @impl

--- a/src/tox/tox_env/register.py
+++ b/src/tox/tox_env/register.py
@@ -40,17 +40,17 @@ class ToxEnvRegister:
         self._package_envs[of_type.id()] = of_type
 
     @property
-    def run_envs(self) -> Iterable[str]:
+    def env_runners(self) -> Iterable[str]:
         """:returns: run environment types currently defined"""
         return self._run_envs.keys()
 
     @property
-    def default_run_env(self) -> str:
+    def default_env_runner(self) -> str:
         """:returns: the default run environment type"""
         return self._default_run_env
 
-    @default_run_env.setter
-    def default_run_env(self, value: str) -> None:
+    @default_env_runner.setter
+    def default_env_runner(self, value: str) -> None:
         """
         Change the default run environment type.
 

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -147,7 +147,7 @@ class RunToxEnv(ToxEnv, ABC):
         self.core.add_config(
             keys=["no_package", "skipsdist"],
             of_type=bool,
-            default=not self.has_package_by_default,
+            default=False,
             desc="is there any packaging involved in this project",
         )
         core_no_package: bool = self.core["no_package"]
@@ -161,11 +161,6 @@ class RunToxEnv(ToxEnv, ABC):
         )
         skip_install: bool = self.conf["skip_install"]
         return not skip_install
-
-    @property
-    @abstractmethod
-    def has_package_by_default(self) -> bool:
-        raise NotImplementedError
 
     def _setup_pkg(self) -> None:
         self._packages = self._build_packages()

--- a/tests/session/cmd/test_list_envs.py
+++ b/tests/session/cmd/test_list_envs.py
@@ -7,14 +7,17 @@ from tox.pytest import ToxProject, ToxProjectCreator
 def project(tox_project: ToxProjectCreator) -> ToxProject:
     ini = """
     [tox]
-    env_list=py39,py38,py
+    env_list=py32,py31,py
     [testenv]
+    package = wheel
+    wheel_build_env = pkg
     description = with {basepython}
     deps = pypy:
     [testenv:py]
-    basepython=py39,py38
+    basepython=py32,py31
     [testenv:fix]
     description = fix it
+    [testenv:pkg]
     """
     return tox_project({"tox.ini": ini})
 
@@ -25,9 +28,9 @@ def test_list_env(project: ToxProject) -> None:
     outcome.assert_success()
     expected = """
     default environments:
-    py39 -> with py39
-    py38 -> with py38
-    py   -> with py39 py38
+    py32 -> with py32
+    py31 -> with py31
+    py   -> with py32 py31
 
     additional environments:
     fix  -> fix it
@@ -41,9 +44,9 @@ def test_list_env_default(project: ToxProject) -> None:
     outcome.assert_success()
     expected = """
     default environments:
-    py39 -> with py39
-    py38 -> with py38
-    py   -> with py39 py38
+    py32 -> with py32
+    py31 -> with py31
+    py   -> with py32 py31
     """
     outcome.assert_out_err(expected, "")
 
@@ -53,8 +56,8 @@ def test_list_env_quiet(project: ToxProject) -> None:
 
     outcome.assert_success()
     expected = """
-    py39
-    py38
+    py32
+    py31
     py
     fix
     """
@@ -66,8 +69,8 @@ def test_list_env_quiet_default(project: ToxProject) -> None:
 
     outcome.assert_success()
     expected = """
-    py39
-    py38
+    py32
+    py31
     py
     """
     outcome.assert_out_err(expected, "")

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -60,7 +60,7 @@ def test_show_config_filter_keys(tox_project: ToxProjectCreator) -> None:
     project = tox_project({"tox.ini": "[testenv]\nmagic=yes"})
     outcome = project.run("c", "-e", "py", "-k", "no_package", "env_name", "--core")
     outcome.assert_success()
-    outcome.assert_out_err("[testenv:py]\nenv_name = py\n\n[tox]\nno_package = True\n", "")
+    outcome.assert_out_err("[testenv:py]\nenv_name = py\n\n[tox]\nno_package = False\n", "")
 
 
 def test_show_config_unused(tox_project: ToxProjectCreator) -> None:

--- a/tests/tox_env/test_register.py
+++ b/tests/tox_env/test_register.py
@@ -7,12 +7,12 @@ from tox.tox_env.register import ToxEnvRegister
 def test_register_set_new_default_no_register() -> None:
     register = ToxEnvRegister()
     with pytest.raises(ValueError, match="run env must be registered before setting it as default"):
-        register.default_run_env = "new-env"
+        register.default_env_runner = "new-env"
 
 
 def test_register_set_new_default_with_register() -> None:
     register = ToxEnvRegister()
     register.add_run_env(VirtualEnvRunner)
-    assert register.default_run_env == ""
-    register.default_run_env = VirtualEnvRunner.id()
-    assert register.default_run_env == "virtualenv"
+    assert register.default_env_runner == ""
+    register.default_env_runner = VirtualEnvRunner.id()
+    assert register.default_env_runner == "virtualenv"

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ commands =
     coverage html -d {toxworkdir}{/}htmlcov
     diff-cover --compare-branch {env:DIFF_AGAINST:upstream/rewrite} {toxworkdir}{/}coverage.xml
 depends =
+    py310
     py39
     py38
     py37


### PR DESCRIPTION
This happens if you declare configuration for a packaging environment.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
Signed-off-by: Bernát Gábor <gaborjbernat@gmail.com>
