### PR TITLE
Remove deprecated `whitelist_externals` configuration option

### DIFF
--- a/docs/changelog/2599.removal.rst
+++ b/docs/changelog/2599.removal.rst
@@ -1,0 +1,1 @@
+Remove deprecated configuration option ``whitelist_externals`` which was replaced by ``allowlist_externals`` - by :user:`jugmac00`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -312,7 +312,7 @@ Base options
    Always recreate virtual environment if this option is true, otherwise leave it up to tox.
 
 .. conf::
-   :keys: allowlist_externals, whitelist_externals
+   :keys: allowlist_externals
    :default: <empty list>
 
    Each line specifies a command name (in glob-style pattern format) which can be used in the commands section even if

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -154,7 +154,7 @@ class ToxEnv(ABC):
             desc="always recreate virtual environment if this option is true, otherwise leave it up to tox",
         )
         self.conf.add_config(
-            keys=["allowlist_externals", "whitelist_externals"],
+            "allowlist_externals",
             of_type=List[str],
             default=[],
             desc="external command glob to allow calling",


### PR DESCRIPTION
`whitelist_externals` was replaced by `allowlist_externals` and has been deprecatd since then.

Also see https://tox.wiki/en/3.18.1/changelog.html#v3-18-0-2020-07-23

This fixes #2599.