### PR TITLE
test_sequential: resolve() the system_executable

### DIFF
--- a/docs/changelog/2720.bugfix.rst
+++ b/docs/changelog/2720.bugfix.rst
@@ -1,0 +1,2 @@
+Fix assertion in ``test_result_json_sequential`` when interpreter
+``_base_executable`` is a hardlink (macOS homebrew) - by user:`masenf`

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -70,7 +70,7 @@ def test_result_json_sequential(
 
     py_info = PythonInfo.current_system()
     host_python = {
-        "executable": py_info.system_executable,
+        "executable": str(Path(py_info.system_executable).resolve()),
         "extra_version_info": None,
         "implementation": py_info.implementation,
         "is_64": py_info.architecture == 64,


### PR DESCRIPTION
When the _base_executable is a hardlink (macOS homebrew), then the virtualenv `PythonInfo.current_system()` call might not return the same path as tox's PythonInfo.interpreter, even though they would be pointing to the same file.

fix issue #2720

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
