### PR TITLE
Fix the description of 'package' option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -589,8 +589,8 @@ Python run
    :keys: package
    :version_added: 4.0
 
-   When option can be one of ``skip``, ``dev-legacy``, ``sdist``, ``wheel`` or ``external``. If :ref:`use_develop` is
-   set this becomes a constant of ``dev-legacy``. If :ref:`skip_install` is set this becomes a constant of ``skip``.
+   When option can be one of ``wheel``, ``sdist``, ``editable``, ``editable-legacy``, ``skip``, or ``external``. If :ref:`use_develop` is
+   set this becomes a constant of ``editable``. If :ref:`skip_install` is set this becomes a constant of ``skip``.
 
 
 .. conf::


### PR DESCRIPTION
It has been stale since #2502 was merged. I suppose this doesn't require a news fragment.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
