### PR TITLE
Passenv: Include default env variables regardless of their case on UNIX

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,6 +35,7 @@ David Diaz
 Ederag
 Eli Collins
 Eugene Yunak
+Fabian Poggenhans
 Felix Hildén
 Fernando L. Pereira
 Florian Bruhin

--- a/docs/changelog/2372.feature.rst
+++ b/docs/changelog/2372.feature.rst
@@ -1,0 +1,1 @@
+Add default environment variables (such as http_proxy) regardless of their case to passenv on UNIX -- by :user:`poggenhans`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -460,7 +460,8 @@ Complete list of settings that you can put into ``testenv*`` sections:
     ``A`` will pass both ``A`` and ``a``.
 
     Some variables are always passed through to ensure the basic functionality
-    of standard library functions or tooling like pip:
+    of standard library functions or tooling like pip.
+    This is also not case sensitive on all platforms except Windows:
 
     * passed through on all platforms: ``CURL_CA_BUNDLE``, ``PATH``,
       ``LANG``, ``LANGUAGE``,

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -809,6 +809,10 @@ def tox_addoption(parser):
             passenv.add("MSYSTEM")  # fixes #429
         else:
             passenv.add("TMPDIR")
+
+            # add non-uppercased variables to passenv if present (only necessary for UNIX)
+            passenv.update(name for name in os.environ if name.upper() in passenv)
+
         for spec in value:
             for name in os.environ:
                 if fnmatchcase(name.upper(), spec.upper()):

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1494,6 +1494,8 @@ class TestConfigTestEnv:
         monkeypatch.setenv("A123A", "a")
         monkeypatch.setenv("A123B", "b")
         monkeypatch.setenv("BX23", "0")
+        if plat == "linux2":
+            monkeypatch.setenv("http_proxy", "c")
         config = newconfig(
             """
             [testenv]
@@ -1518,6 +1520,9 @@ class TestConfigTestEnv:
             assert "MSYSTEM" in envconfig.passenv
         else:
             assert "TMPDIR" in envconfig.passenv
+            if sys.platform != "win32":
+                # this cannot be emulated on win - it doesn't support lowercase env vars
+                assert "http_proxy" in envconfig.passenv
         assert "CURL_CA_BUNDLE" in envconfig.passenv
         assert "PATH" in envconfig.passenv
         assert "PIP_INDEX_URL" in envconfig.passenv
@@ -3575,7 +3580,7 @@ def test_config_via_pyproject_legacy(initproj):
     initproj(
         "config_via_pyproject_legacy-0.5",
         filedefs={
-            "pyproject.toml": u'''
+            "pyproject.toml": '''
                 [project]
                 description = "Factory ⸻ A code generator 🏭"
                 authors = [{name = "Łukasz Langa"}]


### PR DESCRIPTION
This fixes problems with environment variables that are also used in their lower-case form on UNIX systems, such as `http_proxy` and `https_proxy`. They wouldn't be passed on to the test environment, while variables such as `HTTP_PROXY` would.

Closes #2372

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
