### PR TITLE
Do not log distlib.util or filelock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: add-trailing-comma
         args: [--py36-plus]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]

--- a/docs/changelog/2655.bugfix.rst
+++ b/docs/changelog/2655.bugfix.rst
@@ -1,0 +1,1 @@
+Disable logging from ``distlib.util`` and ``filelock`` as these log messages are too verbose - by :user:`gaborbernat`.

--- a/src/tox/report.py
+++ b/src/tox/report.py
@@ -204,36 +204,16 @@ class ToxHandler(logging.StreamHandler):  # type: ignore[type-arg] # is generic 
     def update_verbosity(self, verbosity: int) -> None:
         level = _get_level(verbosity)
         LOGGER.setLevel(level)
-        for name in ("distlib.util", "filelock"):
-            logger = logging.getLogger(name)
-            for logging_filter in logger.filters:  # pragma: no branch  # the filters is never empty
-                if isinstance(logging_filter, LowerInfoLevel):  # pragma: no branch # we always find it
-                    logging_filter.level = level
-                    break
         self._setup_level(self._is_colored, level)
-
-
-class LowerInfoLevel(logging.Filter):
-    def __init__(self, level: int) -> None:
-        super().__init__()
-        self.level = level
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        if record.levelname in "INFO":
-            record.levelno = logging.DEBUG
-            record.levelname = "DEBUG"
-        return record.levelno >= self.level
 
 
 def setup_report(verbosity: int, is_colored: bool) -> ToxHandler:
     _clean_handlers(LOGGER)
     level = _get_level(verbosity)
     LOGGER.setLevel(level)
-    lower_info_level = LowerInfoLevel(level)
     for name in ("distlib.util", "filelock"):
         logger = logging.getLogger(name)
-        logger.filters.clear()
-        logger.addFilter(lower_info_level)
+        logger.disabled = True
     out_err: OutErr = (sys.stdout, sys.stderr)  # type: ignore[assignment]
     handler = ToxHandler(level, is_colored, out_err)
     LOGGER.addHandler(handler)

--- a/tests/config/cli/test_parse.py
+++ b/tests/config/cli/test_parse.py
@@ -6,7 +6,6 @@ import pytest
 
 from tox.config.cli.parse import get_options
 from tox.pytest import CaptureFixture
-from tox.report import LowerInfoLevel
 
 
 def test_help_does_not_default_cmd(capsys: CaptureFixture) -> None:
@@ -26,11 +25,7 @@ def test_verbosity_guess_miss_match(capsys: CaptureFixture) -> None:
 
     for name in ("distlib.util", "filelock"):
         logger = logging.getLogger(name)
-        for logging_filter in logger.filters:  # pragma: no branch # never empty
-            if isinstance(logging_filter, LowerInfoLevel):  # pragma: no branch # we always find it
-                assert logging_filter.level == logging.INFO
-                break
-
+        assert logger.disabled
     logging.error("E")
     logging.warning("W")
     logging.info("I")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -25,8 +25,8 @@ def test_setup_report(mocker: MockerFixture, capsys: CaptureFixture, verbosity: 
         logging.info("info")
         logging.debug("debug")
         logging.log(logging.NOTSET, "not-set")  # this should not be logged
-        lowered = "distlib.util", "filelock"
-        for name in lowered:
+        disabled = "distlib.util", "filelock"
+        for name in disabled:
             logger = logging.getLogger(name)
             logger.warning(f"{name}-warn")
             logger.info(f"{name}-info")
@@ -38,15 +38,15 @@ def test_setup_report(mocker: MockerFixture, capsys: CaptureFixture, verbosity: 
     assert color_init.call_count == (1 if color else 0)
 
     msg_count = min(verbosity + 1, 5)
-    msg_count += (1 if verbosity >= 2 else 0) * len(lowered)  # warning lowered
     is_debug_or_more = verbosity >= 4
     if is_debug_or_more:
         msg_count += 1  # we log at debug level setting up the logger
-        msg_count += (2 if verbosity >= 4 else 1) * len(lowered)
 
     out, err = capsys.readouterr()
     assert not err
     assert out
+    assert "filelock" not in out
+    assert "distlib.util" not in out
     lines = out.splitlines()
     assert len(lines) == msg_count, out
 


### PR DESCRIPTION
These are the way to be verbose and make it hard to read the output. We can put them back if we need them, but `--exit-and-dump-after` should suffice for deadlock detection.