### PR TITLE
PEP-660 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 __pycache__
 *.swp
 *.egg-info
+/tests/demo_pkg_setuptools/build/lib/demo_pkg_setuptools/__init__.py

--- a/docs/changelog/2502.feature.rst
+++ b/docs/changelog/2502.feature.rst
@@ -1,0 +1,2 @@
+Add support for editable wheels, make it the default development mode and rename ``dev-legacy`` mode to
+``editable-legacy`` - by :user:`gaborbernat`.

--- a/src/tox/tox_env/python/package.py
+++ b/src/tox/tox_env/python/package.py
@@ -39,8 +39,12 @@ class SdistPackage(PythonPathPackageWithDeps):
     """sdist package"""
 
 
-class DevLegacyPackage(PythonPathPackageWithDeps):
-    """legacy dev package"""
+class EditableLegacyPackage(PythonPathPackageWithDeps):
+    """legacy editable package"""
+
+
+class EditablePackage(PythonPathPackageWithDeps):
+    """PEP-660 editable package"""
 
 
 class PythonPackageToxEnv(Python, PackageToxEnv, ABC):
@@ -59,7 +63,11 @@ class PythonPackageToxEnv(Python, PackageToxEnv, ABC):
 
     def register_run_env(self, run_env: RunToxEnv) -> Generator[tuple[str, str], PackageToxEnv, None]:
         yield from super().register_run_env(run_env)
-        if not isinstance(run_env, Python) or run_env.conf["package"] != "wheel" or "wheel_build_env" in run_env.conf:
+        if (
+            not isinstance(run_env, Python)
+            or run_env.conf["package"] not in {"wheel", "editable"}
+            or "wheel_build_env" in run_env.conf
+        ):
             return
 
         def default_wheel_tag(conf: Config, env_name: str | None) -> str:  # noqa: U100

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -15,7 +15,7 @@ from tox.tox_env.errors import Recreate
 from tox.tox_env.installer import Installer
 from tox.tox_env.package import PathPackage
 from tox.tox_env.python.api import Python
-from tox.tox_env.python.package import DevLegacyPackage, SdistPackage, WheelPackage
+from tox.tox_env.python.package import EditableLegacyPackage, EditablePackage, SdistPackage, WheelPackage
 from tox.tox_env.python.pip.req_file import PythonDeps
 
 
@@ -123,7 +123,9 @@ class Pip(Installer[Python]):
 
     def _install_list_of_deps(
         self,
-        arguments: Sequence[Requirement | WheelPackage | SdistPackage | DevLegacyPackage | PathPackage],
+        arguments: Sequence[
+            Requirement | WheelPackage | SdistPackage | EditableLegacyPackage | EditablePackage | PathPackage
+        ],
         section: str,
         of_type: str,
     ) -> None:
@@ -131,10 +133,10 @@ class Pip(Installer[Python]):
         for arg in arguments:
             if isinstance(arg, Requirement):
                 groups["req"].append(str(arg))
-            elif isinstance(arg, (WheelPackage, SdistPackage)):
+            elif isinstance(arg, (WheelPackage, SdistPackage, EditablePackage)):
                 groups["req"].extend(str(i) for i in arg.deps)
                 groups["pkg"].append(str(arg.path))
-            elif isinstance(arg, DevLegacyPackage):
+            elif isinstance(arg, EditableLegacyPackage):
                 groups["req"].extend(str(i) for i in arg.deps)
                 groups["dev_pkg"].append(str(arg.path))
             else:

--- a/src/tox/tox_env/python/runner.py
+++ b/src/tox/tox_env/python/runner.py
@@ -39,7 +39,7 @@ class PythonRun(Python, RunToxEnv):
 
     @property
     def _package_types(self) -> tuple[str, ...]:
-        return "wheel", "sdist", "dev-legacy", "skip", "external"
+        return "wheel", "sdist", "editable", "editable-legacy", "skip", "external"
 
     def _register_package_conf(self) -> bool:
         # provision package type
@@ -58,7 +58,7 @@ class PythonRun(Python, RunToxEnv):
             )
             develop_mode = self.conf["use_develop"] or getattr(self.options, "develop", False)
             if develop_mode:
-                self.conf.add_constant(["package"], desc, "dev-legacy")
+                self.conf.add_constant(["package"], desc, "editable")
             else:
                 self.conf.add_config(keys="package", of_type=str, default=self.default_pkg_type, desc=desc)
 

