### PR TITLE
Fix encoding used to read our own log files

### DIFF
--- a/src/tox/action.py
+++ b/src/tox/action.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import locale
 import os
 import pipes
 import signal
@@ -125,7 +126,13 @@ class Action(object):
                 exit_code = process.returncode
             finally:
                 if out_path is not None and out_path.exists():
-                    lines = out_path.read_text("UTF-8").split("\n")
+                    # Log files of Python sub-processes like `python
+                    # -m virtualenv` are opened as text files without
+                    # specifying an explicit encoding, which means
+                    # they use the locale's preferred encoding.  They
+                    # cannot be assumed to be UTF-8.
+                    encoding = locale.getpreferredencoding(False)
+                    lines = out_path.read_text(encoding).split("\n")
                     # first three lines are the action, cwd, and cmd - remove it
                     output = "\n".join(lines[3:])
                 try:


### PR DESCRIPTION
Fixes #1550.

When running Tox on a French Canadian Windows computer under an
account with a username that contains diacritics, Tox crashes with a
`UnicodeDecodeError` because it tries to read its log files with a
hard-coded encoding of `UTF-8`.  These log files contain output from
`python -m virtualenv` and `python -m pip`, whose output contains
references to the username (such as the contents of the ``APPDATA``
environment variable).  The problem is that the subprocesses which
open log files without any explicit encoding.  In that case, the
built-in `open()` uses `locale.getpreferredencoding(False)`, which is
`"cp1252"`.  A username containing an "Latin Small Letter E with
Acute" will be encoded as `\xe9`, which is not valid UTF-8 (the valid
UTF-8 sequence is `\xc3\xa9`).

One workaround is to run Tox with Python in "UTF-8 Mode".  This can be
achieved by setting the `PYTHONUTF8=1` environment variable or by
calling with `python -Xutf8 -m tox`.  Unfortunately, this is not in
the Tox documentation and can be quite confusing.  I spent more than
two hours troubleshooting this (I develop with Python full time and
I'd never heard of the "UTF-8 mode" before).

Of course, we could document the workaround, but it just seems good to
re-open the log files using the same encoding they were opened with in
the first place.

With this change, Tox works nicely with or without the "UTF-8 Mode".

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
