### PR TITLE
Fix link to download stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ versions](https://img.shields.io/pypi/pyversions/tox.svg)](https://pypi.org/proj
 status](https://readthedocs.org/projects/tox/badge/?version=latest&style=flat-square)](https://tox.readthedocs.io/en/latest/?badge=latest)
 [![Code style:
 black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Downloads](https://pepy.tech/badge/tox/month)](https://pepy.tech/project/tox/month)
+[![Downloads](https://pepy.tech/badge/tox/month)](https://pepy.tech/project/tox/)
 
 <a href="https://tox.readthedocs.io">
     <img src="https://raw.githubusercontent.com/tox-dev/tox/master/docs/_static/img/tox.png"


### PR DESCRIPTION
While there is a month badge, there is no `month` page available.