### PR TITLE
Override toxworkdir with --workdir.

### DIFF
--- a/docs/changelog/2654.bugfix.rst
+++ b/docs/changelog/2654.bugfix.rst
@@ -1,0 +1,1 @@
+Override toxworkdir with --workdir.

--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -192,7 +192,7 @@ class CoreConfigSet(ConfigSet):
             return (conf.work_dir if conf.work_dir is not None else cast(Path, self["tox_root"])) / ".tox"
 
         def work_dir_post_process(value: Path) -> Path:
-            return self._conf.work_dir if self._conf.work_dir is not None and self._conf.options.work_dir else value
+            return self._conf.work_dir if self._conf.work_dir and self._conf.options.work_dir else value
 
         self.add_config(
             keys=["work_dir", "toxworkdir"],

--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -191,10 +191,14 @@ class CoreConfigSet(ConfigSet):
         def work_dir_builder(conf: Config, env_name: str | None) -> Path:  # noqa: U100
             return (conf.work_dir if conf.work_dir is not None else cast(Path, self["tox_root"])) / ".tox"
 
+        def work_dir_post_process(value: Path) -> Path:
+            return self._conf.work_dir / ".tox" if self._conf.work_dir is not None else value
+
         self.add_config(
             keys=["work_dir", "toxworkdir"],
             of_type=Path,
             default=work_dir_builder,
+            post_process=work_dir_post_process,
             desc="working directory",
         )
         self.add_config(

--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -192,7 +192,7 @@ class CoreConfigSet(ConfigSet):
             return (conf.work_dir if conf.work_dir is not None else cast(Path, self["tox_root"])) / ".tox"
 
         def work_dir_post_process(value: Path) -> Path:
-            return self._conf.work_dir / ".tox" if self._conf.work_dir is not None else value
+            return self._conf.work_dir if self._conf.work_dir is not None and self._conf.options.work_dir else value
 
         self.add_config(
             keys=["work_dir", "toxworkdir"],

--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -192,7 +192,7 @@ class CoreConfigSet(ConfigSet):
             return (conf.work_dir if conf.work_dir is not None else cast(Path, self["tox_root"])) / ".tox"
 
         def work_dir_post_process(value: Path) -> Path:
-            return self._conf.work_dir if self._conf.work_dir and self._conf.options.work_dir else value
+            return self._conf.work_dir if self._conf.options.work_dir else value
 
         self.add_config(
             keys=["work_dir", "toxworkdir"],

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -176,6 +176,6 @@ def test_set_env_raises_on_non_str(mocker: MockerFixture) -> None:
 @pytest.mark.parametrize("work_dir", ["a", ""])
 def test_config_work_dir(tox_project: ToxProjectCreator, work_dir) -> None:
     project = tox_project({"tox.ini": "[tox]\ntoxworkdir=b"})
-    result = project.run("c", "-k", "toxworkdir", "--core", *(["--workdir", work_dir] if work_dir else []))
+    result = project.run("c", *(["--workdir", work_dir] if work_dir else []))
     expected = Path(project.path, work_dir) if work_dir else result.state.conf.core["toxworkdir"]
     assert expected == result.state.conf.core["toxworkdir"]

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -177,5 +177,5 @@ def test_set_env_raises_on_non_str(mocker: MockerFixture) -> None:
 def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: Path | None) -> None:
     project = tox_project({"tox.ini": "[tox]\ntoxworkdir=b"})
     result = project.run("c", *(["--workdir", str(work_dir)] if work_dir else []))
-    expected = Path(project.path, work_dir) if work_dir else Path("b")
+    expected = project.path / work_dir if work_dir else Path("b")
     assert expected == result.state.conf.core["work_dir"]

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections import OrderedDict
 from pathlib import Path
 from typing import Callable, Dict, Optional, Set, TypeVar
@@ -171,3 +172,10 @@ def test_set_env_raises_on_non_str(mocker: MockerFixture) -> None:
     env_set.loaders.insert(0, MemoryLoader(set_env=1))
     with pytest.raises(TypeError, match="1"):
         assert env_set["set_env"]
+
+
+def test_config_work_dir(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": "[tox]\ntoxworkdir=/tmp/foo"})
+    work_dir_flag = "/tmp/bar"
+    result = project.run("c", "-k", "toxworkdir", "--core", "--workdir", work_dir_flag)
+    assert f"work_dir = {os.path.join(work_dir_flag,'.tox')}{os.linesep}" in result.out

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -173,9 +173,9 @@ def test_set_env_raises_on_non_str(mocker: MockerFixture) -> None:
         assert env_set["set_env"]
 
 
-@pytest.mark.parametrize("work_dir", ["a", ""])
-def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: str) -> None:
+@pytest.mark.parametrize("work_dir", [Path("a"), None])
+def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: Path | None) -> None:
     project = tox_project({"tox.ini": "[tox]\ntoxworkdir=b"})
-    result = project.run("c", *(["--workdir", work_dir] if work_dir else []))
+    result = project.run("c", *(["--workdir", str(work_dir)] if work_dir else []))
     expected = Path(project.path, work_dir) if work_dir else Path("b")
     assert expected == result.state.conf.core["work_dir"]

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -178,4 +178,4 @@ def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: str) -> None:
     project = tox_project({"tox.ini": "[tox]\ntoxworkdir=b"})
     result = project.run("c", *(["--workdir", work_dir] if work_dir else []))
     expected = Path(project.path, work_dir) if work_dir else Path("b")
-    assert expected == result.state.conf.core["toxworkdir"]
+    assert expected == result.state.conf.core["work_dir"]

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -177,5 +177,5 @@ def test_set_env_raises_on_non_str(mocker: MockerFixture) -> None:
 def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: str) -> None:
     project = tox_project({"tox.ini": "[tox]\ntoxworkdir=b"})
     result = project.run("c", *(["--workdir", work_dir] if work_dir else []))
