### PR TITLE
Improved factor selection to allow multiple uses of `-f` for "OR" and to allow hyphenated factors

### DIFF
--- a/docs/changelog/2766.feature.rst
+++ b/docs/changelog/2766.feature.rst
@@ -1,2 +1,1 @@
-* Allow ``-f`` to be used multiple times and to be used on hyphenated factors
-  (e.g. ``-f py311-django -f py39``)
+``-f`` can be used multiple times and on hyphenated factors (e.g. ``-f py311-django -f py39``) - by :user:`sirosen`.

--- a/docs/changelog/2766.feature.rst
+++ b/docs/changelog/2766.feature.rst
@@ -1,0 +1,2 @@
+* Allow ``-f`` to be used multiple times and to be used on hyphenated factors
+  (e.g. ``-f py311-django -f py39``)

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -299,12 +299,12 @@ class EnvSelector:
         self._manager.tox_add_env_config(pkg_conf, self._state)
         return pkg_env
 
-    def _parse_factors(self) -> list[set[str]]:
+    def _parse_factors(self) -> tuple[set[str], ...]:
         # factors is a list of lists, from the combination of nargs="+" and action="append"
         # also parse hyphenated factors into lists of factors
         # so that `-f foo-bar` and `-f foo bar` are treated equivalently
         raw_factors = getattr(self._state.conf.options, "factors", [])
-        return [{f for factor in factor_list for f in factor.split("-")} for factor_list in raw_factors]
+        return tuple({f for factor in factor_list for f in factor.split("-")} for factor_list in raw_factors)
 
     def _mark_active(self) -> None:
         labels = set(getattr(self._state.conf.options, "labels", []))
@@ -323,9 +323,12 @@ class EnvSelector:
                         env_info.is_active = True
             if factors:  # if matches mark it active
                 for name, env_info in self._defined_envs_.items():
+                    if env_info.is_active:
+                        continue
                     for factor_set in factors:
                         if factor_set.issubset(set(name.split("-"))):
                             env_info.is_active = True
+                            break
 
     def __getitem__(self, item: str) -> RunToxEnv | PackageToxEnv:
         """

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -95,7 +95,14 @@ def register_env_select_flags(
             "factors to evaluate (passing multiple factors means 'AND', passing this option multiple times means 'OR')"
         )
         add_to.add_argument(
-            "-f", dest="factors", metavar="factor", help=help_msg, default=[], type=str, nargs="+", action="append"
+            "-f",
+            dest="factors",
+            metavar="factor",
+            help=help_msg,
+            default=[],
+            type=str,
+            nargs="+",
+            action="append",
         )
     help_msg = "exclude all environments selected that match this regular expression"
     add_to.add_argument("--skip-env", dest="skip_env", metavar="re", help=help_msg, default="", type=str)
@@ -297,7 +304,7 @@ class EnvSelector:
         # also parse hyphenated factors into lists of factors
         # so that `-f foo-bar` and `-f foo bar` are treated equivalently
         raw_factors = getattr(self._state.conf.options, "factors", [])
-        return [set(f for factor in factor_list for f in factor.split("-")) for factor_list in raw_factors]
+        return [{f for factor in factor_list for f in factor.split("-")} for factor_list in raw_factors]
 
     def _mark_active(self) -> None:
         labels = set(getattr(self._state.conf.options, "labels", []))

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -323,8 +323,6 @@ class EnvSelector:
                         env_info.is_active = True
             if factors:  # if matches mark it active
                 for name, env_info in self._defined_envs_.items():
-                    if env_info.is_active:
-                        continue
                     for factor_set in factors:
                         if factor_set.issubset(set(name.split("-"))):
                             env_info.is_active = True

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -80,7 +80,7 @@ def test_label_core_and_trait(tox_project: ToxProjectCreator) -> None:
         ),
     ],
 )
-def test_factor_select(tox_project: ToxProjectCreator, selection_arguments, expect_envs) -> None:
+def test_factor_select(tox_project: ToxProjectCreator, selection_arguments: list[str], expect_envs: list[str]) -> None:
     ini = """
         [tox]
         env_list = py3{10,9}-{django20,django21}{-cov,}

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -67,20 +67,24 @@ def test_label_core_and_trait(tox_project: ToxProjectCreator) -> None:
     ("selection_arguments", "expect_envs"),
     [
         (
-            ["-f", "cov", "django20"],
-            ["py310-django20-cov", "py39-django20-cov"],
+            ("-f", "cov", "django20"),
+            ("py310-django20-cov", "py39-django20-cov"),
         ),
         (
-            ["-f", "cov-django20"],
-            ["py310-django20-cov", "py39-django20-cov"],
+            ("-f", "cov-django20"),
+            ("py310-django20-cov", "py39-django20-cov"),
         ),
         (
-            ["-f", "py39", "django20", "-f", "py310", "django21"],
-            ["py310-django21-cov", "py310-django21", "py39-django20-cov", "py39-django20"],
+            ("-f", "py39", "django20", "-f", "py310", "django21"),
+            ("py310-django21-cov", "py310-django21", "py39-django20-cov", "py39-django20"),
         ),
     ],
 )
