### PR TITLE
Do no longer recommend pipx-in-pipx

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,6 @@ affecting other parts of the system.
 
 .. code-block:: bash
 
-    python -m pip install pipx-in-pipx --user
     pipx install tox
     tox --help
 


### PR DESCRIPTION
... as it is no longer actively maintained.

We can trust our users to be able to install pipx in a different way.