### PR TITLE
Fix pointer to legacy changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -735,4 +735,4 @@ v4.0.0a1
    The current tox is the second iteration of implementation. From version ``0.5`` all the way to ``3.X``
    we numbered the first iteration. Version ``4.0.0a1`` is a complete rewrite of the package, and as such this release
    history starts from there. The old changelog is still available in the
-   `legacy branch documentation <https://tox.wiki/en/stable/changelog.html>`_.
+   `legacy branch documentation <https://tox.wiki/en/legacy/changelog.html>`_.


### PR DESCRIPTION
Now that 4.x is `stable`, the link started pointing to the same page.