### PR TITLE
Skip time-machine dep and spinner tests on PyPy

### DIFF
--- a/docs/changelog/2797.misc.rst
+++ b/docs/changelog/2797.misc.rst
@@ -1,0 +1,2 @@
+Skip the ``time-machine`` dependency and spinner tests on PyPy because
+it segfaults on this implementation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ optional-dependencies.testing = [
   "pytest-mock>=3.10",
   "pytest-xdist>=3.1",
   "re-assert>=1.1",
-  "time-machine>=2.8.2",
+  "time-machine>=2.8.2; implementation_name != \"pypy\"",
 ]
 scripts.tox = "tox.run:run"
 dynamic = ["version"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,12 @@ else:  # pragma: no cover (<py38)
     from typing_extensions import Protocol
 
 
+collect_ignore = []
+if sys.implementation.name == "pypy":
+    # time-machine causes segfaults on PyPy
+    collect_ignore.append("util/test_spinner.py")
+
+
 class ToxIniCreator(Protocol):
     def __call__(self, conf: str, override: Sequence[Override] | None = None) -> Config:  # noqa: U100
         ...


### PR DESCRIPTION
The time-machine package is deeply relying on CPython implementation details and causes segfaults on PyPy.  Pull the dependency in only on implementations other than PyPy, and skip collecting the spinner tests on PyPy since they require it.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
