### PR TITLE
Allow installing relative paths that go outside tox root folder

### DIFF
--- a/docs/changelog/2366.bugfix.rst
+++ b/docs/changelog/2366.bugfix.rst
@@ -1,0 +1,1 @@
+Allow installing relative paths that go outside tox root folder. - by :user:`ssbarnea`.

--- a/src/tox/tox_env/python/pip/req/file.py
+++ b/src/tox/tox_env/python/pip/req/file.py
@@ -57,9 +57,15 @@ class ParsedRequirement:
                 else:
                     path = root / req
                 extra_part = f"[{','.join(sorted(extras))}]" if extras else ""
-                rel_path = str(path.resolve().relative_to(root))
-                if rel_path != "." and os.sep not in rel_path:  # prefix paths in cwd to not convert them to requirement
-                    rel_path = f".{os.sep}{rel_path}"
+                try:
+                    rel_path = str(path.resolve().relative_to(root))
+                    if (
+                        rel_path != "." and os.sep not in rel_path
+                    ):  # prefix paths in cwd to not convert them to requirement
+                        rel_path = f".{os.sep}{rel_path}"
+                except ValueError:
+                    rel_path = str(path.resolve())
+
                 self._requirement = f"{rel_path}{extra_part}"
         self._options = options
         self._from_file = from_file

--- a/src/tox/tox_env/python/pip/req/file.py
+++ b/src/tox/tox_env/python/pip/req/file.py
@@ -59,9 +59,8 @@ class ParsedRequirement:
                 extra_part = f"[{','.join(sorted(extras))}]" if extras else ""
                 try:
                     rel_path = str(path.resolve().relative_to(root))
-                    if (
-                        rel_path != "." and os.sep not in rel_path
-                    ):  # prefix paths in cwd to not convert them to requirement
+                    # prefix paths in cwd to not convert them to requirement
+                    if rel_path != "." and os.sep not in rel_path:
                         rel_path = f".{os.sep}{rel_path}"
                 except ValueError:
                     rel_path = str(path.resolve())

--- a/tests/tox_env/python/pip/req/test_file.py
+++ b/tests/tox_env/python/pip/req/test_file.py
@@ -484,3 +484,11 @@ def test_requirement_via_file_protocol_na(tmp_path: Path) -> None:
     pattern = r"non-local file URIs are not supported on this platform: 'file://magic\.com\.*"
     with pytest.raises(ValueError, match=pattern):
         assert req_file.options
+
+
+def test_requirement_to_path_one_level_up(tmp_path: Path) -> None:
+    other_req = tmp_path / "other.txt"
+    other_req.write_text("-e ..")
+    req_file = RequirementsFile(other_req, constraint=False)
+    result = req_file.requirements
+    assert result[0].requirement == str(tmp_path.parent.resolve())

--- a/tests/tox_env/python/pip/test_req_file.py
+++ b/tests/tox_env/python/pip/test_req_file.py
@@ -30,13 +30,8 @@ def test_deps_with_requirements_with_hash(tmp_path: Path) -> None:
     """deps can point to a requirements file that has --hash."""
     exp_hash = "sha256:97a702083b0d906517b79672d8501eee470d60ae55df0fa9d4cfba56c7f65a82"
     requirements = tmp_path / "requirements.txt"
-    requirements.write_text(
-        f"foo==1 --hash {exp_hash}",
-    )
-    python_deps = PythonDeps(
-        raw="-r requirements.txt",
-        root=tmp_path,
-    )
+    requirements.write_text(f"foo==1 --hash {exp_hash}")
+    python_deps = PythonDeps(raw="-r requirements.txt", root=tmp_path)
     assert len(python_deps.requirements) == 1
     parsed_req = python_deps.requirements[0]
     assert str(parsed_req.requirement) == "foo==1"


### PR DESCRIPTION
Fixes: #2366 which is caused by https://github.com/python/cpython/issues/67271

## Thanks for contributing a pull request!

If you are contributing for the first time or provide a trivial fix don't worry too
much about the checklist - we will help you get started.

## Contribution checklist:

(also see [CONTRIBUTING.rst](../tree/master/CONTRIBUTING.rst) for details)

- [x] wrote descriptive pull request text
- [x] added/updated test(s)
- [x] updated/extended the documentation
- [x] added relevant [issue keyword](https://help.github.com/articles/closing-issues-using-keywords/)
      in message body
- [x] added news fragment in [changelog folder](../tree/master/docs/changelog)
  * fragment name: `<issue number>.<type>.rst` for example (588.bugfix.rst)
  * `<type>` is must be one of `bugfix`, `feature`, `deprecation`, `breaking`, `doc`, `misc`
  * if PR has no issue: consider creating one first or change it to the PR number after creating the PR
  * "sign" fragment with ```-- by :user:`<your username>`.```
  * please, use full sentences with correct case and punctuation, for example:
    ```rst
    Fixed an issue with non-ascii contents in doctest text files -- by :user:`superuser`.
    ```
  * also see [examples](../tree/master/docs/changelog)
- [x] added yourself to `CONTRIBUTORS` (preserving alphabetical order)
