### PR TITLE
Do not reinstall in develop mode without setup.py

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -115,6 +115,7 @@ Tim Laurence
 Tyagraj Desigar
 Usama Sadiq
 Ville Skyttä
+Vincent Vanlaer
 Vlastimil Zíma
 Xander Johnson
 anatoly techtonik

--- a/docs/changelog/2197.bugfix.rst
+++ b/docs/changelog/2197.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where ``usedevelop`` would cause an invocation error if setup.py does not exist. -- by :user:`VincentVanlaer`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -596,7 +596,9 @@ Complete list of settings that you can put into ``testenv*`` sections:
     Install the current package in development mode with "setup.py
     develop" instead of installing from the ``sdist`` package. (This
     uses pip's ``-e`` option, so should be avoided if you've specified a
-    custom :conf:`install_command` that does not support ``-e``).
+    custom :conf:`install_command` that does not support ``-e``). Note that
+    changes to the build/install process (including changes in dependencies)
+    are only detected when using setuptools with setup.py.
 
 .. conf:: skip_install ^ true|false ^ false
 

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -325,6 +325,10 @@ class VirtualEnv(object):
 
     def _needs_reinstall(self, setupdir, action):
         setup_py = setupdir.join("setup.py")
+
+        if not setup_py.exists():
+            return False
+
         setup_cfg = setupdir.join("setup.cfg")
         args = [self.envconfig.envpython, str(setup_py), "--name"]
         env = self._get_os_environ()

--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -70,6 +70,7 @@ def test_create(mocksession, newconfig):
     assert not venv.path.check()
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
     args = pcalls[0].args
@@ -135,6 +136,7 @@ def test_create_sitepackages(mocksession, newconfig):
     venv = mocksession.getvenv("site")
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
     args = pcalls[0].args
@@ -144,6 +146,7 @@ def test_create_sitepackages(mocksession, newconfig):
     venv = mocksession.getvenv("nosite")
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
     args = pcalls[0].args
@@ -165,6 +168,7 @@ def test_install_deps_wildcard(newmocksession):
     venv = mocksession.getvenv("py123")
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
         pcalls = mocksession._pcalls
         assert len(pcalls) == 1
         distshare = venv.envconfig.config.distshare
@@ -201,6 +205,7 @@ def test_install_deps_indexserver(newmocksession):
     venv = mocksession.getvenv("py123")
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
         pcalls = mocksession._pcalls
         assert len(pcalls) == 1
         pcalls[:] = []
@@ -233,6 +238,7 @@ def test_install_deps_pre(newmocksession):
     venv = mocksession.getvenv("python")
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
     pcalls = mocksession._pcalls
     assert len(pcalls) == 1
     pcalls[:] = []
@@ -294,6 +300,7 @@ def test_install_sdist_extras(newmocksession):
     venv = mocksession.getvenv("python")
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
     pcalls = mocksession._pcalls
     assert len(pcalls) == 1
     pcalls[:] = []
@@ -314,6 +321,7 @@ def test_develop_extras(newmocksession, tmpdir):
     venv = mocksession.getvenv("python")
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
     pcalls = mocksession._pcalls
     assert len(pcalls) == 1
     pcalls[:] = []
@@ -519,6 +527,7 @@ def test_install_python3(newmocksession):
     venv = mocksession.getvenv("py123")
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
         pcalls = mocksession._pcalls
         assert len(pcalls) == 1
         args = pcalls[0].args
@@ -1177,6 +1186,7 @@ def test_create_download(mocksession, newconfig, download):
     venv = mocksession.getvenv("env")
     with mocksession.newaction(venv.name, "getenv") as action:
         tox_testenv_create(action=action, venv=venv)
+        venv.just_created = True
     pcalls = mocksession._pcalls
     assert len(pcalls) >= 1
     args = pcalls[0].args


### PR DESCRIPTION
The detection logic for figuring out whether a editable install needs to be reinstalled only works for setuptools based builds using setup.py. If setup.py cannot be found the code will fail with an invocation error. Currently no standard mechanism exists to query a package installed in editable mode whether it should be reinstalled or not. Hence, this change skips reinstallation if setup.py cannot be found.

Fixes #2197 

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
