### PR TITLE
Avoid deprecated pytest.warns(None)

### DIFF
--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -2,6 +2,7 @@
 import os
 import re
 import sys
+import warnings
 from textwrap import dedent
 
 import py
@@ -2469,7 +2470,8 @@ class TestConfigTestEnv:
 
         major, minor = sys.version_info[0:2]
 
-        with pytest.warns(None) as lying:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             config = newconfig(
                 """
                 [testenv:py{0}]
@@ -2483,9 +2485,9 @@ class TestConfigTestEnv:
 
         env_config = config.envconfigs["py{}".format(major)]
         assert env_config.basepython == "python{}.{}".format(major, minor - 1)
-        assert len(lying) == 0, "\n".join(repr(r.message) for r in lying)
 
-        with pytest.warns(None) as truthful:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             config = newconfig(
                 """
                 [testenv:py{0}]
@@ -2499,10 +2501,10 @@ class TestConfigTestEnv:
 
         env_config = config.envconfigs["py{}".format(major)]
         assert env_config.basepython == "python{}.{}".format(major, minor)
-        assert len(truthful) == 0, "\n".join(repr(r.message) for r in truthful)
 
     def test_default_factors_conflict_ignore(self, newconfig, capsys):
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             config = newconfig(
                 """
                 [tox]
@@ -2516,7 +2518,6 @@ class TestConfigTestEnv:
         assert len(config.envconfigs) == 1
         envconfig = config.envconfigs["py27"]
         assert envconfig.basepython == "python2.7"
-        assert len(record) == 0, "\n".join(repr(r.message) for r in record)
 
     def test_factors_in_boolean(self, newconfig):
         inisource = """


### PR DESCRIPTION
    tests/unit/config/test_config.py::TestConfigTestEnv::test_default_single_digit_factors
    tests/unit/config/test_config.py::TestConfigTestEnv::test_default_single_digit_factors
    tests/unit/config/test_config.py::TestConfigTestEnv::test_default_factors_conflict_ignore
      /usr/lib/python3.11/site-packages/_pytest/python.py:192: PytestRemovedIn8Warning: Passing None has been deprecated.
      See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests for alternatives in common use cases.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [-] updated/extended the documentation
- [-] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [-] added news fragment in [changelog folder](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)

Let me know if this needs a news fragment.