### PR TITLE
Display registered plugins with --version

### DIFF
--- a/docs/changelog/2358.bugfix.rst
+++ b/docs/changelog/2358.bugfix.rst
@@ -1,0 +1,1 @@
+Display registered plugins with ``tox --version`` - by :user:`mxd4`.

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -162,7 +162,7 @@ class ToxParser(ArgumentParserWithEnvAndConfig):
             cmd,
             help=help_msg,
             aliases=aliases,
-            formatter_class=HelpFormatter,
+            formatter_class=argparse.RawTextHelpFormatter,
             file_config=self.file_config,
         )
         sub_parser.of_cmd = cmd  # mark it as parser for a sub-command

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -99,13 +99,19 @@ class HelpFormatter(ArgumentDefaultsHelpFormatter):
         super().__init__(prog, max_help_position=30, width=240)
 
     def _get_help_string(self, action: Action) -> str | None:
-
         text: str = super()._get_help_string(action) or ""
         if hasattr(action, "default_source"):
             default = " (default: %(default)s)"
             if text.endswith(default):  # pragma: no branch
                 text = f"{text[: -len(default)]} (default: %(default)s -> from %(default_source)s)"
         return text
+
+    def add_raw_text(self, text: str | None) -> None:
+        def keep(content: str) -> str:
+            return content
+
+        if text is not SUPPRESS and text is not None:
+            self._add_item(keep, [text])
 
 
 ToxParserT = TypeVar("ToxParserT", bound="ToxParser")
@@ -162,7 +168,7 @@ class ToxParser(ArgumentParserWithEnvAndConfig):
             cmd,
             help=help_msg,
             aliases=aliases,
-            formatter_class=argparse.RawTextHelpFormatter,
+            formatter_class=HelpFormatter,
             file_config=self.file_config,
         )
         sub_parser.of_cmd = cmd  # mark it as parser for a sub-command
@@ -334,4 +340,5 @@ __all__ = (
     "DEFAULT_VERBOSITY",
     "Parsed",
     "ToxParser",
+    "HelpFormatter",
 )

--- a/src/tox/execute/local_sub_process/read_via_thread_windows.py
+++ b/src/tox/execute/local_sub_process/read_via_thread_windows.py
@@ -4,7 +4,7 @@ On Windows we use overlapped mechanism, borrowing it from asyncio (but without t
 from __future__ import annotations  # pragma: win32 cover
 
 import logging  # pragma: win32 cover
-from asyncio.windows_utils import BUFSIZE  # pragma: win32 cover
+from asyncio.windows_utils import BUFSIZE  # type: ignore # pragma: win32 cover
 from time import sleep  # pragma: win32 cover
 from typing import Callable  # pragma: win32 cover
 

--- a/src/tox/session/cmd/version_flag.py
+++ b/src/tox/session/cmd/version_flag.py
@@ -22,11 +22,11 @@ def tox_add_option(parser: ToxParser) -> None:
 
 
 def get_version_info() -> str:
-    out = [f"{version} from {Path(tox.__file__).absolute()} "]
+    out = [f"{version} from {Path(tox.__file__).absolute()}"]
     plugin_info = MANAGER.manager.list_plugin_distinfo()
     if plugin_info:
         out.append("registered plugins:")
-        for mod, egg_info in plugin_info:
-            source = getattr(mod, "__file__", repr(mod))
+        for module, egg_info in plugin_info:
+            source = getattr(module, "__file__", repr(module))
             out.append(f"    {egg_info.project_name}-{egg_info.version} at {source}")
     return "\n".join(out)

--- a/src/tox/session/cmd/version_flag.py
+++ b/src/tox/session/cmd/version_flag.py
@@ -18,17 +18,16 @@ def tox_add_option(parser: ToxParser) -> None:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"{version} from {Path(tox.__file__).absolute()}.\n{get_registered_plugins()}",
+        version=f"{version} from {Path(tox.__file__).absolute()}\n{get_registered_plugins()}",
     )
 
 
 def get_registered_plugins():
-    out = ["registered plugins:"]
-    plugin_dist_info = MANAGER.manager.list_plugin_distinfo()
-    if plugin_dist_info:
-        for mod, egg_info in plugin_dist_info:
+    out = []
+    plugin_info = MANAGER.manager.list_plugin_distinfo()
+    if plugin_info:
+        out.append("registered plugins:")
+        for mod, egg_info in plugin_info:
             source = getattr(mod, "__file__", repr(mod))
             out.append(f"    {egg_info.project_name}-{egg_info.version} at {source}")
-    else:
-        out.append("None.")
     return "\n".join(out)

--- a/src/tox/session/cmd/version_flag.py
+++ b/src/tox/session/cmd/version_flag.py
@@ -5,25 +5,24 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import tox
 from tox.config.cli.parser import ToxParser
 from tox.plugin import impl
 from tox.plugin.manager import MANAGER