--- a/src/tox/tox_env/python/virtual_env/package/cmd_builder.py
+++ b/src/tox/tox_env/python/virtual_env/package/cmd_builder.py
@@ -116,7 +116,7 @@ class VirtualEnvCmdBuilder(PythonPackageToxEnv, VirtualEnv):
             assert self._sdist_meta_tox_env is not None  # the register run env is guaranteed to be called before this
             with self._sdist_meta_tox_env.display_context(self._has_display_suspended):
                 self._sdist_meta_tox_env.root = next(work_dir.iterdir())  # contains a single egg info folder
-                deps = self._sdist_meta_tox_env.get_package_dependencies()
+                deps = self._sdist_meta_tox_env.get_package_dependencies(for_env)
             package = SdistPackage(path, dependencies_with_extras(deps, extras))
         return [package]
 

--- a/tests/demo_pkg_setuptools/pyproject.toml
+++ b/tests/demo_pkg_setuptools/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=45", "wheel>=0.33"]
+requires = ["setuptools>=63"]
 build-backend = 'setuptools.build_meta'

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -283,9 +283,9 @@ def test_skip_develop_mode(tox_project: ToxProjectCreator, demo_pkg_setuptools: 
     calls = [(i[0][0].conf.name, i[0][3].run_id) for i in execute_calls.call_args_list]
     expected = [
         (".pkg", "install_requires"),
-        (".pkg", "prepare_metadata_for_build_wheel"),
-        (".pkg", "get_requires_for_build_sdist"),
-        ("py", "install_package_deps"),
+        (".pkg", "get_requires_for_build_editable"),
+        (".pkg", "install_requires_for_build_editable"),
+        (".pkg", "build_editable"),
         ("py", "install_package"),
         (".pkg", "_exit"),
     ]

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -197,7 +197,7 @@ def test_show_config_ini_comment_path(tox_project: ToxProjectCreator, tmp_path: 
 def test_show_config_cli_flag(tox_project: ToxProjectCreator) -> None:
     project = tox_project({"tox.ini": "", "pyproject.toml": ""})
     result = project.run("c", "-e", "py,.pkg", "-k", "package", "recreate", "--develop", "-r", "--no-recreate-pkg")
-    expected = "[testenv:py]\npackage = dev-legacy\nrecreate = True\n\n[testenv:.pkg]\nrecreate = False\n"
+    expected = "[testenv:py]\npackage = editable\nrecreate = True\n\n[testenv:.pkg]\nrecreate = False\n"
     assert result.out == expected
 
 

--- a/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
@@ -9,7 +9,7 @@ from tox.pytest import ToxProjectCreator
 
 @pytest.mark.parametrize(
     "pkg_type",
-    ["dev-legacy", "sdist", "wheel"],
+    ["editable-legacy", "editable", "sdist", "wheel"],
 )
 def test_tox_ini_package_type_valid(tox_project: ToxProjectCreator, pkg_type: str) -> None:
     proj = tox_project({"tox.ini": f"[testenv]\npackage={pkg_type}", "pyproject.toml": ""})
@@ -25,11 +25,12 @@ def test_tox_ini_package_type_invalid(tox_project: ToxProjectCreator) -> None:
     proj = tox_project({"tox.ini": "[testenv]\npackage=bad", "pyproject.toml": ""})
     result = proj.run("c", "-k", "package_tox_env_type")
     result.assert_failed()
-    assert " invalid package config type bad requested, must be one of wheel, sdist, dev-legacy, skip" in result.out
+    msg = " invalid package config type bad requested, must be one of wheel, sdist, editable, editable-legacy, skip"
+    assert msg in result.out
 
 
 def test_get_package_deps_different_extras(pkg_with_extras_project: Path, tox_project: ToxProjectCreator) -> None:
-    ini = "[testenv:a]\npackage=dev-legacy\nextras=docs\n[testenv:b]\npackage=sdist\nextras=format"
+    ini = "[testenv:a]\npackage=editable-legacy\nextras=docs\n[testenv:b]\npackage=sdist\nextras=format"
     proj = tox_project({"tox.ini": ini})
     execute_calls = proj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
     result = proj.run("r", "--root", str(pkg_with_extras_project), "-e", "a,b")


### PR DESCRIPTION
Add support for editable wheels, make it the default development mode, and rename ``dev-legacy`` mode to ``editable-legacy``.