### PR TITLE
Restore pip freeze after pip install

### DIFF
--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -163,6 +163,12 @@ def env_run_create_flags(parser: ArgumentParser, mode: str) -> None:
             help="skip package installation for this run",
             action="store_true",
         )
+    parser.add_argument(
+        "--display-dependencies",
+        dest="display_dependencies",
+        help="display the list of the packages installed in the virtual environment",
+        action="store_true",
+    )
 
 
 def report(start: float, runs: list[ToxEnvRunResult], is_colored: bool) -> int:

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Sequence
 
 from packaging.requirements import Requirement
 
-from tox.config.cli.parser import DEFAULT_VERBOSITY
 from tox.config.main import Config
 from tox.config.types import Command
 from tox.execute.request import StdinSource
@@ -74,7 +73,6 @@ class Pip(Installer[Python]):
             stdin=StdinSource.OFF,
             run_id="freeze",
             show=True,
-            # show=self._env.options.verbosity > DEFAULT_VERBOSITY,
         )
         result.assert_success()
         return result.out.splitlines()

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -73,7 +73,8 @@ class Pip(Installer[Python]):
             cmd=cmd.args,
             stdin=StdinSource.OFF,
             run_id="freeze",
-            show=self._env.options.verbosity > DEFAULT_VERBOSITY,
+            show=True,
+            # show=self._env.options.verbosity > DEFAULT_VERBOSITY,
         )
         result.assert_success()
         return result.out.splitlines()

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -143,6 +143,9 @@ class RunToxEnv(ToxEnv, ABC):
             else:
                 self._setup_pkg()
 
+    def _done_with_setup(self) -> None:
+        self.installer.installed()
+
     def _register_package_conf(self) -> bool:
         """If this returns True package_env and package_tox_env_type configurations must be defined"""
         self.core.add_config(

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -144,7 +144,8 @@ class RunToxEnv(ToxEnv, ABC):
                 self._setup_pkg()
 
     def _done_with_setup(self) -> None:
-        self.installer.installed()
+        if self.options.display_dependencies:
+            self.installer.installed()
 
     def _register_package_conf(self) -> bool:
         """If this returns True package_env and package_tox_env_type configurations must be defined"""


### PR DESCRIPTION
Fixes #2685 

This is just an attempt to restore a very useful old behavior: printing the actual versions of the dependencies installed in the virtual environment. If this is the proper way to fix it, I will add tests, docs, etc.
WDYT @gaborbernat (or anyone else :smile: )?

# Notes

* The `installed` method uses the `self._env.execute` which make it difficult to format the output, so it displays a list like:
```
a==1.2.3
b==2.3.4
c==3.4.5
```
instead of the former one-line format:
```
a==1.2.3,b==2.3.4,c==3.4.5
```
* For now I set `show=True` but maybe we want it to be customizable by the user.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
