### PR TITLE
implement pseudo tty on stdout/stderr

### DIFF
--- a/docs/changelog/1773.bugfix.rst
+++ b/docs/changelog/1773.bugfix.rst
@@ -1,0 +1,2 @@
+If tox is running in a tty, allocate a pty (pseudo terminal) for commands
+and copy termios attributes to show colors and improve interactive use - by :user:`masenf`.

--- a/src/tox/execute/local_sub_process/__init__.py
+++ b/src/tox/execute/local_sub_process/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import fnmatch
+import io
 import logging
 import os
 import shutil
@@ -240,12 +241,19 @@ class LocalSubProcessExecuteInstance(ExecuteInstance):
 
     @staticmethod
     def get_stream_file_no(key: str) -> Generator[int, Popen[bytes], None]:
-        process = yield PIPE
-        stream = getattr(process, key)
-        if sys.platform == "win32":  # explicit check for mypy # pragma: win32 cover
-            yield stream.handle
+        allocated_pty = _pty(key)
+        if allocated_pty is not None:
+            main_fd, child_fd = allocated_pty
+            yield child_fd
+            os.close(child_fd)  # close the child process pipe
+            yield main_fd
         else:
-            yield stream.name
+            process = yield PIPE
+            stream = getattr(process, key)
+            if sys.platform == "win32":  # explicit check for mypy # pragma: win32 cover
+                yield stream.handle
+            else:
+                yield stream.name
 
     def set_out_err(self, out: SyncWrite, err: SyncWrite) -> tuple[SyncWrite, SyncWrite]:
         prev = self._out, self._err
@@ -254,6 +262,56 @@ class LocalSubProcessExecuteInstance(ExecuteInstance):
         if self._read_stderr is not None:  # pragma: no branch
             self._read_stderr.handler = err.handler
         return prev
