### PR TITLE
setup.cfg: Replace deprecated license_file with license_files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: tox-ini-fmt
         args: [ "-p", "fix_lint" ]
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.0.0
+    rev: v2.2.0
     hooks:
       - id: setup-cfg-fmt
         args: [ --min-py3-version, "3.5", "--max-py-version", "3.10" ]

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -89,6 +89,7 @@ Mauricio Villegas
 Mehdi Abaakouk
 Michael Manganiello
 Mickaël Schoentgen
+Michał Górny
 Mikhail Kyshtymov
 Miro Hrončok
 Monty Taylor

--- a/docs/changelog/2521.misc.rst
+++ b/docs/changelog/2521.misc.rst
@@ -1,0 +1,1 @@
+Replaced deprecated ``license_file`` key with ``license_files`` in ``setup.cfg`` -- by :user:`mgorny`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 40.0.4",
+    "setuptools >= 42.0.0",
     "setuptools_scm >= 2.0.0",
     "wheel >= 0.29.0",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ author = Holger Krekel, Oliver Bestwalter, Bernát Gábor and others
 maintainer = Bernát Gábor, Oliver Bestwalter, Anthony Sottile, Jürgen Gmach
 maintainer_email = gaborjbernat@gmail.com
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Replace the deprecated `license_file` key with `license_files` to fix setuptools deprecation warning:

> The license_file parameter is deprecated, use license_files instead.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [ ] added/updated test(s) (n/a)
- [ ] updated/extended the documentation (n/a)
- [ ] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body (n/a)
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)