### PR TITLE
Lock parallel package operations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
           - flake8-unused-arguments==0.0.12
           - flake8-noqa==1.3
           - pep8-naming==0.13.2
-          - flake8-pyproject==1.2.1
+          - flake8-pyproject==1.2.2
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.7.1"
     hooks:

--- a/docs/changelog/2594.bugfix.rst
+++ b/docs/changelog/2594.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure that two parallel tox instance invocations on different tox environment targets will work by holding a file lock
+onto the packaging operations (e.g., in bash ``tox4 r -e py311 &; tox4 r -e py310``) - by :user:`gaborbernat`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "pyproject-api>=1.2.1",
   'tomli>=2.0.1; python_version < "3.11"',
   "virtualenv>=20.17",
+  "filelock>=3.8.1",
   'importlib-metadata>=5.1; python_version < "3.8"',
   'typing-extensions>=4.4; python_version < "3.8"',
 ]
@@ -49,7 +50,6 @@ optional-dependencies.testing = [
   "devpi-process>=0.3",
   "diff-cover>=7.2",
   "distlib>=0.3.6",
-  "filelock>=3.8",
   "flaky>=3.7",
   "hatch-vcs>=0.2",
   "hatchling>=1.11.1",

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -290,7 +290,7 @@ class ToxEnv(ABC):
         env_dir = self.env_dir
         if env_dir.exists():
             LOGGER.warning("remove tox env folder %s", env_dir)
-            ensure_empty_dir(env_dir)
+            ensure_empty_dir(env_dir, except_filename="file.lock")
         self._log_id = 0  # we deleted logs, so start over counter
         self.cache.reset()
         self._run_state.update({"setup": False, "clean": True})

--- a/src/tox/util/path.py
+++ b/src/tox/util/path.py
@@ -4,10 +4,12 @@ from pathlib import Path
 from shutil import rmtree
 
 
-def ensure_empty_dir(path: Path) -> None:
+def ensure_empty_dir(path: Path, except_filename: str | None = None) -> None:
     if path.exists():
         if path.is_dir():
             for sub_path in path.iterdir():
+                if sub_path.name == except_filename:
+                    continue
                 if sub_path.is_dir():
                     rmtree(sub_path, ignore_errors=True)
                 else:


### PR DESCRIPTION
This ensures that two tox invocations on different target environments will work.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>

Depends on https://github.com/tox-dev/py-filelock/actions/runs/3617976658