### PR TITLE
Ensure only one tox environment operates on a packaging environment

### DIFF
--- a/docs/changelog/2564.bugfix.rst
+++ b/docs/changelog/2564.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure only on run environment operates at a time on a packaging environment (fixes unexpected failures when running in
+parallel mode) - by :user:`gaborbernat`.

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -70,6 +70,7 @@ fromdocname
 fromhex
 fs
 fullmatch
+getattribute
 getbasetemp
 getfqdn
 getitem


### PR DESCRIPTION
This isn't easy to test because of the built-in race condition aspect.

Resolves https://github.com/tox-dev/tox/issues/2564.
