### PR TITLE
Fix license_file SetuptoolsDeprecationWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ author = Holger Krekel, Oliver Bestwalter, Bernát Gábor and others
 maintainer = Bernát Gábor, Oliver Bestwalter, Anthony Sottile, Jürgen Gmach
 maintainer_email = gaborjbernat@gmail.com
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ author = Holger Krekel, Oliver Bestwalter, Bernát Gábor and others
 maintainer = Bernát Gábor, Oliver Bestwalter, Anthony Sottile, Jürgen Gmach
 maintainer_email = gaborjbernat@gmail.com
 license = MIT
+license_file = LICENSE
 license_files = LICENSE
 platforms = any
 classifiers =


### PR DESCRIPTION
Fix this warning seen during running tox's tests:

```
/.../tox/.tox/.package/lib/python3.10/site-packages/setuptools/config/setupcfg.py:508:
  SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use
  license_files instead. warnings.warn(msg, warning_class)
```

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [n/a] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
