### PR TITLE
Remove read-only files upon cleanup

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -107,6 +107,7 @@ Pierre-Jean Campigotto
 Pierre-Luc Tessier Gagné
 Prakhar Gurunani
 Rahul Bangar
+Robert Gomulka
 Ronald Evers
 Ronny Pfannschmidt
 Ryuichi Ohori

--- a/docs/changelog/2498.bugfix.rst
+++ b/docs/changelog/2498.bugfix.rst
@@ -1,0 +1,1 @@
+Remove read-only files in ``ensure_empty_dir``.

--- a/src/tox/util/path.py
+++ b/src/tox/util/path.py
@@ -1,3 +1,4 @@
+import errno, os, stat
 import shutil
 
 from tox import reporter
@@ -6,5 +7,18 @@ from tox import reporter
 def ensure_empty_dir(path):
     if path.check():
         reporter.info("  removing {}".format(path))
-        shutil.rmtree(str(path), ignore_errors=True)
+        shutil.rmtree(str(path), onerror=_remove_readonly)
         path.ensure(dir=1)
+
+
+def _remove_readonly(func, path, exc_info):
+    """Clear the readonly bit and reattempt the removal."""
+    if isinstance(exc_info[1], OSError):
+        if exc_info[1].errno == errno.EACCES:
+            try:
+                os.chmod(path, stat.S_IWRITE)
+                func(path)
+            except Exception:
+                # when second attempt fails, ignore the problem
+                # to maintain some level of backward compatibility
+                pass

--- a/tests/integration/test_path_utils_removal.py
+++ b/tests/integration/test_path_utils_removal.py
@@ -1,20 +1,19 @@
 import os
 from stat import S_IREAD
-from tempfile import TemporaryDirectory, NamedTemporaryFile
 
 from tox.util.path import ensure_empty_dir
 
-try:
-    from unittest.mock import Mock, patch
-except ImportError:
-    from mock import Mock, patch
 
+def test_remove_read_only(tmpdir):
+    nested_dir = tmpdir / "nested_dir"
+    nested_dir.mkdir()
 
-def test_remove_read_only(initproj, cmd):
-    temp_dir = TemporaryDirectory()
-    read_only_file = NamedTemporaryFile(dir=temp_dir.name, delete=False)
-    os.chmod(read_only_file.name, S_IREAD)
-    
-    ensure_empty_dir(temp_dir.name)
-    
-    assert not os.path.exists(temp_dir.name)
+    # create read-only file
+    read_only_file = nested_dir / "tmpfile.txt"
+    with open(str(read_only_file), "w"):
+        pass
+    os.chmod(str(read_only_file), S_IREAD)
+
+    ensure_empty_dir(nested_dir)
+
+    assert not os.listdir(nested_dir)

--- a/tests/integration/test_path_utils_removal.py
+++ b/tests/integration/test_path_utils_removal.py
@@ -1,0 +1,20 @@
+import os
+from stat import S_IREAD
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+
+from tox.util.path import ensure_empty_dir
+
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
+
+
+def test_remove_read_only(initproj, cmd):
+    temp_dir = TemporaryDirectory()
+    read_only_file = NamedTemporaryFile(dir=temp_dir.name, delete=False)
+    os.chmod(read_only_file.name, S_IREAD)
+    
+    ensure_empty_dir(temp_dir.name)
+    
+    assert not os.path.exists(temp_dir.name)

--- a/tests/integration/test_path_utils_removal.py
+++ b/tests/integration/test_path_utils_removal.py
@@ -16,4 +16,4 @@ def test_remove_read_only(tmpdir):
 
     ensure_empty_dir(nested_dir)
 
-    assert not os.listdir(nested_dir)
+    assert not os.listdir(str(nested_dir))


### PR DESCRIPTION
Delete read-only files in ``ensure_empty_dir``.

fixes #2498