### PR TITLE
avoid double-running for in-repo branches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,8 @@
 name: check
 on:
   push:
+    branches: [master, 'test-me-*']
+    tags:
   pull_request:
   schedule:
     - cron: "0 8 * * *"


### PR DESCRIPTION
noticed that we ran twice as many checks as needed in #2295 