### PR TITLE
Handle encodings properly in SyncWrite, fixes #2422

### DIFF
--- a/src/tox/execute/api.py
+++ b/src/tox/execute/api.py
@@ -122,7 +122,12 @@ class Execute(ABC):
             out, err = out_err
             out_buffer, err_buffer = out.buffer, err.buffer
             out_sync = SyncWrite(out_buffer.name, out_buffer if show else None, encoding=out.encoding)
-            err_sync = SyncWrite(err_buffer.name, err_buffer if show else None, Fore.RED if self._colored else None, encoding=err.encoding)
+            err_sync = SyncWrite(
+                err_buffer.name,
+                err_buffer if show else None,
+                Fore.RED if self._colored else None,
+                encoding=err.encoding,
+            )
             with out_sync, err_sync:
                 instance = self.build_instance(request, self._option_class(env), out_sync, err_sync)
                 with instance as status:

--- a/src/tox/execute/api.py
+++ b/src/tox/execute/api.py
@@ -119,9 +119,10 @@ class Execute(ABC):
         start = time.monotonic()
         try:
             # collector is what forwards the content from the file streams to the standard streams
-            out, err = out_err[0].buffer, out_err[1].buffer
-            out_sync = SyncWrite(out.name, out if show else None)
-            err_sync = SyncWrite(err.name, err if show else None, Fore.RED if self._colored else None)
+            out, err = out_err
+            out_buffer, err_buffer = out.buffer, err.buffer
+            out_sync = SyncWrite(out_buffer.name, out_buffer if show else None, encoding=out.encoding)
+            err_sync = SyncWrite(err_buffer.name, err_buffer if show else None, Fore.RED if self._colored else None, encoding=err.encoding)
             with out_sync, err_sync:
                 instance = self.build_instance(request, self._option_class(env), out_sync, err_sync)
                 with instance as status:
@@ -129,6 +130,7 @@ class Execute(ABC):
                 exit_code = status.exit_code
         finally:
             end = time.monotonic()
+
         status.outcome = Outcome(
             request,
             show,

--- a/src/tox/execute/stream.py
+++ b/src/tox/execute/stream.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import sys
 from contextlib import contextmanager
 from threading import Event, Lock, Timer
 from types import TracebackType
@@ -17,7 +17,7 @@ class SyncWrite:
 
     REFRESH_RATE = 0.1
 
-    def __init__(self, name: str, target: IO[bytes] | None, color: str | None = None) -> None:
+    def __init__(self, name: str, target: IO[bytes] | None, color: str | None = None, encoding: str | None = None) -> None:
         self._content = bytearray()
         self._target: IO[bytes] | None = target
         self._target_enabled: bool = target is not None
@@ -27,6 +27,7 @@ class SyncWrite:
         self._at: int = 0
         self._color: str | None = color
         self.name = name
+        self.encoding = sys.getdefaultencoding() if encoding is None else encoding
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name!r}, target={self._target!r}, color={self._color!r})"
@@ -100,7 +101,7 @@ class SyncWrite:
     @property
     def text(self) -> str:
         with self._content_lock:
-            return self._content.decode("utf-8")
+            return self._content.decode(self.encoding)
 
     @property
     def content(self) -> bytearray:

--- a/src/tox/execute/stream.py
+++ b/src/tox/execute/stream.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 from contextlib import contextmanager
 from threading import Event, Lock, Timer
@@ -17,7 +18,9 @@ class SyncWrite:
 
     REFRESH_RATE = 0.1
 
-    def __init__(self, name: str, target: IO[bytes] | None, color: str | None = None, encoding: str | None = None) -> None:
+    def __init__(
+        self, name: str, target: IO[bytes] | None, color: str | None = None, encoding: str | None = None
+    ) -> None:
         self._content = bytearray()
         self._target: IO[bytes] | None = target
         self._target_enabled: bool = target is not None

--- a/tests/execute/test_stream.py
+++ b/tests/execute/test_stream.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from colorama import Fore
 from io import BytesIO
+
 import pytest
+from colorama import Fore
 
 from tox.execute.stream import SyncWrite
 

--- a/tests/execute/test_stream.py
+++ b/tests/execute/test_stream.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from colorama import Fore
+from io import BytesIO
+import pytest
 
 from tox.execute.stream import SyncWrite
 
@@ -8,3 +10,24 @@ from tox.execute.stream import SyncWrite
 def test_sync_write_repr() -> None:
     sync_write = SyncWrite(name="a", target=None, color=Fore.RED)
     assert repr(sync_write) == f"SyncWrite(name='a', target=None, color={Fore.RED!r})"
+
+
+@pytest.mark.parametrize("encoding", ("utf-8", "latin-1", "cp1252"))
+def test_sync_write_encoding(encoding) -> None:
+    text = "Hello W\N{LATIN SMALL LETTER O WITH DIAERESIS}rld: "
+    io = BytesIO()
+
+    sync_write = SyncWrite(name="a", target=io, color=Fore.RED, encoding=encoding)
+    sync_write.handler(text.encode(encoding))
+    assert sync_write.text == text
+
+
+@pytest.mark.parametrize("encoding", ("latin-1", "cp1252"))
+def test_sync_invalid_encoding(encoding) -> None:
+    text = "Hello W\N{LATIN SMALL LETTER O WITH DIAERESIS}rld: "
+    io = BytesIO()
+
+    sync_write = SyncWrite(name="a", target=io, color=Fore.RED, encoding="utf-8")
+    sync_write.handler(text.encode(encoding))
+    with pytest.raises(UnicodeDecodeError):
+        assert sync_write.text == text


### PR DESCRIPTION
This pull requests adds the `encoding` parameter to `SyncWrite` to hopefully fix #2422

While I have not yet produced a minimal working example that reproduces the bug in 2422, 
it is definitely wrong to always just assume utf-8.

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
