### PR TITLE
Do not allow extending the config set beyond setup

### DIFF
--- a/docs/changelog/2243.feature.rst
+++ b/docs/changelog/2243.feature.rst
@@ -1,0 +1,2 @@
+Do not allow extending the config set beyond setup to ensures that all configuration values are visible via the config
+sub-command. - by :user:`gaborbernat`.

--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -28,11 +28,15 @@ class ConfigSet(ABC):
         self._defined: dict[str, ConfigDefinition[Any]] = {}
         self._keys: dict[str, None] = {}
         self._alias: dict[str, str] = {}
+        self._final = False
         self.register_config()
 
     @abstractmethod
     def register_config(self) -> None:
         raise NotImplementedError
+
+    def mark_finalized(self) -> None:
+        self._final = True
 
     def add_config(
         self,
@@ -54,6 +58,8 @@ class ConfigSet(ABC):
         :param factory: factory method to use to build the object
         :return: the new dynamic config definition
         """
+        if self._final:
+            raise RuntimeError("config set has been marked final and cannot be extended")
         keys_ = self._make_keys(keys)
         definition = ConfigDynamicDefinition(keys_, desc, of_type, default, post_process, factory)
         result = self._add_conf(keys_, definition)
@@ -68,6 +74,8 @@ class ConfigSet(ABC):
         :param value: the config value to use
         :return: the new constant config value
         """
+        if self._final:
+            raise RuntimeError("config set has been marked final and cannot be extended")
         keys_ = self._make_keys(keys)
         definition = ConfigConstantDefinition(keys_, desc, value)
         result = self._add_conf(keys_, definition)

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -206,8 +206,15 @@ class EnvSelector:
             # reorder to as defined rather as found
             order = chain(env_name_to_active, (i for i in self._defined_envs_ if i not in env_name_to_active))
             self._defined_envs_ = {name: self._defined_envs_[name] for name in order if name in self._defined_envs_}
+            self._finalize_config()
             self._mark_active()
         return self._defined_envs_
+
+    def _finalize_config(self) -> None:
+        assert self._defined_envs_ is not None
+        for tox_env in self._defined_envs_.values():
+            tox_env.env.conf.mark_finalized()
+        self._state.conf.core.mark_finalized()
 
     def _build_run_env(self, name: str) -> RunToxEnv | None:
         if self._provision is not None and self._provision[0] is False and name == self._provision[1]:

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -159,6 +159,7 @@ class ToxEnv(ABC):
             default=[],
             desc="external command glob to allow calling",
         )
+        assert self.installer is not None  # trigger installer creation to allow configuration registration
 
     def _recreate_default(self, conf: Config, value: str | None) -> bool:  # noqa: U100
         return cast(bool, self.options.recreate)


### PR DESCRIPTION
This ensures that all configuration values are visible via the config
sub-command.

Signed-off-by: Bernát Gábor <gaborjbernat@gmail.com>
