### PR TITLE
Allow space-separated passenv variables

### DIFF
--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -132,7 +132,7 @@ class ToxEnv(ABC):
 
         def pass_env_post_process(values: list[str]) -> list[str]:
             values.extend(self._default_pass_env())
-            return sorted({k: None for k in values}.keys())
+            return sorted({k: None for val in values for k in val.split()}.keys())
 
         self.conf.add_config(
             keys=["pass_env", "passenv"],

--- a/tests/tox_env/test_tox_env_api.py
+++ b/tests/tox_env/test_tox_env_api.py
@@ -86,3 +86,18 @@ def test_tox_env_pass_env_match_ignore_case(char: str, glob: str) -> None:
     with patch("os.environ", {"A1": "1", "a2": "2", "A2": "3", "B": "4"}):
         env = ToxEnv._load_pass_env([f"{char}{glob}"])
     assert env == {"A1": "1", "a2": "2", "A2": "3"}
+
+
+@pytest.mark.parametrize("passenv", ["A B", "\n  A\n  B"])
+def test_pass_env_delimiter(tox_project: ToxProjectCreator, passenv: str) -> None:
+    prj = tox_project(
+        {
+            "tox.ini": (
+                f'[testenv]\npassenv={passenv}\ncommands=python -c "'
+                "import os; print(os.environ['A'], os.environ['B'])\""
+            ),
+        },
+    )
+    prj.monkeypatch.setenv("A", "a")
+    prj.monkeypatch.setenv("B", "b")
+    assert prj.run().success


### PR DESCRIPTION
Fixes #2615

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix_lint`)
- [ ] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
