### PR TITLE
test_result_json_sequential: use PythonInfo.current

### DIFF
--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -68,7 +68,7 @@ def test_result_json_sequential(
     with log.open("rt") as file_handler:
         log_report = json.load(file_handler)
 
-    py_info = PythonInfo.current_system()
+    py_info = PythonInfo.current()
     host_python = {
         "executable": py_info.system_executable,
         "extra_version_info": None,


### PR DESCRIPTION
fixes test issue #2720 when using macOS homebrew installed python versions.

Getting `PythonInfo.current()` sets the returned `py_info.system_executable` to the real, resolved interpreter path that also gets returned by tox's `--result-json`, which deep in the internals, [calls `resolve()`](https://github.com/tox-dev/tox/blob/b365892901f81cf7a831d5e41dca7f7f43c4c107/src/tox/tox_env/python/virtual_env/api.py#L143) on the interpreter path.

In my experiments, the problem can also be resolved (without this patch) by NOT calling `resolve()` down in `tox_env.python.virtuale_env.api`, but that seems like a heavier fix than changing how an asserted value is constructed inside test code.

That said, I have NO IDEA what the difference really is between `PythonInfo.current` and `PythonInfo.current_system` other than the latter triggers a call to [`_resolve_to_system`](https://github.com/pypa/virtualenv/blob/6845f6f2660fc786c92a01e077b4ae07a87d5a6b/src/virtualenv/discovery/py_info.py#L407-L428); if you could enlighten me on why this change may be a bad idea, I'd be happy to correct my mental model.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
