### PR TITLE
Fixes issues when PATH is set in set_env

### DIFF
--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -109,6 +109,9 @@ class VirtualEnv(Python):
 
     def virtualenv_env_vars(self) -> dict[str, str]:
         env = self.environment_variables.copy()
+        # we want to use PATH from environment rather than any PATH
+        # modifications in set_env to find the python executable
+        env["PATH"] = os.environ.get("PATH", "")
         base_python: list[str] = self.conf["base_python"]
         if "VIRTUALENV_NO_PERIODIC_UPDATE" not in env:
             env["VIRTUALENV_NO_PERIODIC_UPDATE"] = "True"

--- a/tests/tox_env/test_tox_env_api.py
+++ b/tests/tox_env/test_tox_env_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import patch
@@ -113,3 +114,18 @@ def test_change_dir_is_created_if_not_exist(tox_project: ToxProjectCreator) -> N
     result_first = prj.run("r")
     result_first.assert_success()
     assert (prj.path / "a" / "b").exists()
+
+
+def test_path_from_set_env(tox_project: ToxProjectCreator) -> None:
+    tox_ini = """
+        [testenv]
+        package = skip
+        set_env =
+            PATH=/dev/null
+        commands =
+            python -c 'import os; print("PATH", os.environ["PATH"])'
+    """
+    prj = tox_project({"tox.ini": inspect.cleandoc(tox_ini)})  # noqa: SC200
+    result = prj.run("r")
+    result.assert_success()
+    assert "/dev/null" in result.out


### PR DESCRIPTION
This PR fixes two issues that have appeared with tox 4 having to due with the handling of the PATH environment variable.

## Issues fixed

#### Use `os.environ["PATH"]` when locating python executable for environment

When creating a virtual env, use `os.environ["PATH"]` rather than any PATH from a `set_env` to locate the python executable for the environment. (See #2691 for a motivation.)

#### The logic for updating PATH when `ToxEnv._paths` is set was not respecting any PATH from `set_env`

`ToxEnv.environment_variables` caches its result.  There was logic in the *setter* for `ToxEnv._paths` to update the cached value for PATH when `_paths` was set.  (`ToxEnv._paths` contained a list of directories that are to be prepended to PATH.  It is used to add the virtual env's bindir to the PATH.) That logic was not respecting any customization for PATH in `set_env`, with the result that once the virtual env was constructed, any customizations to PATH from `set_env`  was discarded.

The fix here moves the logic for prefixing PATH to `tox.tox_env.python.api.Python`, since it's not used elsewhere.


## Checklist
Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
