### PR TITLE
Restore TOX_SKIP_ENV filtering

### DIFF
--- a/docs/changelog/2698.bugfix.rst
+++ b/docs/changelog/2698.bugfix.rst
@@ -1,1 +1,2 @@
-``TOX_SKIP_ENV`` environment variable now works again - by :user:`mgedmin`.
+``TOX_SKIP_ENV`` environment variable now works again, and can also be set via the CLI argument ``--skip-env``
+for any command where ``-e`` can be set - by :user:`mgedmin`.

--- a/docs/changelog/2698.bugfix.rst
+++ b/docs/changelog/2698.bugfix.rst
@@ -1,0 +1,2 @@
+``TOX_SKIP_ENV`` environment variable now works again (it was unintentionally
+broken in the tox 4.0.0 release)

--- a/docs/changelog/2698.bugfix.rst
+++ b/docs/changelog/2698.bugfix.rst
@@ -1,2 +1,1 @@
-``TOX_SKIP_ENV`` environment variable now works again (it was unintentionally
-broken in the tox 4.0.0 release)
+``TOX_SKIP_ENV`` environment variable now works again - by :user:`mgedmin`.

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import re
 from argparse import ArgumentParser
 from collections import Counter
 from dataclasses import dataclass
@@ -320,14 +322,16 @@ class EnvSelector:
 
         :return: an iteration of tox environments
         """
-        ignore_envs: set[str] = set()
+        tox_env_filter = os.environ.get("TOX_SKIP_ENV")
+        tox_env_filter_re = re.compile(tox_env_filter) if tox_env_filter is not None else None
         for name, env_info in self._defined_envs.items():
             if only_active and not env_info.is_active:
                 continue
             if not package and not isinstance(env_info.env, RunToxEnv):
                 continue
+            if tox_env_filter_re is not None and tox_env_filter_re.match(name):
+                continue
             yield name
-            ignore_envs.add(name)
 
     def ensure_only_run_env_is_active(self) -> None:
         envs, active = self._defined_envs, self._env_name_to_active()

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import re
 from argparse import ArgumentParser
 from collections import Counter
@@ -94,6 +93,8 @@ def register_env_select_flags(
         add_to.add_argument("-m", dest="labels", metavar="label", help=help_msg, default=[], type=str, nargs="+")
         help_msg = "factors to evaluate"
         add_to.add_argument("-f", dest="factors", metavar="factor", help=help_msg, default=[], type=str, nargs="+")
+    help_msg = "exclude all environments selected that match this regular expression"
+    add_to.add_argument("--skip-env", dest="skip_env", metavar="re", help=help_msg, default="", type=str)
     return add_to
 
 
@@ -125,7 +126,7 @@ class EnvSelector:
         self._provision: None | tuple[bool, str, MemoryLoader] = None
 
         self._state.conf.core.add_config("labels", Dict[str, EnvList], {}, "core labels")
-        tox_env_filter_regex = os.environ.get("TOX_SKIP_ENV", "").strip()
+        tox_env_filter_regex = getattr(state.conf.options, "skip_env", "").strip()
         self._filter_re = re.compile(tox_env_filter_regex) if tox_env_filter_regex else None
 
     def _collect_names(self) -> Iterator[tuple[Iterable[str], bool]]:

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -108,13 +108,14 @@ class _ToxEnvInfo:
 
 class EnvSelector:
 
-    _warned_about: set[str] = set()  #: shared set of skipped environments that were already warned about
+    _warned_about: set[str]  #: shared set of skipped environments that were already warned about
 
     def __init__(self, state: State) -> None:
         # needs core to load the default tox environment list
         # to load the package environments of a run environments we need the run environment builder
         # to load labels we need core + the run environment
         self.on_empty_fallback_py = True
+        self._warned_about = set()
         self._state = state
         self._cli_envs: CliEnv | None = getattr(self._state.conf.options, "env", None)
         self._defined_envs_: None | dict[str, _ToxEnvInfo] = None

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -338,7 +338,7 @@ class EnvSelector:
                 continue
             if tox_env_filter_re is not None and tox_env_filter_re.match(name):
                 if name not in self._warned_about:
-                    LOGGER.info("skip environment %s, matches filter %r", name, tox_env_filter_re.pattern)
+                    LOGGER.warning("skip environment %s, matches filter %r", name, tox_env_filter_re.pattern)
                     self._warned_about.add(name)
                 continue
             yield name

--- a/tests/config/cli/test_cli_env_var.py
+++ b/tests/config/cli/test_cli_env_var.py
@@ -62,6 +62,7 @@ def test_verbose_no_test() -> None:
         "index_url": [],
         "factors": [],
         "labels": [],
+        "skip_env": "",
     }
 
 
@@ -120,6 +121,7 @@ def test_env_var_exhaustive_parallel_values(
         "factors": [],
         "labels": [],
         "exit_and_dump_after": 0,
+        "skip_env": "",
     }
     assert options.parsed.verbosity == 4
     assert options.cmd_handlers == core_handlers

--- a/tests/config/cli/test_cli_ini.py
+++ b/tests/config/cli/test_cli_ini.py
@@ -99,6 +99,7 @@ def default_options(tmp_path: Path) -> dict[str, Any]:
         "factors": [],
         "labels": [],
         "exit_and_dump_after": 0,
+        "skip_env": "",
     }
 
 
@@ -134,6 +135,7 @@ def test_ini_exhaustive_parallel_values(exhaustive_ini: Path, core_handlers: dic
         "factors": [],
         "labels": [],
         "exit_and_dump_after": 0,
+        "skip_env": "",
     }
     assert options.parsed.verbosity == 4
     assert options.cmd_handlers == core_handlers

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -82,3 +82,15 @@ def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch) -> None:
     outcome = project.run("l", "--no-desc")
     outcome.assert_success()
     outcome.assert_out_err("py310\npy39\n", "")
+
+
+def test_tox_skip_env_logs(tox_project: ToxProjectCreator, monkeypatch) -> None:
+    monkeypatch.setenv("TOX_SKIP_ENV", "m[y]py")
+    ini = """
+        [tox]
+        env_list = py3{10,9},mypy
+        """
+    project = tox_project({"tox.ini": ini})
+    outcome = project.run("l", "--no-desc", "-v")
+    outcome.assert_success()
+    outcome.assert_out_err("ROOT: skip environment mypy, matches filter 'm[y]py'\npy310\npy39\n", "")

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -80,6 +80,14 @@ def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) 
     outcome.assert_out_err("py310\npy39\n", "")
 
 
+def test_tox_skip_env_cli(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv("TOX_SKIP_ENV", raising=False)
+    project = tox_project({"tox.ini": "[tox]\nenv_list = py3{10,9},mypy"})
+    outcome = project.run("l", "--no-desc", "-q", "--skip-env", "m[y]py")
+    outcome.assert_success()
+    outcome.assert_out_err("py310\npy39\n", "")
+
+
 def test_tox_skip_env_logs(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("TOX_SKIP_ENV", "m[y]py")
     project = tox_project({"tox.ini": "[tox]\nenv_list = py3{10,9},mypy"})

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -74,11 +74,7 @@ def test_factor_select(tox_project: ToxProjectCreator) -> None:
 
 def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("TOX_SKIP_ENV", "m[y]py")
-    ini = """
-        [tox]
-        env_list = py3{10,9},mypy
-        """
-    project = tox_project({"tox.ini": ini})
+    project = tox_project({"tox.ini": "[tox]\nenv_list = py3{10,9},mypy"})
     outcome = project.run("l", "--no-desc", "-q")
     outcome.assert_success()
     outcome.assert_out_err("py310\npy39\n", "")
@@ -86,11 +82,7 @@ def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) 
 
 def test_tox_skip_env_logs(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("TOX_SKIP_ENV", "m[y]py")
-    ini = """
-        [tox]
-        env_list = py3{10,9},mypy
-        """
-    project = tox_project({"tox.ini": ini})
+    project = tox_project({"tox.ini": "[tox]\nenv_list = py3{10,9},mypy"})
     outcome = project.run("l", "--no-desc")
     outcome.assert_success()
     outcome.assert_out_err("ROOT: skip environment mypy, matches filter 'm[y]py'\npy310\npy39\n", "")

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from tox.pytest import ToxProjectCreator
+from tox.pytest import MonkeyPatch, ToxProjectCreator
 
 
 def test_label_core_can_define(tox_project: ToxProjectCreator) -> None:
@@ -72,7 +72,7 @@ def test_factor_select(tox_project: ToxProjectCreator) -> None:
     outcome.assert_out_err("py310-django20-cov\npy39-django20-cov\n", "")
 
 
-def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch) -> None:
+def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("TOX_SKIP_ENV", "m[y]py")
     ini = """
         [tox]
