### PR TITLE
feature: split and install dependencies if a comma-space is in the deps line.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -108,6 +108,7 @@ Pierre-Luc Tessier Gagné
 Prakhar Gurunani
 Rahul Bangar
 Robert Gomulka
+Robb Lovell
 Ronald Evers
 Ronny Pfannschmidt
 Ryuichi Ohori

--- a/docs/changelog/2506.feature.rst
+++ b/docs/changelog/2506.feature.rst
@@ -1,0 +1,1 @@
+Split and install dependencies if a comma-space is in the deps line.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1001,6 +1001,8 @@ Reading it line by line:
 - ``Django>=1.6,<1.7`` similarly depends on ``django16`` factor,
 - ``unittest2`` will be loaded for Python 3.6 environments.
 
+NOTE: that if multiple dependencies are needed for optional deps lines, separate dependencies by a ', ' (a comma and a space).
+
 tox provides a number of default factors corresponding to Python interpreter
 versions. The conditional setting above will lead to either ``python3.6`` or
 ``python2.7`` used as base python, e.g. ``python3.6`` is selected if current

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1001,7 +1001,11 @@ Reading it line by line:
 - ``Django>=1.6,<1.7`` similarly depends on ``django16`` factor,
 - ``unittest2`` will be loaded for Python 3.6 environments.
 
-NOTE: that if multiple dependencies are needed for optional deps lines, separate dependencies by a ', ' (a comma and a space).
+NOTE: If multiple dependencies are needed for an optional dependency line (like py36: above), you can list separate dependencies by a comma-space separated list (', ': a comma and a space). For example:
+
+    [testenv]
+    deps =
+        py36: unittest2, types-requests
 
 tox provides a number of default factors corresponding to Python interpreter
 versions. The conditional setting above will lead to either ``python3.6`` or

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -316,7 +316,7 @@ class VirtualEnv(object):
         dependencies = []
         for dependency in self.envconfig.deps:
             if ", " in dependency.name:
-                new_dep_names = (dependency.name.split(", "))
+                new_dep_names = dependency.name.split(", ")
                 new_dep_names = list(map(lambda s: s.strip(), new_dep_names))
                 for new_dep_name in new_dep_names:
                     dependency_copy = copy.copy(dependency)


### PR DESCRIPTION
## Description

Implementation of feature request: #2506 

There are two failed tests, one failure I believe is due to this change, the other I believe to be pre-existing.

I have modified the venv.py file's get_resolved_dependencies() function to split the dependency listed if a comma-space exists in the string. I found that comma's only or spaces only failed around 7 tests and given my unfamiliarity with the codebase, I opted for a more stringent syntax. 

I believe that a split on a 'comma only' would be more expected. If someone more familiar with the code might understand why a split on a comma only is problematic and could fix the additional tests, then it should probably be implemented with a split on a comma only.

Giving a list on separate lines is also not supported, but additional work could make that possible.

I have added `import copy` and used copy.copy to clone the dependency and I am unsure if this is problematic for python 2.7.

I am unsure of backward compatibility issues this might introduce given my unfamiliarity with Tox in general and the code base. Please feel free to critique what I have proposed, alternate solutions would be welcome.

## Todo's

TODO: Fix 2 failing tests.
TODO: Multi-line dependency spec
TODO: comma only dependency spec.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
