### PR TITLE
Expand installation instruction for common linux distros, macos

### DIFF
--- a/docs/changelog/2489.doc.rst
+++ b/docs/changelog/2489.doc.rst
@@ -1,0 +1,1 @@
+Expand linux/macos package manager installation instructions -- by :user:`alago1`.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -52,6 +52,39 @@ so that you can do changes and submit patches.
 [Linux/macOS] Install via your package manager
 ----------------------------------------------
 
-You can also find tox packaged for many Linux distributions and Homebrew for macOs - usually under the name of **python-tox** or simply **tox**. Be aware though that there also other projects under the same name (most prominently a `secure chat client <https://tox.chat/>`_ with no affiliation to this project), so make sure you install the correct package.
+You can also find tox packaged for many Linux distributions and Homebrew for macOs.
+
+Debian, Ubuntu
+
+.. code-block:: shell
+
+    $ apt-get install tox
+
+Fedora, CentOS, Red Hat
+
+.. code-block:: shell
+
+    $ yum -y install python-tox
+
+Arch Linux
+
+.. code-block:: shell
+
+    $ pacman -S python-tox
+
+openSUSE
+
+.. code-block:: shell
+
+    $ zypper install python3-tox
+
+Homebrew
+
+.. code-block:: shell
+
+    $ brew install tox
+
+The project may also be available for other package managers. Be aware though that there also other projects under the same name (most prominently a `secure chat client <https://tox.chat/>`_ with no affiliation to this project), so make sure you install the correct package.
+Most often, the package is named ``tox`` or ``python-tox``.
 
 .. include:: links.rst


### PR DESCRIPTION
The instructions for installing tox through linux/macos package managers mention potential name conflicts with other projects but lacks in examples. I also could not find info anywhere else in the docs that expanded upon this.

I looked through the repositories for the most popular linux distro's package managers and homebrew for macos and added a section with the installation commands. Given there's some variation in project's name between `tox`, `python-tox`, and `python3-tox`, I think this section helps to add some clarity to these specific installation instructions.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [X] wrote descriptive pull request text
- [ ] added/updated test(s)
- [X] updated/extended the documentation
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [X] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [ ] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
