### PR TITLE
Skip factors that don't start with an alphabetic character

### DIFF
--- a/docs/changelog/2657.bugfix.rst
+++ b/docs/changelog/2657.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a numeric factor in an environment name can wrongly cause a "conflicting factors" error - by :user:`nsoranzo`.

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -128,6 +128,9 @@ class Python(ToxEnv, ABC):
     def extract_base_python(env_name: str) -> str | None:
         candidates: list[str] = []
         for factor in env_name.split("-"):
+            if not factor[0].isalpha():
+                # This may be considered a valid spec by virtualenv, but not in tox
+                continue
             spec = PythonSpec.from_string_spec(factor)
             impl = spec.implementation or "python"
             if impl.lower() in INTERPRETER_SHORT_NAMES and env_name is not None and spec.path is None:

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -35,6 +35,8 @@ def test_conflicting_base_python_factor() -> None:
     name = f"py{major}{minor}-py{major}{minor-1}"
     with pytest.raises(ValueError, match=f"conflicting factors py{major}{minor}, py{major}{minor-1} in {name}"):
         Python.extract_base_python(name)
+    name = f"py{major}{minor}-1234"
+    Python.extract_base_python(name)
 
 
 def test_build_wheel_in_non_base_pkg_env(


### PR DESCRIPTION
A numeric factor in an environment name can wrongly cause a "conflicting factors" error.
Fix https://github.com/tox-dev/tox/issues/2657 .

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
