### PR TITLE
docs(config): Fix minor typo

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -617,7 +617,7 @@ Python run
 External package builder
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-tox supports operating with externally built packages. External packages might be provided in two wayas:
+tox supports operating with externally built packages. External packages might be provided in two ways:
 
 - explicitly via the :ref:`--installpkg <tox-run---installpkg>` CLI argument,
 - setting the :ref:`package` to ``external`` and using a tox packaging environment named ``<package_env>_external``


### PR DESCRIPTION
Fix a minor typo in the docs.

> Please, make sure you address all the checklists

I did not, I did this quickly through the GitHub web UI.  Feel free to reject this PR if that's insufficient.