+
+
+def _pty(key: str) -> tuple[int, int] | None:
+    """
+    Allocate a virtual terminal (pty) for a subprocess.
+
+    A virtual terminal allows a process to perform syscalls that fetch attributes related to the tty,
+    for example to determine whether to use colored output or enter interactive mode.
+
+    The termios attributes of the controlling terminal stream will be copied to the allocated pty.
+
+    :param key: The stream to copy attributes from. Either "stdout" or "stderr".
+    :return: (main_fd, child_fd) of an allocated pty; or None on error or if unsupported (win32).
+    """
+    if sys.platform == "win32":  # explicit check for mypy # pragma: win32 cover
+        return None
+
+    stream: io.TextIOWrapper = getattr(sys, key)
+
+    # when our current stream is a tty, emulate pty for the child
+    #   to allow host streams traits to be inherited
+    if not stream.isatty():
+        return None
+
+    try:
+        import fcntl
+        import pty
+        import struct
+        import termios
+    except ImportError:  # pragma: no cover
+        return None  # cannot proceed on platforms without pty support
+
+    try:
+        main, child = pty.openpty()
+    except OSError:  # could not open a tty
+        return None  # pragma: no cover
+
+    try:
+        mode = termios.tcgetattr(stream)
+        termios.tcsetattr(child, termios.TCSANOW, mode)
+    except (termios.error, OSError):  # could not inherit traits
+        return None  # pragma: no cover
+
+    # adjust sub-process terminal size
+    columns, lines = shutil.get_terminal_size(fallback=(-1, -1))
+    if columns != -1 and lines != -1:
+        size = struct.pack("HHHH", columns, lines, 0, 0)
+        fcntl.ioctl(child, termios.TIOCSWINSZ, size)
+
+    return main, child
 
 
 __all__ = (

--- a/src/tox/execute/stream.py
+++ b/src/tox/execute/stream.py
@@ -55,12 +55,12 @@ class SyncWrite:
             at = content.rfind(b"\n")
             if at != -1:  # pragma: no branch
                 at = len(self._content) - len(content) + at + 1
-        if at != -1:
-            self._cancel()
-            try:
+        self._cancel()
+        try:
+            if at != -1:
                 self._write(at)
-            finally:
-                self._start()
+        finally:
+            self._start()
 
     def _start(self) -> None:
         self.timer = Timer(self.REFRESH_RATE, self._trigger_timer)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -108,6 +108,7 @@ nonlocal
 notset
 nox
 objtype
+openpty
 ov
 pathname
 pep517
@@ -119,6 +120,7 @@ posix
 prereleases
 prj
 psutil
+pty
 purelib
 py311
 py38
@@ -156,6 +158,11 @@ statemachine
 string2lines
 stringify
 subparsers
+tcgetattr
+TCSANOW
+tcsetattr
+TIOCSWINSZ
+termios
 termux
 testenv
 tmpdir


### PR DESCRIPTION
# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

# `pty`

This is my first attempt at fixing #1773, starting with the example code posted on that issue, and adapting it for some changes that have occured since then.

For the most part the code worked really nice already.

I did encounter the one problem mentioned after setting the Popen `stdout` and `stderr` handles to pty:

> but once done that the stdin echo seems to no longer buffer realtime, and is instead only line-buffered. This is bad for interacting with the GDB

After lots of poking around, I determine that the code in `SyncWrite`, which is supposed to write the content to the target after some minimum delay, was not restarting its timer appropriately, causing the output to "hang" until `SyncWrite` discovered a newline `\n`.

With that fix in https://github.com/tox-dev/tox/commit/9b06df54e59989140b394baafc408fb7041dfa7f, everything seems to be working fine, EXCEPT, the log files now have ANSI escape sequences in them... which may or may not be desirable. After all, that _is_ what the program output.

After this patch, colored output and interactive use (`pdb`, `ipython`) appears to be working out of the box!

# Testing

Here's my "human" test file with 4 cases, to exemplify the differences between tox 3, tox 4, and this patch.

I've made these sort of non-scientific comparisons on a macOS 10.15 machine.

```
[tox]
skipsdist = true
envlist = py, pytest, textual, vim

[testenv]
commands =
    python -i -c 'import sys; \
        print("sys.stdout.isatty(): %s" % sys.stdout.isatty()); \
        print("to stdout, should be colorless\n"); \
        print("sys.stderr.isatty(): %s" % sys.stderr.isatty()); \
        print("to stderr, should be red?\n", file=sys.stderr)'

[testenv:pytest]
deps = pytest
commands =
    pytest {posargs} --pdb

[testenv:textual]
deps = textual
commands =
    python -m textual

[testenv:vim]
allowlist_externals = vim
commands = vim -p /tmp/f1 /tmp/f2 /tmp/f3
```

## tox 3 ("current behavior" expected by users)

* `py`
  * sys.stdout.isatty(): True
  * sys.stderr.isatty(): True
  * printed lines are in order
  * session is interactive, arrow keys work, input is echoed
  * stderr is not colored red (that's a tox4 feature)
* `pytest`
  * color output (green dots, red `F`, and red `Failed:` text
  * pdb session is interactive, arrow keys work, input is echoed
* `textual`
  * demo works, but appears to be in "low color" or "reduced feature" mode
* `vim`: fully interactive, working as expected

### tox 3 (Using `tee` to pipe the output to a log file)

* `py`
  * sys.stdout.isatty(): False
  * sys.stderr.isatty(): False
  * printed lines out of order (after pressing `<enter>`)
  * session is non-interactive, arrow keys print control codes, input is echoed, but stdout is block buffered and output is delayed to screen.
* `pytest`
  * monochrome output
  * pdb session is non-interactive, arrow keys print control codes
* `textual`
  * surprisingly, demo works. still in "low color" or "reduced feature" mode and small fixed window size (toggle light/dark mode fixes window size)
* `vim`: fully interactive, working as expected (also surprising)

## tox 4 ("new behavior" shows some regression in expected functionality)

* `py`
  * stderr is colored red
  * printed lines out of order (pressing `<enter>` shows previous output)
  * sys.stdout.isatty(): False
  * sys.stderr.isatty(): False
  * session is non-interactive, arrow keys print control codes. input is echoed, but stdout and stderr are buffered unexpectedly (for example: the prompt doesn't show up until a newline appears on stderr)
* `pytest`
  * familiar dot and status letters are monochrome; stderr is red (as expected)
  * pdb session is not interactive, arrow keys print control codes
* `textual`
  * surprisingly, demo works basically perfectly. not sure how they pulled that off 🤯 
* `vim`
  * sort of works (better than expected), but there are still delayed output issues, sometimes nothing shows up when you type. However, switching tabs (`gt` and `gT` can sometimes trigger a refresh).

### tox 4 (Using `tee` to pipe the output to a log file)

* `py`: no change using `tee`
* `pytest`: no change using `tee`
* `textual`: behaves like tox 3 with `tee`
* `vim`: no change using `tee`

## tox 4 **with this patch!**

* `py`
  * sys.stdout.isatty(): True
  * sys.stderr.isatty(): True
  * stderr text is colored red
  * session is interactive, arrow keys work, input is echoed
* `pytest`
  * color output (green dots, red `F`, and red `Failed:` text
  * pdb session is interactive, arrow keys work, input is echoed
* `textual`
  * demo works perfectly, no change from tox 4; using high color mode, unlike tox 3.
* `vim`: fully interactive, working as expected

### tox 4 **with this patch!** (Using `tee` to pipe the output to a log file)

* `py`
  * sys.stdout.isatty(): False
  * sys.stderr.isatty(): True
  * monochrome output
  * session is non-interactive, arrow keys print control codes. input is echoed; not observing any buffering issues (likey `SyncWrite` fix at work)
* `pytest`
  * monochrome output
  * pdb session is non-interactive, arrow keys print control codes
* `textual`: behaves like tox 3 with `tee`
* `vim`: fully interactive, working as expected (again, not sure how, but i'll take it)

# TODO

* ~Failing test to investigate~ turned out to be a macOS issue with **homebrew-installed python interpreters**. The test was expecting the executable to be `/usr/local/opt/python@3.11/bin/python3.11`, but when it runs throught the virtualenv, the path name comes out as `/usr/local/Cellar/python@3.11/3.11.0/Frameworks/Python.framework/Versions/3.11/bin/python3.11`... These are both hardlinks to the same inode. Not reproducing on linux.
* ~Additional test coverage for this feature~ added to existing `test_local_subprocess_tty`
* ~Testing on other platforms:~
  * [x] windows
  * [x] linux
  * [x] pypy