### PR TITLE
Document that `-v` adds debug info to `--showconfig` and `--help-ini``

### DIFF
--- a/docs/changelog/2622.doc.rst
+++ b/docs/changelog/2622.doc.rst
@@ -1,0 +1,2 @@
+Document that running ``--showconfig```or ``--help-ini`` with the ``-v`` flag will add interleaved debugging
+information, whereas tox v3 added extra lines at the start  - by :user:`jugmac00`.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -93,6 +93,8 @@ tox 4 - CLI arguments changed
 - When you want to pass an option to a test command, e.g. to ``pytest``, now you must use ``--`` as a separator, this
   worked with version 3 also, but any unknown trailing arguments were automatically passed through, while now this is
   no longer the case.
+- Running ``--showconfig```or ``--help-ini`` with the ``-v`` flag will add interleaved debugging information, whereas
+  tox 3 added additional lines at the start. If you want to generate valid ini files you must not use the ``-v`` flag.
 
 tox 4 - packaging changes
 +++++++++++++++++++++++++


### PR DESCRIPTION
So if you want to generate a valid ini file, you must not use verbose mode.

This fixes #2622.