### PR TITLE
Fix default verbosity in help

### DIFF
--- a/docs/changelog/2707.bugfix.rst
+++ b/docs/changelog/2707.bugfix.rst
@@ -1,0 +1,1 @@
+``--help`` now reports the default verbosity level (which is WARNING) correctly.

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -274,7 +274,7 @@ def add_verbosity_flags(parser: ArgumentParser) -> None:
     verbosity_group = parser.add_argument_group("verbosity")
     verbosity_group.description = (
         f"every -v increases, every -q decreases verbosity level, "
-        f"default {logging.getLevelName(LEVELS[3])}, map {level_map}"
+        f"default {logging.getLevelName(LEVELS[DEFAULT_VERBOSITY])}, map {level_map}"
     )
     verbosity = verbosity_group.add_mutually_exclusive_group()
     verbosity.add_argument(


### PR DESCRIPTION
Fix default verbosity reporting in --help output

Fixes #2708.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
