### PR TITLE
PythonDeps: move `cli_only` handling logic to `_parse_requirements`

### DIFF
--- a/docs/changelog/2373.bugfix.rst
+++ b/docs/changelog/2373.bugfix.rst
@@ -1,0 +1,1 @@
+Allow ``--hash`` to be specified in requirements.txt files. - by :user:`masenf`.

--- a/src/tox/tox_env/python/pip/req/args.py
+++ b/src/tox/tox_env/python/pip/req/args.py
@@ -18,10 +18,10 @@ class _OurArgumentParser(ArgumentParser):
         raise ValueError(msg)
 
 
-def build_parser(cli_only: bool) -> ArgumentParser:
+def build_parser() -> ArgumentParser:
     parser = _OurArgumentParser(add_help=False, prog="", allow_abbrev=False)
     _global_options(parser)
-    _req_options(parser, cli_only)
+    _req_options(parser)
     return parser
 
 
@@ -47,11 +47,10 @@ def _global_options(parser: ArgumentParser) -> None:
     )
 
 
-def _req_options(parser: ArgumentParser, cli_only: bool) -> None:
+def _req_options(parser: ArgumentParser) -> None:
     parser.add_argument("--install-option", action=AddSortedUniqueAction)
     parser.add_argument("--global-option", action=AddSortedUniqueAction)
-    if not cli_only:
-        parser.add_argument("--hash", action=AddSortedUniqueAction, type=_validate_hash)
+    parser.add_argument("--hash", action=AddSortedUniqueAction, type=_validate_hash)
 
 
 _HASH = re.compile(r"sha(256:[a-f0-9]{64}|384:[a-f0-9]{96}|512:[a-f0-9]{128})")

--- a/src/tox/tox_env/python/pip/req/file.py
+++ b/src/tox/tox_env/python/pip/req/file.py
@@ -156,7 +156,7 @@ class RequirementsFile:
     @property
     def _parser(self) -> ArgumentParser:
         if self._parser_private is None:
-            self._parser_private = build_parser(False)
+            self._parser_private = build_parser()
         return self._parser_private
 
     def _ensure_requirements_parsed(self) -> None:

--- a/tests/tox_env/python/pip/test_req_file.py
+++ b/tests/tox_env/python/pip/test_req_file.py
@@ -14,3 +14,31 @@ def test_legacy_requirement_file(tmp_path: Path, legacy_flag: str) -> None:
     assert python_deps.as_root_args == [legacy_flag, "a.txt"]
     assert vars(python_deps.options) == {}
     assert [str(i) for i in python_deps.requirements] == ["b" if legacy_flag == "-r" else "-c b"]
+
+
+def test_deps_with_hash(tmp_path: Path) -> None:
+    """deps with --hash should raise an exception."""
+    python_deps = PythonDeps(
+        raw="foo==1 --hash sha256:97a702083b0d906517b79672d8501eee470d60ae55df0fa9d4cfba56c7f65a82",
+        root=tmp_path,
+    )
+    with pytest.raises(ValueError, match="Cannot use --hash in deps list"):
+        _ = python_deps.requirements
+
+
+def test_deps_with_requirements_with_hash(tmp_path: Path) -> None:
+    """deps can point to a requirements file that has --hash."""
+    exp_hash = "sha256:97a702083b0d906517b79672d8501eee470d60ae55df0fa9d4cfba56c7f65a82"
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text(
+        f"foo==1 --hash {exp_hash}",
+    )
+    python_deps = PythonDeps(
+        raw="-r requirements.txt",
+        root=tmp_path,
+    )
+    assert len(python_deps.requirements) == 1
+    parsed_req = python_deps.requirements[0]
+    assert str(parsed_req.requirement) == "foo==1"
+    assert parsed_req.options == {"hash": [exp_hash]}
+    assert parsed_req.from_file == str(requirements)


### PR DESCRIPTION
* Remove `cli_only` parameter from `build_parser`.
* Remove special case handling for `--hash` option (only valid in requirements.txt files, not `pip install`).
* Validate options in `PythonDeps._parse_requirements`:
  * Only check `cli_only` logic for `ParsedRequirement` objects that directly come from the `PythonDeps`.
  * Allow included `requirements.txt` lines to correctly parse `--hash` (Fix #2373).
  * Provides a more contextual error message to end users when `--hash` is used in the deps list.

## #2373 [[test case] tox4: fails to process requirement files with `--hash`](https://github.com/tox-dev/tox/commit/c0f00e7fa0799373db0aad3b13e67ba3e8024a1b)

* Specifying `--hash` in the deps list doesn't work (pip would reject this anyway).
* Specifying `--hash` in a requirements.txt file named in the deps list should work, and recursive parsing should correctly extract the hash.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [ ] updated/extended the documentation
- [x] added relevant issue keyword in message body
- [x] added news fragment in changelog folder: [2373.bugfix.rst](https://github.com/tox-dev/tox/blob/426a394aaf30e01fe5e7f7ad2135ac94729b2e25/docs/changelog/2373.bugfix.rst)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)

# Background

I just released a new plugin today, [`tox-pin-deps`](https://github.com/masenf/tox-pin-deps), and hit #2373 while trying to get it working on tox4. 