-def test_factor_select(tox_project: ToxProjectCreator, selection_arguments: list[str], expect_envs: list[str]) -> None:
+def test_factor_select(
+    tox_project: ToxProjectCreator,
+    selection_arguments: tuple[str, ...],
+    expect_envs: tuple[str, ...],
+) -> None:
     ini = """
         [tox]
         env_list = py3{10,9}-{django20,django21}{-cov,}
@@ -88,7 +92,7 @@ def test_factor_select(tox_project: ToxProjectCreator, selection_arguments: list
     project = tox_project({"tox.ini": ini})
     outcome = project.run("l", "--no-desc", *selection_arguments)
     outcome.assert_success()
-    outcome.assert_out_err("\n".join(expect_envs) + "\n", "")
+    outcome.assert_out_err("{}\n".format("\n".join(expect_envs)), "")
 
 
 def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from tox.pytest import MonkeyPatch, ToxProjectCreator
 
 
@@ -61,37 +63,32 @@ def test_label_core_and_trait(tox_project: ToxProjectCreator) -> None:
     outcome.assert_out_err("py310\npy39\nflake8\ntype\n", "")
 
 
-def test_factor_select(tox_project: ToxProjectCreator) -> None:
+@pytest.mark.parametrize(
+    ("selection_arguments", "expect_envs"),
+    [
+        (
+            ["-f", "cov", "django20"],
+            ["py310-django20-cov", "py39-django20-cov"],
+        ),
+        (
+            ["-f", "cov-django20"],
+            ["py310-django20-cov", "py39-django20-cov"],
+        ),
+        (
+            ["-f", "py39", "django20", "-f", "py310", "django21"],
+            ["py310-django21-cov", "py310-django21", "py39-django20-cov", "py39-django20"],
+        ),
+    ],
+)
+def test_factor_select(tox_project: ToxProjectCreator, selection_arguments, expect_envs) -> None:
     ini = """
         [tox]
         env_list = py3{10,9}-{django20,django21}{-cov,}
         """
     project = tox_project({"tox.ini": ini})
-    outcome = project.run("l", "--no-desc", "-f", "cov", "django20")
+    outcome = project.run("l", "--no-desc", *selection_arguments)
     outcome.assert_success()
-    outcome.assert_out_err("py310-django20-cov\npy39-django20-cov\n", "")
-
-
-def test_factor_select_containing_hyphenate(tox_project: ToxProjectCreator) -> None:
-    ini = """
-        [tox]
-        env_list = py3{10,9}-{django20,django21}{-cov,}
-        """
-    project = tox_project({"tox.ini": ini})
-    outcome = project.run("l", "--no-desc", "-f", "cov-django20")
-    outcome.assert_success()
-    outcome.assert_out_err("py310-django20-cov\npy39-django20-cov\n", "")
-
-
-def test_factor_select_multiple_factors(tox_project: ToxProjectCreator) -> None:
-    ini = """
-        [tox]
-        env_list = py3{10,9}-{django20,django21}{-cov,}
-        """
-    project = tox_project({"tox.ini": ini})
-    outcome = project.run("l", "--no-desc", "-f", "py39", "django20", "-f", "py310", "django21")
-    outcome.assert_success()
-    outcome.assert_out_err("py310-django21-cov\npy310-django21\npy39-django20-cov\npy39-django20\n", "")
+    outcome.assert_out_err("\n".join(expect_envs) + "\n", "")
 
 
 def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -72,6 +72,17 @@ def test_factor_select(tox_project: ToxProjectCreator) -> None:
     outcome.assert_out_err("py310-django20-cov\npy39-django20-cov\n", "")
 
 
+def test_factor_select_multiple_factors(tox_project: ToxProjectCreator) -> None:
+    ini = """
+        [tox]
+        env_list = py3{10,9}-{django20,django21}{-cov,}
+        """
+    project = tox_project({"tox.ini": ini})
+    outcome = project.run("l", "--no-desc", "-f", "py39", "django20", "-f", "py310", "django21")
+    outcome.assert_success()
+    outcome.assert_out_err("py310-django21-cov\npy310-django21\npy39-django20-cov\npy39-django20\n", "")
+
+
 def test_tox_skip_env(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("TOX_SKIP_ENV", "m[y]py")
     project = tox_project({"tox.ini": "[tox]\nenv_list = py3{10,9},mypy"})

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -72,6 +72,17 @@ def test_factor_select(tox_project: ToxProjectCreator) -> None:
     outcome.assert_out_err("py310-django20-cov\npy39-django20-cov\n", "")
 
 
+def test_factor_select_containing_hyphenate(tox_project: ToxProjectCreator) -> None:
+    ini = """
+        [tox]
+        env_list = py3{10,9}-{django20,django21}{-cov,}
+        """
+    project = tox_project({"tox.ini": ini})
+    outcome = project.run("l", "--no-desc", "-f", "cov-django20")
+    outcome.assert_success()
+    outcome.assert_out_err("py310-django20-cov\npy39-django20-cov\n", "")
+
+
 def test_factor_select_multiple_factors(tox_project: ToxProjectCreator) -> None:
     ini = """
         [tox]


