### PR TITLE
Fix logging error with emoji in git branch name.

### DIFF
--- a/docs/changelog/2768.bugfix.rst
+++ b/docs/changelog/2768.bugfix.rst
@@ -1,0 +1,1 @@
+Fix logging error with emoji in git branch name.

--- a/src/tox/pytest.py
+++ b/src/tox/pytest.py
@@ -161,7 +161,7 @@ class ToxProject:
                 at_path.mkdir(exist_ok=True)
                 ToxProject._setup_files(at_path, None, value)
             elif isinstance(value, str):
-                at_path.write_text(textwrap.dedent(value))
+                at_path.write_text(textwrap.dedent(value), encoding="utf-8")
             elif value is None:
                 at_path.mkdir()
             else:

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -444,7 +444,7 @@ class ToxEnv(ABC):
 
     @staticmethod
     def _write_execute_log(env_name: str, log_file: Path, request: ExecuteRequest, status: ExecuteStatus) -> None:
-        with log_file.open("wt") as file:
+        with log_file.open("wt", encoding="utf-8") as file:
             file.write(f"name: {env_name}\n")
             file.write(f"run_id: {request.run_id}\n")
             for env_key, env_value in request.env.items():

--- a/tests/tox_env/test_tox_env_api.py
+++ b/tests/tox_env/test_tox_env_api.py
@@ -34,7 +34,8 @@ def test_allow_list_external_fail(tox_project: ToxProjectCreator, fake_exe_on_pa
 
 def test_env_log(tox_project: ToxProjectCreator) -> None:
     cmd = "commands=python -c 'import sys; print(1); print(2); print(3, file=sys.stderr); print(4, file=sys.stderr)'"
-    prj = tox_project({"tox.ini": f"[testenv]\npackage=skip\n{cmd}"})
+    env_vars = "    UNPREDICTABLE = 🪟"
+    prj = tox_project({"tox.ini": f"[testenv]\npackage=skip\nset_env =\n{env_vars}\n{cmd}"})
     result_first = prj.run("r")
     result_first.assert_success()
 


### PR DESCRIPTION
Fixes a bug on Windows where the logger fails when environment variables with unicode emoji are passed to tox using set_env or pass_env. Resolves #2768.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
