### PR TITLE
Fail on blanks in passed env vars

### DIFF
--- a/docs/changelog/2658.feature.rst
+++ b/docs/changelog/2658.feature.rst
@@ -1,0 +1,1 @@
+Fail on ''pass_env/passenv'' entries containing blanks, detecting missing commas

--- a/docs/changelog/2658.feature.rst
+++ b/docs/changelog/2658.feature.rst
@@ -1,1 +1,1 @@
-Fail on ''pass_env/passenv'' entries containing blanks, detecting missing commas
+Fail on :ref:`pass_env`/:ref:`passenv` entries containing whitespace - by :user:`ericzolf`.

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -21,7 +21,7 @@ from tox.execute.api import Execute, ExecuteStatus, Outcome, StdinSource
 from tox.execute.request import ExecuteRequest
 from tox.journal import EnvJournal
 from tox.report import OutErr, ToxHandler
-from tox.tox_env.errors import Recreate, Skip
+from tox.tox_env.errors import Fail, Recreate, Skip
 from tox.tox_env.info import Info
 from tox.tox_env.installer import Installer
 from tox.util.path import ensure_empty_dir
@@ -131,6 +131,12 @@ class ToxEnv(ABC):
         )
 
         def pass_env_post_process(values: list[str]) -> list[str]:
+            blank_values = [v for v in values if " " in v or "\t" in v]
+            if blank_values:
+                raise Fail(
+                    f"pass_env/passenv variable can't have values containing "
+                    f"blanks like {blank_values}; a comma is possibly missing",
+                )
             values.extend(self._default_pass_env())
             return sorted({k: None for k in values}.keys())
 

--- a/tests/tox_env/test_tox_env_api.py
+++ b/tests/tox_env/test_tox_env_api.py
@@ -80,6 +80,26 @@ def test_tox_env_pass_env_literal_miss() -> None:
     assert not env
 
 
+def test_tox_env_pass_env_fail(tox_project: ToxProjectCreator) -> None:
+    prj = tox_project(
+        {
+            "tox.ini": """[testenv]
+    passenv = MYENV YOURENV, THEIRENV
+    commands=python -c 'import os; print("MYENV", os.getenv("MYENV"))'""",
+        },
+    )
+
+    result = prj.run("r")
+
+    result.assert_failed(1)
+    out = (
+        r"py: failed with pass_env/passenv variable can't have values "
+        r"containing blanks like \['MYENV YOURENV'\]; "
+        r"a comma is possibly missing.*"
+    )
+    result.assert_out_err(out=out, err="", regex=True)
+
+
 @pytest.mark.parametrize("glob", ["*", "?"])
 @pytest.mark.parametrize("char", ["a", "A"])
 def test_tox_env_pass_env_match_ignore_case(char: str, glob: str) -> None:


### PR DESCRIPTION
Avoids to oversee pass_env/passenv going from blank to comma separated list between tox 3 and 4
Resolves https://github.com/tox-dev/tox/issues/2658

(as I create this PR, I allowed myself to fix the `tox -e fix`~_lint~ checkmark)
# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

I know that I'm not fully done but I would appreciate first feedback on my code before I pursue, as this is my first PR for this project.