### PR TITLE
Use gethostname instead of potentially slow getfqdn

### DIFF
--- a/docs/changelog/2375.bugfix.rst
+++ b/docs/changelog/2375.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid potential 30s delay caused by socket.getfqdn(). -- by :user:`ssbarnea`

--- a/src/tox/logs/result.py
+++ b/src/tox/logs/result.py
@@ -22,7 +22,7 @@ class ResultLog(object):
             "reportversion": "1",
             "toxversion": __version__,
             "platform": sys.platform,
-            "host": os.getenv(str("HOSTNAME")) or socket.getfqdn(),
+            "host": os.getenv(str("HOSTNAME")) or socket.gethostname(),
             "commands": command_log,
         }
 

--- a/tests/unit/test_result.py
+++ b/tests/unit/test_result.py
@@ -31,7 +31,7 @@ def test_pre_set_header(clean_hostname_envvar):
     assert replog.dict["reportversion"] == "1"
     assert replog.dict["toxversion"] == tox.__version__
     assert replog.dict["platform"] == sys.platform
-    assert replog.dict["host"] == socket.getfqdn()
+    assert replog.dict["host"] == socket.gethostname()
     data = replog.dumps_json()
     replog2 = ResultLog.from_json(data)
     assert replog2.dict == replog.dict
@@ -44,7 +44,7 @@ def test_set_header(pkg, clean_hostname_envvar):
     assert replog.dict["reportversion"] == "1"
     assert replog.dict["toxversion"] == tox.__version__
     assert replog.dict["platform"] == sys.platform
-    assert replog.dict["host"] == socket.getfqdn()
+    assert replog.dict["host"] == socket.gethostname()
     expected = {"basename": "hello-1.0.tar.gz", "sha256": pkg.computehash("sha256")}
     env_log = replog.get_envlog("a")
     env_log.set_header(installpkg=pkg)


### PR DESCRIPTION
This avoid bug that is adding 30s on some machines where getfqdn()
is very slow, as this is caused by an unsolved python bug.

Related: https://bugs.python.org/issue35164
Fixes: #2375

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
