### PR TITLE
Document necessity to escape `#` sign used in `commands`

### DIFF
--- a/docs/changelog/2615.doc.rst
+++ b/docs/changelog/2615.doc.rst
@@ -1,0 +1,2 @@
+Document that space separator is no longer valid for the :ref:`passenv` and instead one should use comma  -
+by :user:`gaborbernat`.

--- a/docs/changelog/2617.doc.rst
+++ b/docs/changelog/2617.doc.rst
@@ -1,1 +1,1 @@
-Document necessity to escape ``#`` used  in ``commands``, ``commands_pre`` or ``commands_post`` - by :user:`jugmac00`.
+Document necessity to escape ``#`` within INI configuration - by :user:`jugmac00`.

--- a/docs/changelog/2617.doc.rst
+++ b/docs/changelog/2617.doc.rst
@@ -1,0 +1,1 @@
+Document necessity to escape ``#`` used  in ``commands``, ``commands_pre`` or ``commands_post`` - by :user:`jugmac00`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -409,6 +409,11 @@ Run
    Commands to run before running the :ref:`commands`. All evaluation and configuration logic applies from
    :ref:`commands`.
 
+   .. note::
+
+     When you use the ``#`` sign inside ``commands_pre``, you need to escape it, e.g.
+     ``commands_pre = bash -c "echo 'foo\#bar'"``.
+
 .. conf::
    :keys: commands
    :default: <empty list>
@@ -437,12 +442,22 @@ Run
      ``path/to/my_script`` prefer ``{tox_root}{/}path{/}to{/}my_script``. If your inline script is platform dependent
      refer to :ref:`platform-specification` on how to select different script per platform.
 
+   .. note::
+
+     When you use the ``#`` sign inside ``commands``, you need to escape it, e.g.
+     ``commands = bash -c "echo 'foo\#bar'"``.
+
 .. conf::
    :keys: commands_post
    :default: <empty list>
 
    Commands to run after running the :ref:`commands`. Execute regardless of the outcome of both :ref:`commands` and
    :ref:`commands_pre`. All evaluation and configuration logic applies from :ref:`commands`.
+
+   .. note::
+
+     When you use the ``#`` sign inside ``commands_post``, you need to escape it, e.g.
+     ``commands_post = bash -c "echo 'foo\#bar'"``.
 
 .. conf::
    :keys: change_dir, changedir

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -409,11 +409,6 @@ Run
    Commands to run before running the :ref:`commands`. All evaluation and configuration logic applies from
    :ref:`commands`.
 
-   .. note::
-
-     When you use the ``#`` sign inside ``commands_pre``, you need to escape it, e.g.
-     ``commands_pre = bash -c "echo 'foo\#bar'"``.
-
 .. conf::
    :keys: commands
    :default: <empty list>
@@ -442,22 +437,12 @@ Run
      ``path/to/my_script`` prefer ``{tox_root}{/}path{/}to{/}my_script``. If your inline script is platform dependent
      refer to :ref:`platform-specification` on how to select different script per platform.
 
-   .. note::
-
-     When you use the ``#`` sign inside ``commands``, you need to escape it, e.g.
-     ``commands = bash -c "echo 'foo\#bar'"``.
-
 .. conf::
    :keys: commands_post
    :default: <empty list>
 
    Commands to run after running the :ref:`commands`. Execute regardless of the outcome of both :ref:`commands` and
    :ref:`commands_pre`. All evaluation and configuration logic applies from :ref:`commands`.
-
-   .. note::
-
-     When you use the ``#`` sign inside ``commands_post``, you need to escape it, e.g.
-     ``commands_post = bash -c "echo 'foo\#bar'"``.
 
 .. conf::
    :keys: change_dir, changedir

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -42,6 +42,23 @@ tox 4 - removed tox.ini keys
 | ``isolated_build``       | Isolated builds are now always used.        |
 +--------------------------+---------------------------------------------+
 
+tox 4 - changed behaviour for tox.ini keys
+++++++++++++++++++++++++++++++++++++++++++
+
+- When using any of the ``commands``, ``commands_pre`` or ``commands_post`` keys, you need to escape the ``#`` sign.
+
+Valid in tox 3:
+
+.. code-block:: ini
+
+  commands = bash -c "echo 'foo#bar'"
+
+Valid in tox 4:
+
+.. code-block:: ini
+
+  commands = bash -c "echo 'foo\#bar'"
+
 tox 4 - substitutions removed
 +++++++++++++++++++++++++++++
 - The ``distshare`` substitution has been removed.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -13,6 +13,37 @@ tox 4 - Python support
   for earlier Python versions or different Python interpreters. PyPy support is best effort, meaning we do not test it
   as part of our CI runs, however if you discover issues under PyPy we will accept PRs addressing it.
 
+tox 4 - changed INI rules
++++++++++++++++++++++++++
+- The ``#`` character now always acts as comment within ``tox.ini`` or ``setup.cfg`` tox configuration file. Where you
+  need to pass on a ``#`` character you will need to escape it in form of ``\#`` so tox does not handle everything right
+  of the ``#`` character as a comment. Valid in tox 3:
+
+  .. code-block:: ini
+
+      # valid in tox 3
+      commands = bash -c "echo 'foo#bar'"
+
+      # valid in tox 4
+      commands = bash -c "echo 'foo\#bar'"
+
+- Within the ``pass_env`` you can no longer use space as value separator, instead you need to use the ``,`` or the
+  newline character. This is to have the same value separation rules for all tox configuration lines.
+
+  .. code-block:: ini
+
+      # valid in tox 3
+      passenv = ALPHA BETA
+      passenv =
+          ALPHA
+          BETA
+
+      # valid in tox 4
+      passenv = ALPHA, BETA
+      passenv =
+          ALPHA
+          BETA
+
 tox 4 - known regressions
 +++++++++++++++++++++++++
 
@@ -41,23 +72,6 @@ tox 4 - removed tox.ini keys
 +--------------------------+---------------------------------------------+
 | ``isolated_build``       | Isolated builds are now always used.        |
 +--------------------------+---------------------------------------------+
-
-tox 4 - changed behaviour for tox.ini keys
-++++++++++++++++++++++++++++++++++++++++++
-
-- When using any of the ``commands``, ``commands_pre`` or ``commands_post`` keys, you need to escape the ``#`` sign.
-
-Valid in tox 3:
-
-.. code-block:: ini
-
-  commands = bash -c "echo 'foo#bar'"
-
-Valid in tox 4:
-
-.. code-block:: ini
-
-  commands = bash -c "echo 'foo\#bar'"
 
 tox 4 - substitutions removed
 +++++++++++++++++++++++++++++


### PR DESCRIPTION
... `commands_pre` or `commands_post`.

This fixes #2617.
Resolves https://github.com/tox-dev/tox/issues/2615