### PR TITLE
tox3: Support provision of tox 4 with the min_version option

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,7 @@
 name: check
 on:
   push:
-    branches: [master, 'test-me-*']
+    branches: [legacy, 'test-me-*']
     tags:
   pull_request:
   schedule:

--- a/docs/changelog/2661.feature.rst
+++ b/docs/changelog/2661.feature.rst
@@ -1,0 +1,1 @@
+Support provision of tox 4 with the ``min_version`` option - by :user:`hroncok`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -43,6 +43,12 @@ Global settings are defined under the ``tox`` section as:
    When tox is invoked with the ``--no-provision`` flag,
    the provision won't be attempted, tox will fail instead.
 
+   .. versionchanged:: 3.27.2
+
+    ``min_version`` has the same meaning and usage as ``minversion``
+    to support a best effort provision of tox 4.
+
+
 .. conf:: requires ^ LIST of PEP-508
 
     .. versionadded:: 3.2.0

--- a/src/tox/config/__init__.py
+++ b/src/tox/config/__init__.py
@@ -1344,6 +1344,10 @@ class ParseIni(object):
     def handle_provision(self, config, reader):
         config.requires = reader.getlist("requires")
         config.minversion = reader.getstring("minversion", None)
+        # tox 4 prefers the min_version name of this option.
+        # We check is as well in case the config is intended for tox 4.
+        # This allows to make a *best effort* attempt to provision tox 4 from tox 3.
+        config.minversion = config.minversion or reader.getstring("min_version", None)
         config.provision_tox_env = name = reader.getstring("provision_tox_env", ".tox")
         min_version = "tox >= {}".format(config.minversion or Version(tox.__version__).public)
         deps = self.ensure_requires_satisfied(config, config.requires, min_version)

--- a/tests/unit/session/test_parallel.py
+++ b/tests/unit/session/test_parallel.py
@@ -272,8 +272,7 @@ def test_parallel_result_json_concurrent(cmd, parallel_project, tmp_path):
             # needs to be process to have it's own stdout
             invoke_result[thread_name] = subprocess.check_output(
                 [sys.executable, "-m", "tox", "-p", "all", "--result-json", str(result_json)],
-                universal_newlines=True,
-            )
+            ).decode("utf-8")
         except subprocess.CalledProcessError as exception:
             invoke_result[thread_name] = exception
 

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ commands =
 
 [testenv:coverage]
 description = [run locally after tests]: combine coverage data and create report;
-    generates a diff coverage against origin/master (can be changed by setting DIFF_AGAINST env var)
+    generates a diff coverage against origin/legacy (can be changed by setting DIFF_AGAINST env var)
 passenv =
     {[testenv]passenv}
     DIFF_AGAINST
@@ -73,7 +73,7 @@ commands =
     coverage report -m
     coverage xml -o {toxworkdir}/coverage.xml
     coverage html -d {toxworkdir}/htmlcov
-    diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
+    diff-cover --compare-branch {env:DIFF_AGAINST:origin/legacy} {toxworkdir}/coverage.xml
 depends = py27, py35, py36, py37, py38, py39, py310, py311, pypy, pypy3
 
 [testenv:docs]


### PR DESCRIPTION
Fixes https://github.com/tox-dev/tox/issues/2661

# Thanks for contribution

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