-    expected = Path(project.path, work_dir) if work_dir else result.state.conf.core["toxworkdir"]
+    expected = Path(project.path, work_dir) if work_dir else Path("b")
     assert expected == result.state.conf.core["toxworkdir"]

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -174,7 +174,7 @@ def test_set_env_raises_on_non_str(mocker: MockerFixture) -> None:
 
 
 @pytest.mark.parametrize("work_dir", ["a", ""])
-def test_config_work_dir(tox_project: ToxProjectCreator, work_dir) -> None:
+def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: str) -> None:
     project = tox_project({"tox.ini": "[tox]\ntoxworkdir=b"})
     result = project.run("c", *(["--workdir", work_dir] if work_dir else []))
     expected = Path(project.path, work_dir) if work_dir else result.state.conf.core["toxworkdir"]

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -176,6 +176,6 @@ def test_set_env_raises_on_non_str(mocker: MockerFixture) -> None:
 
 def test_config_work_dir(tox_project: ToxProjectCreator) -> None:
     project = tox_project({"tox.ini": "[tox]\ntoxworkdir=/tmp/foo"})
-    work_dir_flag = "/tmp/bar"
+    work_dir_flag = "a"
     result = project.run("c", "-k", "toxworkdir", "--core", "--workdir", work_dir_flag)
-    assert f"work_dir = {os.path.join(work_dir_flag,'.tox')}{os.linesep}" in result.out
+    assert f"work_dir = {os.path.join(project.path, work_dir_flag,'.tox')}{os.linesep}" in result.out

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -173,9 +173,9 @@ def test_set_env_raises_on_non_str(mocker: MockerFixture) -> None:
         assert env_set["set_env"]
 
 
-@pytest.mark.parametrize("work_dir", [Path("a"), None])
-def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: Path | None) -> None:
+@pytest.mark.parametrize("work_dir", ["a", ""])
+def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: str) -> None:
     project = tox_project({"tox.ini": "[tox]\ntoxworkdir=b"})
-    result = project.run("c", *(["--workdir", str(work_dir)] if work_dir else []))
+    result = project.run("c", *(["--workdir", str(project.path / work_dir)] if work_dir else []))
     expected = project.path / work_dir if work_dir else Path("b")
     assert expected == result.state.conf.core["work_dir"]

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from collections import OrderedDict
 from pathlib import Path
 from typing import Callable, Dict, Optional, Set, TypeVar
@@ -174,8 +173,9 @@ def test_set_env_raises_on_non_str(mocker: MockerFixture) -> None:
         assert env_set["set_env"]
 
 
-def test_config_work_dir(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({"tox.ini": "[tox]\ntoxworkdir=/tmp/foo"})
-    work_dir_flag = "a"
-    result = project.run("c", "-k", "toxworkdir", "--core", "--workdir", work_dir_flag)
-    assert f"work_dir = {os.path.join(project.path, work_dir_flag,'.tox')}{os.linesep}" in result.out
+@pytest.mark.parametrize("work_dir", ["a", ""])
+def test_config_work_dir(tox_project: ToxProjectCreator, work_dir) -> None:
+    project = tox_project({"tox.ini": "[tox]\ntoxworkdir=b"})
+    result = project.run("c", "-k", "toxworkdir", "--core", *(["--workdir", work_dir] if work_dir else []))
+    expected = Path(project.path, work_dir) if work_dir else result.state.conf.core["toxworkdir"]
+    assert expected == result.state.conf.core["toxworkdir"]


### PR DESCRIPTION
# Thanks for contribution
Closes #2654 
Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