@@ -84,7 +84,7 @@ def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch) -> None:
     outcome.assert_out_err("py310\npy39\n", "")
 
 
-def test_tox_skip_env_logs(tox_project: ToxProjectCreator, monkeypatch) -> None:
+def test_tox_skip_env_logs(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("TOX_SKIP_ENV", "m[y]py")
     ini = """
         [tox]

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -79,7 +79,7 @@ def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) 
         env_list = py3{10,9},mypy
         """
     project = tox_project({"tox.ini": ini})
-    outcome = project.run("l", "--no-desc")
+    outcome = project.run("l", "--no-desc", "-q")
     outcome.assert_success()
     outcome.assert_out_err("py310\npy39\n", "")
 
@@ -91,6 +91,6 @@ def test_tox_skip_env_logs(tox_project: ToxProjectCreator, monkeypatch: MonkeyPa
         env_list = py3{10,9},mypy
         """
     project = tox_project({"tox.ini": ini})
-    outcome = project.run("l", "--no-desc", "-v")
+    outcome = project.run("l", "--no-desc")
     outcome.assert_success()
     outcome.assert_out_err("ROOT: skip environment mypy, matches filter 'm[y]py'\npy310\npy39\n", "")

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -70,3 +70,15 @@ def test_factor_select(tox_project: ToxProjectCreator) -> None:
     outcome = project.run("l", "--no-desc", "-f", "cov", "django20")
     outcome.assert_success()
     outcome.assert_out_err("py310-django20-cov\npy39-django20-cov\n", "")
+
+
+def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch) -> None:
+    monkeypatch.setenv("TOX_SKIP_ENV", "m[y]py")
+    ini = """
+        [tox]
+        env_list = py3{10,9},mypy
+        """
+    project = tox_project({"tox.ini": ini})
+    outcome = project.run("l", "--no-desc")
+    outcome.assert_success()
+    outcome.assert_out_err("py310\npy39\n", "")


### PR DESCRIPTION
This is still documented in docs/config.rst.  The only missing thing is the reporting at verbosity level 2.

I feel bad about the missing reporting.  Could someone help me figure it out?

Fixes #2698.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
