### PR TITLE
Fix PYTHONPATH passed to envreport / "pip freeze"

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,6 +33,7 @@ Cyril Roelandt
 Dane Hillard
 David Staheli
 David Diaz
+Dmitrii Sutiagin a.k.a. f3flight
 Ederag
 Eli Collins
 Eugene Yunak

--- a/docs/changelog/2528.bugfix.rst
+++ b/docs/changelog/2528.bugfix.rst
@@ -1,0 +1,1 @@
+Add env cleanup to envreport - fix PYTHONPATH leak into "envreport" -- by :user:`f3flight`.

--- a/src/tox/venv.py
+++ b/src/tox/venv.py
@@ -840,7 +840,11 @@ def tox_runtest_post(venv):
 def tox_runenvreport(venv, action):
     # write out version dependency information
     args = venv.envconfig.list_dependencies_command
-    output = venv._pcall(args, cwd=venv.envconfig.config.toxinidir, action=action, returnout=True)
+    env = venv._get_os_environ()
+    venv.ensure_pip_os_environ_ok(env)
+    output = venv._pcall(
+        args, cwd=venv.envconfig.config.toxinidir, action=action, returnout=True, env=env
+    )
     # the output contains a mime-header, skip it
     output = output.split("\n\n")[-1]
     packages = output.strip().split("\n")

--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -1243,4 +1243,8 @@ def test_runenvreport_pythonpath_discarded(newmocksession, mocker):
     mock_os_environ.return_value = dict(PYTHONPATH="/some/path/")
     mock_pcall = mocker.patch.object(venv, "_pcall")
     tox_runenvreport(venv, None)
-    assert "PYTHONPATH" not in mock_pcall.mock_calls[0].kwargs["env"]
+    try:
+        env = mock_pcall.mock_calls[0].kwargs["env"]
+    except TypeError:  # older pytest (python 3.7 and below)
+        env = mock_pcall.mock_calls[0][2]["env"]
+    assert "PYTHONPATH" not in env

--- a/tests/unit/test_venv.py
+++ b/tests/unit/test_venv.py
@@ -14,6 +14,7 @@ from tox.venv import (
     VirtualEnv,
     getdigest,
     prepend_shebang_interpreter,
+    tox_runenvreport,
     tox_testenv_create,
     tox_testenv_install_deps,
 )
@@ -1233,3 +1234,13 @@ def test_path_change(tmpdir, mocksession, newconfig, monkeypatch):
         path = x.env["PATH"]
         assert os.environ["PATH"] in path
         assert path.endswith(str(venv.envconfig.config.toxinidir) + "/bin")
+
+
+def test_runenvreport_pythonpath_discarded(newmocksession, mocker):
+    mock_os_environ = mocker.patch("tox.venv.VirtualEnv._get_os_environ")
+    mocksession = newmocksession([], "")
+    venv = mocksession.getvenv("python")
+    mock_os_environ.return_value = dict(PYTHONPATH="/some/path/")
+    mock_pcall = mocker.patch.object(venv, "_pcall")
+    tox_runenvreport(venv, None)
+    assert "PYTHONPATH" not in mock_pcall.mock_calls[0].kwargs["env"]


### PR DESCRIPTION
Closes #2528
This fix uses the same approach as used for "pip install" (https://github.com/tox-dev/tox/blob/3.27.0/src/tox/venv.py#L432)