### PR TITLE
Avoid recreation of virtualenv due to symlinks

### DIFF
--- a/docs/changelog/2574.bugfix.rst
+++ b/docs/changelog/2574.bugfix.rst
@@ -1,0 +1,1 @@
+Resolve symlinks when saving Python executable path - by :user:`ssbarnea`.

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -140,7 +140,7 @@ class VirtualEnv(Python):
             version=interpreter.version,
             is_64=(interpreter.architecture == 64),
             platform=interpreter.platform,
-            extra={"executable": Path(interpreter.system_executable)},
+            extra={"executable": Path(interpreter.system_executable).resolve()},
         )
 
     def prepend_env_var_path(self) -> list[Path]:


### PR DESCRIPTION
If people called tox alternating between `python3 -m tox` and `tox`,
they would endup triggering venv recreation, even if there was only
one python. We should always resolve symlinks to avoid such false
env invalidations.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
