### PR TITLE
Relax test_list_installed_deps() to allow other packages

### DIFF
--- a/docs/changelog/2796.misc.rst
+++ b/docs/changelog/2796.misc.rst
@@ -1,0 +1,3 @@
+Relax the assertion in ``test_list_installed_deps`` to allow packages
+other than ``pip`` to be present in the fresh venv, to fix tests
+on PyPy.

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -186,6 +186,6 @@ def test_list_installed_deps(in_ci: bool, tox_project: ToxProjectCreator, mocker
     mocker.patch("tox.tox_env.python.api.is_ci", return_value=in_ci)
     result = tox_project({"tox.ini": "[testenv]\nskip_install = true"}).run("r", "-e", "py")
     if in_ci:
-        assert "py: pip==" in result.out
+        assert "pip==" in result.out
     else:
-        assert "py: pip==" not in result.out
+        assert "pip==" not in result.out


### PR DESCRIPTION
Relax the check in `test_list_installed_deps()` to allow `pip freeze` to return other packages before `pip`.  This is necessary if the Python interpreter vendors some packages itself, so that they are available even in fresh venv.  This is the case e.g. for cffi in PyPy.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix (it's a fix for the tests, so… ;-))
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
