### PR TITLE
Backslash Escape Semantics

### DIFF
--- a/docs/changelog/2732.bugfix.rst
+++ b/docs/changelog/2732.bugfix.rst
@@ -1,0 +1,6 @@
+For value substitution, ``\\`` is now treated as an escape for literal backslash ``\``, which itself will not act as an
+escape for subsequent substitutions. Any substitution which yields a single backslash, will be treated as a literal
+backslash and also not act as an escape for subsequent substitutions.
+
+As a result of this change, ``{/}``, a substitution for ``os.sep``, yields ``\`` on windows and will now NOT act as an
+escape for subsequent substitutions. - by :user:`masenf`

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -26,6 +26,10 @@ ARGS_GROUP = re.compile(r"(?<!\\\\|:[A-Z]):")
 
 
 def replace(conf: Config, loader: IniLoader, value: str, args: ConfigLoadArgs) -> str:
+    value_parts = value.split("\\\\")  # double backslash is always an escape for backslash
+    if len(value_parts) > 1:
+        # recursively handle replacements for values between literal backslash
+        return "\\".join(replace(conf, loader, vp, args) for vp in value_parts)
     # perform all non-escaped replaces
     end = 0
     while True:

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -43,6 +43,9 @@ def replace(conf: Config, loader: IniLoader, value: str, args: ConfigLoadArgs) -
             # want to enforce escaping curly braces, e.g. it should work to write: env_list = {py39,py38}-{,dep}
             end = end + 1
             continue
+        elif replaced == "\\":
+            # a replaced backslash should NOT affect subsequent iterations, so recurse on left and right
+            return replaced.join(replace(conf, loader, vp, args) for vp in [value[:start], value[end + 1 :]])
         new_value = f"{value[:start]}{replaced}{value[end + 1:]}"
         end = 0  # if we performed a replacement start over
         if new_value == value:  # if we're not making progress stop (circular reference?)

--- a/tests/config/loader/ini/replace/test_replace_env_var.py
+++ b/tests/config/loader/ini/replace/test_replace_env_var.py
@@ -11,6 +11,27 @@ def test_replace_env_set(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> N
     assert result == "something good"
 
 
+def test_replace_env_set_double_bs(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """Double backslash should escape to single backslash and not affect surrounding replacements."""
+    monkeypatch.setenv("MAGIC", "something good")
+    result = replace_one(r"{env:MAGIC}\\{env:MAGIC}")
+    assert result == r"something good\something good"
+
+
+def test_replace_env_set_triple_bs(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """Triple backslash should escape to single backslash also escape subsequent replacement."""
+    monkeypatch.setenv("MAGIC", "something good")
+    result = replace_one(r"{env:MAGIC}\\\{env:MAGIC}")
+    assert result == r"something good\{env:MAGIC}"
+
+
+def test_replace_env_set_quad_bs(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """Quad backslash should escape to two backslashes and not affect surrounding replacements."""
+    monkeypatch.setenv("MAGIC", "something good")
+    result = replace_one(r"\\{env:MAGIC}\\\\{env:MAGIC}\\")
+    assert result == r"\something good\\something good" + "\\"
+
+
 def test_replace_env_missing(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
     """If we have a factor that is not specified within the core env-list then that's also an environment"""
     monkeypatch.delenv("MAGIC", raising=False)

--- a/tests/config/loader/ini/replace/test_replace_env_var.py
+++ b/tests/config/loader/ini/replace/test_replace_env_var.py
@@ -32,6 +32,22 @@ def test_replace_env_set_quad_bs(replace_one: ReplaceOne, monkeypatch: MonkeyPat
     assert result == r"\something good\\something good" + "\\"
 
 
+def test_replace_env_when_value_is_backslash(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """When the replacement value is backslash, it shouldn't affect the next replacement."""
+    monkeypatch.setenv("MAGIC", "tragic")
+    monkeypatch.setenv("BS", "\\")
+    result = replace_one(r"{env:BS}{env:MAGIC}")
+    assert result == r"\tragic"
+
+
+def test_replace_env_when_value_is_stuff_then_backslash(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """When the replacement value is a string containing backslash, it can affect the next replacement."""
+    monkeypatch.setenv("MAGIC", "tragic")
+    monkeypatch.setenv("BS", "stuff\\")
+    result = replace_one(r"{env:BS}{env:MAGIC}")
+    assert result == r"stuff{env:MAGIC}"
+
+
 def test_replace_env_missing(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
     """If we have a factor that is not specified within the core env-list then that's also an environment"""
     monkeypatch.delenv("MAGIC", raising=False)

--- a/tests/config/loader/ini/replace/test_replace_os_sep.py
+++ b/tests/config/loader/ini/replace/test_replace_os_sep.py
@@ -2,9 +2,20 @@ from __future__ import annotations
 
 import os
 
+import pytest
+
 from tests.config.loader.ini.replace.conftest import ReplaceOne
 
 
 def test_replace_os_sep(replace_one: ReplaceOne) -> None:
     result = replace_one("{/}")
     assert result == os.sep
+
+
+@pytest.mark.parametrize("sep", ["/", "\\"])
+def test_replace_os_sep_before_curly(monkeypatch, replace_one: ReplaceOne, sep: str) -> None:
+    """Explicit test case for issue #2732 (windows only)."""
+    monkeypatch.setattr(os, "sep", sep)
+    monkeypatch.delenv("_", raising=False)
+    result = replace_one("{/}{env:_:foo}")
+    assert result == os.sep + "foo"


### PR DESCRIPTION
# Semantics

As written in this patch, the following rules now apply for escaping the literal backslash

1. `\\` will be treated as an escape sequence for a literal backslash `\`. In a value, two backslashes will _never_ result in escaping some other special character to the right.
2. If the value of a replacement is a single backslash `\`, then it is treated as a literal and will _never_ result in escaping some other special character to the right.
3. If the value of a replacement contains a backslash and other characters, then it is NOT treated as a literal backslash and may still affect adjacent characters. This is to allow recursive env expansion to expand to values with escaped specials. (i.e. `{env:FOO}` where `FOO="fun with \\{env:BAR}"` to avoid expanding `{env:BAR}` after the sub). However, this also opens the door to the shenanigans seen in #2732 where `FOO="bad idea\\"` and the value is something like `{env:FOO}{env:BAR}`... in this case, the trailing backslash from `$FOO` ends up escaping the next substitution. I couldn't really think of a nice way to handle this while remaining general and not over complicating the code. I don't think it will come up often.

Fixes #2732 

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation