### PR TITLE
Fix add_config factory argument type annotation bad for containers

### DIFF
--- a/docs/changelog/2233.bugfix.rst
+++ b/docs/changelog/2233.bugfix.rst
@@ -1,0 +1,2 @@
+Fix type annotation is broken for :meth:`tox.config.sets.ConfigSet.add_config` when adding a container type
+- by :user:`gaborbernat`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,6 +103,7 @@ fail_under = 95
 omit =
     src/tox/config/cli/for_docs.py
     tests/execute/local_subprocess/bad_process.py
+    tests/type_check/*
 
 [coverage:paths]
 source =

--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -45,7 +45,7 @@ class ConfigSet(ABC):
         default: Callable[[Config, str | None], V] | V,
         desc: str,
         post_process: Callable[[V], V] | None = None,
-        factory: Factory[V] = None,
+        factory: Factory[Any] = None,
     ) -> ConfigDynamicDefinition[V]:
         """
         Add configuration value.
@@ -55,7 +55,8 @@ class ConfigSet(ABC):
         :param default: the default value of the config value
         :param desc: a help message describing the configuration
         :param post_process: a callback to post-process the configuration value after it has been loaded
-        :param factory: factory method to use to build the object
+        :param factory: factory method used to build contained objects (if ``of_type`` is a container type it
+          should perform the contained item creation, otherwise creates objects that match the type)
         :return: the new dynamic config definition
         """
         if self._final:

--- a/tests/type_check/add_config_container_factory.py
+++ b/tests/type_check/add_config_container_factory.py
@@ -1,0 +1,20 @@
+"""check that factory for a container works"""
+from __future__ import annotations
+
+from typing import List
+
+from tox.config.sets import ConfigSet
+
+
+class EnvDockerConfigSet(ConfigSet):
+    def register_config(self) -> None:
+        def factory(container_name: object) -> str:  # noqa: U100
+            ...
+
+        self.add_config(
+            keys=["k"],
+            of_type=List[str],
+            default=[],
+            desc="desc",
+            factory=factory,
+        )


### PR DESCRIPTION
Resolves #2233. Could not find any better solution than bail out type checking here :shrug: 