### PR TITLE
Fix double clean package and broken report

### DIFF
--- a/docs/changelog/2300.bugfix.rst
+++ b/docs/changelog/2300.bugfix.rst
@@ -1,0 +1,2 @@
+Sequential run fails because the packaging environment is deleted twice for sequential runs with recreate flag on
+- by :user:`gaborbernat`.

--- a/docs/changelog/2309.bugfix.rst
+++ b/docs/changelog/2309.bugfix.rst
@@ -1,0 +1,2 @@
+Environment assigment for output breaks when using ``-rv`` (when we cannot guess upfront the verbosity level from the
+CLI arguments) - by :user:`gaborbernat`.

--- a/src/tox/config/cli/parse.py
+++ b/src/tox/config/cli/parse.py
@@ -35,7 +35,7 @@ def get_options(*args: str) -> Options:
     guess_verbosity, log_handler, source = _get_base(args)
     parsed, cmd_handlers = _get_all(args)
     if guess_verbosity != parsed.verbosity:
-        setup_report(parsed.verbosity, parsed.is_colored)  # pragma: no cover
+        log_handler.update_verbosity(parsed.verbosity)
     return Options(parsed, pos_args, source, cmd_handlers, log_handler)
 
 

--- a/src/tox/report.py
+++ b/src/tox/report.py
@@ -204,8 +204,8 @@ class ToxHandler(logging.StreamHandler):  # type: ignore[type-arg] # is generic 
         LOGGER.setLevel(level)
         for name in ("distlib.util", "filelock"):
             logger = logging.getLogger(name)
-            for logging_filter in logger.filters:
-                if isinstance(logging_filter, LowerInfoLevel):
+            for logging_filter in logger.filters:  # pragma: no branch  # the filters is never empty
+                if isinstance(logging_filter, LowerInfoLevel):  # pragma: no branch # we always find it
                     logging_filter.level = level
                     break
         self._setup_level(self._is_colored, level)

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -233,14 +233,14 @@ class ToxEnv(ABC):
             else:
                 self._done_with_setup()
             finally:
-                self._run_state.update({"setup": True, "clean": False})
+                self._run_state["setup"] = True
 
     def teardown(self) -> None:
         if not self._run_state["teardown"]:
             try:
                 self._teardown()
             finally:
-                self._run_state.update({"teardown": True})
+                self._run_state["teardown"] = True
 
     def _teardown(self) -> None:
         pass

--- a/tests/config/cli/test_parse.py
+++ b/tests/config/cli/test_parse.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from tox.config.cli.parse import get_options
 from tox.pytest import CaptureFixture
+from tox.report import LowerInfoLevel
 
 
 def test_help_does_not_default_cmd(capsys: CaptureFixture) -> None:
@@ -13,3 +16,25 @@ def test_help_does_not_default_cmd(capsys: CaptureFixture) -> None:
     assert not err
     assert "--verbose" in out
     assert "subcommands:" in out
+
+
+def test_verbosity_guess_miss_match(capsys: CaptureFixture) -> None:
+    result = get_options("-rv")
+    assert result.parsed.verbosity == 3
+
+    assert logging.getLogger().level == logging.INFO
+
+    for name in ("distlib.util", "filelock"):
+        logger = logging.getLogger(name)
+        for logging_filter in logger.filters:  # pragma: no branch # never empty
+            if isinstance(logging_filter, LowerInfoLevel):  # pragma: no branch # we always find it
+                assert logging_filter.level == logging.INFO
+                break
+
+    logging.error("E")
+    logging.warning("W")
+    logging.info("I")
+    logging.debug("D")
+
+    out, err = capsys.readouterr()
+    assert out == "ROOT: E\nROOT: W\nROOT: I\n"

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -411,3 +411,9 @@ def test_virtualenv_cache(tox_project: ToxProjectCreator) -> None:
 def test_sequential_help(tox_project: ToxProjectCreator) -> None:
     outcome = tox_project({"tox.ini": ""}).run("r", "-h")
     outcome.assert_success()
+
+
+def test_sequential_clears_pkg_at_most_once(tox_project: ToxProjectCreator, demo_pkg_inline: Path) -> None:
+    project = tox_project({"tox.ini": ""})
+    result = project.run("r", "--root", str(demo_pkg_inline), "-e", "a,b", "-r")
+    result.assert_success()


### PR DESCRIPTION
- Fix environment logging is off when verbosity cannot be guessed on CLI
- Do not clean sequential packaging envs twice


Resolves #2300.