### PR DESCRIPTION
### Summary

To enable better factor selection, this PR applies two changes. (resolves #2766)

1. `-f` can now be passed multiple times. Envs matching any `-f` usage are selected (OR) on top of the existing behavior that envs must match all factors in a given usage (AND).

2. `-f` will now split factors with hyphens.

(1) is the key functional change. (2) is not strictly necessary, but makes usage conform a little better to user expectations (or at least the expectations of one user! 👋 😉 ).

### Example Usage

Consider an env list as follows:
```
envlist = py3{10,9}-django2{0,1}{,-cov}
```

Prior to this change, the following usage was valid: `tox l -f py39 django20` and would select `py39-django20 py39-django20-cov`.
After this change, the same selection can be expressed with `tox l -f py39-django20`. Furthermore, the following selection which was previously *not* possible can be expressed:

```
$ tox l -f py39-django20 -f django21-cov
py310-django21-cov
py39-django20
py39-django20-cov
py39-django21-cov
```

The groups of selections are combined with OR semantics, but the individual selections are combined with AND.

### Implementation Notes

I separated these two features into two commits, anticipating that (2) might be contentious. I would like to keep it as I don't think it adds much complexity, but I'm ready and willing to pull it out if necessary.

The parsing/interpretation of factors is now separated out into a dedicated helper method, which I note most other CLI args do not have. It looks like the CLI code avoids breaking things apart into too many small functions, but I thought this case benefits enough in terms of readability to be worth it. Again, I'm happy to change this in response to feedback.

The help message is rather long for this now, and I'm still not sure it's fully descriptive. Perhaps a future FAQ on how to use factors and labels would help.

### Checklist

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation