### PR TITLE
Force virtualenv and pip to output UTF-8

### DIFF
--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -245,7 +245,7 @@ class PosargsOption:
 class InstallcmdOption:
     name = "install_command"
     type = "argv_install_command"
-    default = r"python -m pip install \{opts\} \{packages\}"
+    default = r"python -Xutf8 -m pip install \{opts\} \{packages\}"
     help = "install command for dependencies and package under test."
 
     def postprocess(self, testenv_config, value):

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -717,7 +717,7 @@ _SKIP_VENV_CREATION = os.environ.get("_TOX_SKIP_ENV_CREATION_TEST", False) == "1
 @tox.hookimpl
 def tox_testenv_create(venv, action):
     config_interpreter = venv.getsupportedinterpreter()
-    args = [sys.executable, "-m", "virtualenv"]
+    args = [sys.executable, "-Xutf8", "-m", "virtualenv"]
     if venv.envconfig.sitepackages:
         args.append("--system-site-packages")
     if venv.envconfig.alwayscopy:


### PR DESCRIPTION
Fixes #1550.

This is an alternate take on #2390 that is better targetted to the specific
issue and may prove less risky overall.

After running these two commands with output redirected to a file, we
read said files with an explicit request for UTF-8 encoding.  On some
cases this does not contain UTF-8 data.  For example, on a French
Canadian Windows machine with non-ASCII characters in the username,
the output contains the contents of the `APPDATA` environment
variable, which is printed to the current code page (`cp1252`).

This change enables Python's "UTF-8 Mode" when running `virtualenv`
and `pip` to guarantee the output is UTF-8 everywhere.

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [ ] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [ ] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
