### PR TITLE
Require Python 3.10 to generate the tox documentation

### DIFF
--- a/docs/changelog/2321.bugfix.rst
+++ b/docs/changelog/2321.bugfix.rst
@@ -1,0 +1,1 @@
+Require Python 3.10 to generate docs - by :user:`jugmac00`.

--- a/tox.ini
+++ b/tox.ini
@@ -58,8 +58,8 @@ commands =
     mypy tests
 
 [testenv:docs]
-basepython = python3.10
 description = build documentation
+basepython = python3.10
 extras =
     docs
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ commands =
     mypy tests
 
 [testenv:docs]
+basepython = python3.10
 description = build documentation
 extras =
     docs


### PR DESCRIPTION
This fixes #2321