### PR TITLE
Fix SetuptoolsDeprecationWarning about using --global-option

### DIFF
--- a/docs/changelog/2478.bugfix.rst
+++ b/docs/changelog/2478.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``SetuptoolsDeprecationWarning`` about using ``--global-option`` -- by :user:`adamchainz`

--- a/src/tox/helper/build_isolated.py
+++ b/src/tox/helper/build_isolated.py
@@ -38,5 +38,5 @@ _ensure_module_in_paths(backend, backend_paths)
 if backend_obj:
     backend = getattr(backend, backend_obj)
 
-basename = backend.build_sdist(dist_folder, {"--global-option": ["--formats=gztar"]})
+basename = backend.build_sdist(dist_folder, {"--build-option": ["--formats=gztar"]})
 print(basename)

--- a/tests/unit/package/builder/test_package_builder_isolated.py
+++ b/tests/unit/package/builder/test_package_builder_isolated.py
@@ -25,6 +25,7 @@ def test_verbose_isolated_build(initproj, mock_venv, cmd):
         },
     )
     result = cmd("--sdistonly", "-v", "-v", "-v", "-e", "py")
+    assert "The arguments ['--formats=gztar'] were given via `--global-option`." not in result.err
     assert "running sdist" in result.out, result.out
     assert "running egg_info" in result.out, result.out
     assert "example123-0.5.tar.gz" in result.out, result.out


### PR DESCRIPTION
Fixes #2478.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
