### PR TITLE
venv: Do not fail for test commands that don't exist with "-" leader

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@ Brett Smith
 Bruno Oliveira
 Carl Meyer
 Charles Brunet
+Chris Down
 Chris Jerdonek
 Chris Rose
 Clark Boylan

--- a/docs/changelog/2315.feature.rst
+++ b/docs/changelog/2315.feature.rst
@@ -1,0 +1,2 @@
+Ignore missing commands if they are prefixed by ``-``
+-- by :user:`cdown`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -264,7 +264,7 @@ Complete list of settings that you can put into ``testenv*`` sections:
 
     Commands will execute one by one in sequential fashion until one of them fails (their exit
     code is non-zero) or all of them succeed. The exit code of a command may be ignored (meaning
-    they are always considered successful) by prefixing the command with a dash (``-``) - this is
+    they are always considered successful even if they don't exist) by prefixing the command with a dash (``-``) - this is
     similar to how ``make`` recipe lines work. The outcome of the environment is considered successful
     only if all commands (these + setup + teardown) succeeded (exit code ignored via the
     ``-`` or success exit code value of zero).

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -595,7 +595,17 @@ class VirtualEnv(object):
         reporter.verbosity2("setting PATH={}".format(env["PATH"]))
 
         # get command
-        args[0] = self.getcommandpath(args[0], venv, cwd)
+        try:
+            args[0] = self.getcommandpath(args[0], venv, cwd)
+        except tox.exception.InvocationError:
+            if ignore_ret:
+                self.status = getattr(self, "status", 0)
+                msg = "command not found but explicitly ignored"
+                reporter.warning("{}\ncmd: {}".format(msg, args[0]))
+                return ""  # in case it's returnout
+            else:
+                raise
+
         if sys.platform != "win32" and "TOX_LIMITED_SHEBANG" in os.environ:
             args = prepend_shebang_interpreter(args)
 

--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -980,6 +980,21 @@ def test_ignore_outcome_failing_cmd(newmocksession):
     mocksession.report.expect("warning", "*command failed but result from testenv is ignored*")
 
 
+def test_ignore_outcome_missing_cmd(newmocksession):
+    mocksession = newmocksession(
+        [],
+        """\
+        [testenv]
+        commands=-thiscommanddoesntexist
+        """,
+    )
+
+    venv = mocksession.getvenv("python")
+    venv.test()
+    assert venv.status == 0
+    mocksession.report.expect("warning", "*command not found but explicitly ignored*")
+
+
 def test_tox_testenv_create(newmocksession):
     log = []
 


### PR DESCRIPTION
Commands which fail, even at (for example) dynamic loader stage get a
pass if there's a "-" leader to indicate to ignore errors. That means
that any user using this must accept that there's a chance that the
command will not execute whatsoever.

Since these outcomes are the same as the executable not existing at all,
allow "-" to also silence the command not existing in the first place.

As an example, with:

    [testenv:bogus]
    commands =
	-bogus

Before:

    ERROR: InvocationError for command could not find executable bogus
    ________________________ summary ________________________
    ERROR:   bogus: commands failed

After:

    WARNING: command not found but explicitly ignored
    cmd: bogus
    ________________________ summary ________________________
    bogus: commands succeeded
    congratulations :)

Closes #2315.