### PR TITLE
Fix extracting extras from markers with many extras

### DIFF
--- a/docs/changelog/2791.bugfix.rst
+++ b/docs/changelog/2791.bugfix.rst
@@ -1,0 +1,1 @@
+Fix extracting extras from markers with many extras - by :user:`q0w`.

--- a/src/tox/tox_env/python/virtual_env/package/util.py
+++ b/src/tox/tox_env/python/virtual_env/package/util.py
@@ -45,10 +45,9 @@ def extract_extra_markers(deps: list[Requirement]) -> list[tuple[Requirement, se
                 extra_markers.add(marker_value.value)
                 del markers[_at]
                 _at -= 1
-                if _at > 0 and (isinstance(markers[_at], str) and markers[_at] in ("and", "or")):
+                if _at >= 0 and (isinstance(markers[_at], str) and markers[_at] in ("and", "or")):
                     del markers[_at]
                 if len(markers) == 0:
                     req.marker = None
-                break
         result.append((req, extra_markers or {None}))
     return result

--- a/tests/tox_env/python/virtual_env/package/test_python_package_util.py
+++ b/tests/tox_env/python/virtual_env/package/test_python_package_util.py
@@ -51,6 +51,15 @@ def test_load_dependency_many_extra(pkg_with_extras: PathDistribution) -> None:
         assert str(left) == str(right)
 
 
+def test_load_dependency_poetry_many_extra() -> None:
+    requires = [Requirement('filelock<4.0.0,>=3.9.0; extra == "extras1" or extra == "extras2"')]
+    result = dependencies_with_extras(requires, {"extras1"}, "")
+    exp = [Requirement("filelock<4.0.0,>=3.9.0")]
+    for left, right in zip_longest(result, exp):
+        assert isinstance(right, Requirement)
+        assert str(left) == str(right)
+
+
 def test_loads_deps_recursive_extras() -> None:
     requires = [
         Requirement("no-extra"),

--- a/tests/tox_env/python/virtual_env/package/test_python_package_util.py
+++ b/tests/tox_env/python/virtual_env/package/test_python_package_util.py
@@ -51,15 +51,6 @@ def test_load_dependency_many_extra(pkg_with_extras: PathDistribution) -> None:
         assert str(left) == str(right)
 
 
-def test_load_dependency_poetry_many_extra() -> None:
-    requires = [Requirement('filelock<4.0.0,>=3.9.0; extra == "extras1" or extra == "extras2"')]
-    result = dependencies_with_extras(requires, {"extras1"}, "")
-    exp = [Requirement("filelock<4.0.0,>=3.9.0")]
-    for left, right in zip_longest(result, exp):
-        assert isinstance(right, Requirement)
-        assert str(left) == str(right)
-
-
 def test_loads_deps_recursive_extras() -> None:
     requires = [
         Requirement("no-extra"),
@@ -72,3 +63,9 @@ def test_loads_deps_recursive_extras() -> None:
     ]
     result = dependencies_with_extras(requires, {"dev"}, "name")
     assert [str(i) for i in result] == ["no-extra", "dep1[magic]", "dep1", "dep2[a,b]"]
+
+
+def test_load_dependency_requirement_or_extras() -> None:
+    requires = [Requirement('filelock<4.0.0,>=3.9.0; extra == "extras1" or extra == "extras2"')]
+    result = dependencies_with_extras(requires, {"extras1"}, "")
+    assert [str(r) for r in result] == ["filelock<4.0.0,>=3.9.0"]


### PR DESCRIPTION
# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
