### PR TITLE
Fix fallback to "python" environment when "isolated_build = true" is set

### DIFF
--- a/docs/changelog/2474.bugfix.rst
+++ b/docs/changelog/2474.bugfix.rst
@@ -1,0 +1,1 @@
+Fix fallback to ``python`` environment when ``isolated_build = true`` is set -- by :user:`Unrud`

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -380,6 +380,16 @@ class TestConfigPackage:
         assert config.setupdir.realpath() == tmpdir.realpath()
         assert config.toxworkdir.realpath() == tmpdir.join(".tox").realpath()
 
+    def test_defaults_isolated_build(self, newconfig):
+        config = newconfig(
+            [],
+            """
+            [tox]
+            isolated_build = true
+        """,
+        )
+        assert "python" in config.envconfigs
+
     def test_project_paths(self, tmpdir, newconfig):
         config = newconfig(
             """


### PR DESCRIPTION
Skip the section generated by `isolated_build = true` when collection all environments instead of removing the `isolated_build_env` afterwards.

Fixes #2474

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