+from tox.version import version
 
 
 @impl
 def tox_add_option(parser: ToxParser) -> None:
-    import tox
-    from tox.version import version
-
     parser.add_argument(
         "--version",
         action="version",
-        version=f"{version} from {Path(tox.__file__).absolute()}\n{get_registered_plugins()}",
+        version=get_version_info(),
     )
 
 
-def get_registered_plugins():
-    out = []
+def get_version_info() -> str:
+    out = [f"{version} from {Path(tox.__file__).absolute()} "]
     plugin_info = MANAGER.manager.list_plugin_distinfo()
     if plugin_info:
         out.append("registered plugins:")

--- a/src/tox/session/cmd/version_flag.py
+++ b/src/tox/session/cmd/version_flag.py
@@ -28,7 +28,7 @@ def get_registered_plugins():
     if plugin_dist_info:
         for mod, egg_info in plugin_dist_info:
             source = getattr(mod, "__file__", repr(mod))
-            out.append("    {}-{} at {}".format(egg_info.project_name, egg_info.version, source))
+            out.append(f"    {egg_info.project_name}-{egg_info.version} at {source}")
     else:
         out.append("None.")
     return "\n".join(out)

--- a/src/tox/session/cmd/version_flag.py
+++ b/src/tox/session/cmd/version_flag.py
@@ -3,10 +3,13 @@ Display the version information about tox.
 """
 from __future__ import annotations
 
+import sys
+from argparse import SUPPRESS, Action, ArgumentParser, Namespace
 from pathlib import Path
+from typing import Any, Sequence, cast
 
 import tox
-from tox.config.cli.parser import ToxParser
+from tox.config.cli.parser import HelpFormatter, ToxParser
 from tox.plugin import impl
 from tox.plugin.manager import MANAGER
 from tox.version import version
@@ -14,11 +17,24 @@ from tox.version import version
 
 @impl
 def tox_add_option(parser: ToxParser) -> None:
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=get_version_info(),
-    )
+    class _V(Action):
+        def __init__(self, option_strings: Sequence[str], dest: str = SUPPRESS) -> None:
+            help_msg = "show program's and plugins version number and exit"
+            super().__init__(option_strings=option_strings, dest=dest, nargs=0, help=help_msg, default=SUPPRESS)
+
+        def __call__(
+            self,
+            parser: ArgumentParser,
+            namespace: Namespace,  # noqa: U100
+            values: str | Sequence[Any] | None,  # noqa: U100
+            option_string: str | None = None,  # noqa: U100
+        ) -> None:
+            formatter = cast(HelpFormatter, parser._get_formatter())
+            formatter.add_raw_text(get_version_info())
+            parser._print_message(formatter.format_help(), sys.stdout)
+            parser.exit()
+
+    parser.add_argument("--version", action=_V)
 
 
 def get_version_info() -> str:

--- a/src/tox/session/cmd/version_flag.py
+++ b/src/tox/session/cmd/version_flag.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from tox.config.cli.parser import ToxParser
 from tox.plugin import impl
+from tox.plugin.manager import MANAGER
 
 
 @impl
@@ -17,5 +18,17 @@ def tox_add_option(parser: ToxParser) -> None:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"{version} from {Path(tox.__file__).absolute()}",
+        version=f"{version} from {Path(tox.__file__).absolute()}.\n{get_registered_plugins()}",
     )
+
+
+def get_registered_plugins():
+    out = ["registered plugins:"]
+    plugin_dist_info = MANAGER.manager.list_plugin_distinfo()
+    if plugin_dist_info:
+        for mod, egg_info in plugin_dist_info:
+            source = getattr(mod, "__file__", repr(mod))
+            out.append("    {}-{} at {}".format(egg_info.project_name, egg_info.version, source))
+    else:
+        out.append("None.")
+    return "\n".join(out)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,42 +1,44 @@
 from __future__ import annotations
 
-from unittest import mock
+from types import SimpleNamespace
 
+from pytest_mock import MockFixture
+
+from tox import __version__
 from tox.plugin.manager import MANAGER
 from tox.pytest import ToxProjectCreator
 
 
 def test_version() -> None:
-    from tox import __version__
-
     assert __version__
 
 
 def test_version_without_plugin(tox_project: ToxProjectCreator) -> None:
-    from tox import __version__
-
     outcome = tox_project({"tox.ini": ""}).run("--version")
     outcome.assert_success()
     assert __version__ in outcome.out
     assert "plugin" not in outcome.out
 
 
-def test_version_with_plugin(tox_project: ToxProjectCreator) -> None:
-    from tox import __version__
+def test_version_with_plugin(tox_project: ToxProjectCreator, mocker: MockFixture) -> None:
+    dist = [
+        (
+            mocker.create_autospec("types.ModuleType", __file__=f"{i}-path"),
+            SimpleNamespace(project_name=i, version=v),
+        )
+        for i, v in (("B", "1.0"), ("A", "2.0"))
+    ]
+    mocker.patch.object(MANAGER.manager, "list_plugin_distinfo", return_value=dist)
 
-    mock_module = mock.Mock(__file__="dummy-path")
-
-    mock_egg_info = mock.Mock(
-        project_name="dummy-project",
-        version="1.0",
-    )
-
-    with mock.patch.object(MANAGER.manager, "list_plugin_distinfo", return_value=[(mock_module, mock_egg_info)]):
-        outcome = tox_project({"tox.ini": ""}).run("--version")
+    outcome = tox_project({"tox.ini": ""}).run("--version")
 
     outcome.assert_success()
-    assert __version__ in outcome.out
-    assert "registered plugins:" in outcome.out
-    assert "dummy-path" in outcome.out
-    assert "dummy-project" in outcome.out
-    assert "1.0" in outcome.out
+    assert not outcome.err
+    lines = outcome.out.splitlines()
+    assert lines[0].startswith(__version__)
+
+    assert lines[1:] == [
+        "registered plugins:",
+        "    B-1.0 at B-path",
+        "    A-2.0 at A-path",
+    ]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from _pytest.monkeypatch import MonkeyPatch
 
-from tox import __version__
 from tox.plugin.manager import MANAGER
 from tox.pytest import ToxProjectCreator
 
@@ -14,6 +13,8 @@ def test_version() -> None:
 
 
 def test_version_without_plugin(tox_project: ToxProjectCreator) -> None:
+    from tox import __version__
+
     outcome = tox_project({"tox.ini": ""}).run("--version")
     outcome.assert_success()
     assert __version__ in outcome.out
@@ -21,6 +22,8 @@ def test_version_without_plugin(tox_project: ToxProjectCreator) -> None:
 
 
 def test_version_with_plugin(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
+    from tox import __version__
+
     def dummy_plugin():
         class MockModule:
             __file__ = "dummy-path"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from tox import __version__
+from tox.pytest import ToxProjectCreator
 
-def test_version() -> None:
-    from tox import __version__
 
-    assert __version__
+def test_version_no_plugin(tox_project: ToxProjectCreator) -> None:
+    outcome = tox_project({"tox.ini": "", "pyproject.toml": ""}).run("r", "--version")
+    assert __version__ in outcome.out
+    assert "plugin" not in outcome.out

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -33,9 +33,10 @@ def test_version_with_plugin(tox_project: ToxProjectCreator) -> None:
 
     with mock.patch.object(MANAGER.manager, "list_plugin_distinfo", return_value=[(mock_module, mock_egg_info)]):
         outcome = tox_project({"tox.ini": ""}).run("--version")
-        outcome.assert_success()
-        assert __version__ in outcome.out
-        assert "registered plugins:" in outcome.out
-        assert "dummy-path" in outcome.out
-        assert "dummy-project" in outcome.out
-        assert "1.0" in outcome.out
+
+    outcome.assert_success()
+    assert __version__ in outcome.out
+    assert "registered plugins:" in outcome.out
+    assert "dummy-path" in outcome.out
+    assert "dummy-project" in outcome.out
+    assert "1.0" in outcome.out

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,10 +1,42 @@
 from __future__ import annotations
 
+from _pytest.monkeypatch import MonkeyPatch
+
 from tox import __version__
+from tox.plugin.manager import MANAGER
 from tox.pytest import ToxProjectCreator
 
 
-def test_version_no_plugin(tox_project: ToxProjectCreator) -> None:
-    outcome = tox_project({"tox.ini": "", "pyproject.toml": ""}).run("r", "--version")
+def test_version() -> None:
+    from tox import __version__
+
+    assert __version__
+
+
+def test_version_without_plugin(tox_project: ToxProjectCreator) -> None:
+    outcome = tox_project({"tox.ini": ""}).run("--version")
+    outcome.assert_success()
     assert __version__ in outcome.out
     assert "plugin" not in outcome.out
+
+
+def test_version_with_plugin(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
+    def dummy_plugin():
+        class MockModule:
+            __file__ = "dummy-path"
+
+        class MockEggInfo:
+            project_name = "dummy-project"
+            version = "1.0"
+
+        return [(MockModule, MockEggInfo)]
+
+    monkeypatch.setattr(MANAGER.manager, "list_plugin_distinfo", dummy_plugin)
+
+    outcome = tox_project({"tox.ini": ""}).run("--version")
+    outcome.assert_success()
+    assert __version__ in outcome.out
+    assert "registered plugins:" in outcome.out
+    assert "dummy-path" in outcome.out
+    assert "dummy-project" in outcome.out
+    assert "1.0" in outcome.out

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from _pytest.monkeypatch import MonkeyPatch
+from unittest import mock
 
 from tox.plugin.manager import MANAGER
-from tox.pytest import ToxProjectCreator
+from tox.pytest import MonkeyPatch, ToxProjectCreator
 
 
 def test_version() -> None:
@@ -24,17 +24,14 @@ def test_version_without_plugin(tox_project: ToxProjectCreator) -> None:
 def test_version_with_plugin(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
     from tox import __version__
 
-    def dummy_plugin():
-        class MockModule:
-            __file__ = "dummy-path"
+    mock_module = mock.Mock(__file__="dummy-path")
 
-        class MockEggInfo:
-            project_name = "dummy-project"
-            version = "1.0"
+    mock_egg_info = mock.Mock(
+        project_name="dummy-project",
+        version="1.0",
+    )
 
-        return [(MockModule, MockEggInfo)]
-
-    monkeypatch.setattr(MANAGER.manager, "list_plugin_distinfo", dummy_plugin)
+    monkeypatch.setattr(MANAGER.manager, "list_plugin_distinfo", lambda: [(mock_module, mock_egg_info)])
 
     outcome = tox_project({"tox.ini": ""}).run("--version")
     outcome.assert_success()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from unittest import mock
 
 from tox.plugin.manager import MANAGER
-from tox.pytest import MonkeyPatch, ToxProjectCreator
+from tox.pytest import ToxProjectCreator
 
 
 def test_version() -> None:
@@ -21,7 +21,7 @@ def test_version_without_plugin(tox_project: ToxProjectCreator) -> None:
     assert "plugin" not in outcome.out
 
 
-def test_version_with_plugin(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
+def test_version_with_plugin(tox_project: ToxProjectCreator) -> None:
     from tox import __version__
 
     mock_module = mock.Mock(__file__="dummy-path")
@@ -31,12 +31,11 @@ def test_version_with_plugin(tox_project: ToxProjectCreator, monkeypatch: Monkey
         version="1.0",
     )
 
-    monkeypatch.setattr(MANAGER.manager, "list_plugin_distinfo", lambda: [(mock_module, mock_egg_info)])
-
-    outcome = tox_project({"tox.ini": ""}).run("--version")
-    outcome.assert_success()
-    assert __version__ in outcome.out
-    assert "registered plugins:" in outcome.out
-    assert "dummy-path" in outcome.out
-    assert "dummy-project" in outcome.out
-    assert "1.0" in outcome.out
+    with mock.patch.object(MANAGER.manager, "list_plugin_distinfo", return_value=[(mock_module, mock_egg_info)]):
+        outcome = tox_project({"tox.ini": ""}).run("--version")
+        outcome.assert_success()
+        assert __version__ in outcome.out
+        assert "registered plugins:" in outcome.out
+        assert "dummy-path" in outcome.out
+        assert "dummy-project" in outcome.out
+        assert "1.0" in outcome.out

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ description = run type check on code base
 setenv =
     {tty:MYPY_FORCE_COLOR = 1}
 deps =
-    mypy==0.931
+    mypy==0.950
     types-cachetools
     types-chardet
 commands =

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -53,6 +53,7 @@ devenv
 devnull
 devpi
 dirname
+distinfo
 distlib
 divmod
 doc2path


### PR DESCRIPTION
Ref #2358

Hi! First time contributing here. 
I tried to display the registered plugins when calling `tox --version`, by looking at how it was done on [master](https://github.com/tox-dev/tox/blob/master/src/tox/config/__init__.py#L359).

Looks like this works, however the formatter used by `argparse` removes `\n` characters, therefore the display is inline:
```
$ tox --version
4.0.0b2.dev15+gd1845907 from /Users/maximed/PycharmProjects/tox-rewrite/src/tox/__init__.py. registered plugins tox-mxd-0.0.0 at /Users/maximed/PycharmProjects/tox-mxd/tox_mxd.py
```

I didn't commit it but changing the formatter to `RawTextHelpFormatter` in [`parser.py`](https://github.com/tox-dev/tox/blob/rewrite/src/tox/config/cli/parser.py#L165) actually fixes it:
```
$ tox --version
4.0.0b2.dev15+gd1845907.d20220506 from /Users/maximed/PycharmProjects/tox-rewrite/src/tox/__init__.py.
registered plugins:
    tox-mxd-0.0.0 at /Users/maximed/PycharmProjects/tox-mxd/tox_mxd.py
```
Any idea how to improve the display without having to change the formatter of the parser? I'm still getting familiar with tox and argparse. And python. :innocent: