### PR TITLE
Provide an explanatory message when attempted command parsing produces an empty result

### DIFF
--- a/docs/changelog/2695.bugfix.rst
+++ b/docs/changelog/2695.bugfix.rst
@@ -1,1 +1,1 @@
-Fail more gracefully on empty pip :ref:`install_command` - by :user: `jayaddison`
+Fail more gracefully on empty pip :ref:`install_command` - by :user:`jayaddison`

--- a/docs/changelog/2695.bugfix.rst
+++ b/docs/changelog/2695.bugfix.rst
@@ -1,1 +1,1 @@
-Fail more gracefully on empty pip :ref:`install_command` - by :user:`jayaddison`
+Fail more gracefully when pip :ref:`install_command` is empty - by :user:`jayaddison`

--- a/docs/changelog/2695.bugfix.rst
+++ b/docs/changelog/2695.bugfix.rst
@@ -1,0 +1,1 @@
+Fail more gracefully on empty pip :ref:`install_command` - by :user: `jayaddison`

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -63,6 +63,11 @@ class StrConvert(Convert[str]):
                 pos = splitter.instream.tell()
         except ValueError:
             args.append(value[pos:])
+        if len(args) == 0:
+            raise TypeError(
+                f"Attempting to parse {value!r} into a command failed: no command was found. "
+                "Check your tox configuration for environments with missing command values."
+            )
         if args[0] != "-" and args[0].startswith("-"):
             args[0] = args[0][1:]
             args = ["-"] + args

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -64,7 +64,7 @@ class StrConvert(Convert[str]):
         except ValueError:
             args.append(value[pos:])
         if len(args) == 0:
-            raise TypeError(f"attempting to parse {value!r} into a command failed")
+            raise ValueError(f"attempting to parse {value!r} into a command failed")
         if args[0] != "-" and args[0].startswith("-"):
             args[0] = args[0][1:]
             args = ["-"] + args

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -64,10 +64,7 @@ class StrConvert(Convert[str]):
         except ValueError:
             args.append(value[pos:])
         if len(args) == 0:
-            raise TypeError(
-                f"Attempting to parse {value!r} into a command failed: no command was found. "
-                "Check your tox configuration for environments with missing command values."
-            )
+            raise TypeError(f"attempting to parse {value!r} into a command failed")
         if args[0] != "-" and args[0].startswith("-"):
             args[0] = args[0][1:]
             args = ["-"] + args

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -166,7 +166,10 @@ class Pip(Installer[Python]):
         outcome.assert_success()
 
     def build_install_cmd(self, args: Sequence[str]) -> list[str]:
-        cmd: Command = self._env.conf["install_command"]
+        try:
+            cmd: Command = self._env.conf["install_command"]
+        except ValueError as exc:
+            raise Fail(f"unable to determine pip install command: {str(exc)}") from exc
         install_command = cmd.args
         try:
             opts_at = install_command.index("{packages}")

--- a/tests/config/loader/test_str_convert.py
+++ b/tests/config/loader/test_str_convert.py
@@ -56,19 +56,13 @@ def test_str_convert_ok(raw: str, value: Any, of_type: type[Any]) -> None:
     assert result == value
 
 
-_EMPTY_COMMAND_MESSAGE = (
-    "Attempting to parse '{}' into a command failed: no command was found. "
-    "Check your tox configuration for environments with missing command values."
-)
-
-
 @pytest.mark.parametrize(
     ("raw", "of_type", "exc_type", "msg"),
     [
         ("a", TypeVar, TypeError, r"a cannot cast to .*typing.TypeVar.*"),
         ("3", Literal["1", "2"], ValueError, r"3 must be one of \('1', '2'\)"),
         ("3", Union[str, int], TypeError, r"3 cannot cast to typing.Union\[str, int\]"),
-        ("", Command, TypeError, _EMPTY_COMMAND_MESSAGE.format("")),
+        ("", Command, TypeError, r"attempting to parse '' into a command failed"),
     ],
 )
 def test_str_convert_nok(raw: str, of_type: type[Any], msg: str, exc_type: type[Exception]) -> None:

--- a/tests/config/loader/test_str_convert.py
+++ b/tests/config/loader/test_str_convert.py
@@ -62,7 +62,7 @@ def test_str_convert_ok(raw: str, value: Any, of_type: type[Any]) -> None:
         ("a", TypeVar, TypeError, r"a cannot cast to .*typing.TypeVar.*"),
         ("3", Literal["1", "2"], ValueError, r"3 must be one of \('1', '2'\)"),
         ("3", Union[str, int], TypeError, r"3 cannot cast to typing.Union\[str, int\]"),
-        ("", Command, TypeError, r"attempting to parse '' into a command failed"),
+        ("", Command, ValueError, r"attempting to parse '' into a command failed"),
     ],
 )
 def test_str_convert_nok(raw: str, of_type: type[Any], msg: str, exc_type: type[Exception]) -> None:

--- a/tests/config/loader/test_str_convert.py
+++ b/tests/config/loader/test_str_convert.py
@@ -56,12 +56,19 @@ def test_str_convert_ok(raw: str, value: Any, of_type: type[Any]) -> None:
     assert result == value
 
 
+_EMPTY_COMMAND_MESSAGE = (
+    "Attempting to parse '{}' into a command failed: no command was found. "
+    "Check your tox configuration for environments with missing command values."
+)
+
+
 @pytest.mark.parametrize(
     ("raw", "of_type", "exc_type", "msg"),
     [
         ("a", TypeVar, TypeError, r"a cannot cast to .*typing.TypeVar.*"),
         ("3", Literal["1", "2"], ValueError, r"3 must be one of \('1', '2'\)"),
         ("3", Union[str, int], TypeError, r"3 cannot cast to typing.Union\[str, int\]"),
+        ("", Command, TypeError, _EMPTY_COMMAND_MESSAGE.format("")),
     ],
 )
 def test_str_convert_nok(raw: str, of_type: type[Any], msg: str, exc_type: type[Exception]) -> None:

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -99,6 +99,21 @@ def test_show_config_exception(tox_project: ToxProjectCreator) -> None:
     assert txt in outcome.out
 
 
+def test_show_config_empty_install_command_exception(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.ini": """
+        [testenv:a]
+        install_command =
+        """,
+        },
+    )
+    outcome = project.run("c", "-e", "a", "-k", "install_command")
+    outcome.assert_success()
+    txt = "\ninstall_command = # Exception: " "ValueError(\"attempting to parse '' into a command failed\")"
+    assert txt in outcome.out
+
+
 @pytest.mark.parametrize("stdout_is_atty", [True, False])
 def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty: bool, mocker: MockerFixture) -> None:
     mocker.patch("sys.stdout.isatty", return_value=stdout_is_atty)

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -72,26 +72,28 @@ def test_show_config_unused(tox_project: ToxProjectCreator) -> None:
     assert "\n# !!! unused: magic, magical\n" in outcome.out
 
 
-@pytest.mark.parametrize("ini,key,expected_outcome", [
-    (
-        """
+@pytest.mark.parametrize(
+    "ini,key,expected_outcome",
+    [
+        (
+            """
         [testenv:a]
         base_python = missing-python
         """,
-        "env_site_packages_dir",
-        "\nenv_site_packages_dir = # Exception: "
-        "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'",
-    ),
-    (
-        """
+            "env_site_packages_dir",
+            "\nenv_site_packages_dir = # Exception: "
+            "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'",
+        ),
+        (
+            """
         [testenv:a]
         install_command =
         """,
-        "install_command",
-        "install_command = # Exception: "
-        "ValueError(\"attempting to parse \'\' into a command failed\")",
-    ),
-])
+            "install_command",
+            "install_command = # Exception: " "ValueError(\"attempting to parse '' into a command failed\")",
+        ),
+    ],
+)
 def test_show_config_exception(tox_project: ToxProjectCreator, ini, key, expected_outcome) -> None:
     project = tox_project({"tox.ini": dedent(ini)})
     outcome = project.run("c", "-e", "a", "-k", key)

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -99,7 +99,7 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
             install_command =
             """,
             "install_command",
-            "install_command = # Exception: " "ValueError(\"attempting to parse '' into a command failed\")",
+            "install_command = # Exception: ValueError(\"attempting to parse '' into a command failed\")",
         ),
     ],
 )

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -82,7 +82,7 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
 
 
 @pytest.mark.parametrize(
-    "ini,key,expected_outcome",
+    ("ini", "key", "expected_outcome"),
     [
         (
             """

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -82,7 +82,7 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
 
 
 @pytest.mark.parametrize(
-    ("ini", "key", "expected_outcome"),
+    "ini,key,expected_outcome",
     [
         (
             """

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -89,7 +89,7 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
         """,
         "env_site_packages_dir",
         "\nenv_site_packages_dir = # Exception: "
-        "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'",
+        "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'"
     ),
     (
         """

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -77,18 +77,18 @@ def test_show_config_unused(tox_project: ToxProjectCreator) -> None:
     [
         (
             """
-        [testenv:a]
-        base_python = missing-python
-        """,
+            [testenv:a]
+            base_python = missing-python
+            """,
             "env_site_packages_dir",
             "\nenv_site_packages_dir = # Exception: "
             "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'",
         ),
         (
             """
-        [testenv:a]
-        install_command =
-        """,
+            [testenv:a]
+            install_command =
+            """,
             "install_command",
             "install_command = # Exception: " "ValueError(\"attempting to parse '' into a command failed\")",
         ),

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -81,31 +81,22 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
     assert outcome.out == f"[testenv:py]\npy_dot_ver = {py_ver}\npy_impl = {impl}\ndeps = {impl}{py_ver}\n"
 
 
-@pytest.mark.parametrize("ini,key,expected_outcome", [
-    (
-        """
+def test_show_config_exception(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.ini": """
         [testenv:a]
         base_python = missing-python
         """,
-        "env_site_packages_dir",
+        },
+    )
+    outcome = project.run("c", "-e", "a", "-k", "env_site_packages_dir")
+    outcome.assert_success()
+    txt = (
         "\nenv_site_packages_dir = # Exception: "
         "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'"
-    ),
-    (
-        """
-        [testenv:a]
-        install_command =
-        """,
-        "install_command",
-        "install_command = # Exception: "
-        "ValueError(\"attempting to parse \'\' into a command failed\")",
-    ),
-])
-def test_show_config_exception(tox_project: ToxProjectCreator, ini, key, expected_outcome) -> None:
-    project = tox_project({"tox.ini": dedent(ini)})
-    outcome = project.run("c", "-e", "a", "-k", key)
-    outcome.assert_success()
-    assert expected_outcome in outcome.out
+    )
+    assert txt in outcome.out
 
 
 @pytest.mark.parametrize("stdout_is_atty", [True, False])

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -80,7 +80,7 @@ def test_show_config_unused(tox_project: ToxProjectCreator) -> None:
         """,
         "env_site_packages_dir",
         "\nenv_site_packages_dir = # Exception: "
-        "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'"
+        "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'",
     ),
     (
         """

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -99,7 +99,7 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
             install_command =
             """,
             "install_command",
-            "install_command = # Exception: ValueError(\"attempting to parse '' into a command failed\")",
+            "install_command = # Exception: " "ValueError(\"attempting to parse '' into a command failed\")",
         ),
     ],
 )

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -86,18 +86,18 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
     [
         (
             """
-            [testenv:a]
-            base_python = missing-python
-            """,
+        [testenv:a]
+        base_python = missing-python
+        """,
             "env_site_packages_dir",
             "\nenv_site_packages_dir = # Exception: "
             "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'",
         ),
         (
             """
-            [testenv:a]
-            install_command =
-            """,
+        [testenv:a]
+        install_command =
+        """,
             "install_command",
             "install_command = # Exception: " "ValueError(\"attempting to parse '' into a command failed\")",
         ),

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -103,7 +103,7 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
         ),
     ],
 )
-def test_show_config_exception(tox_project: ToxProjectCreator, ini: str, key: str, expected_outcome: str) -> None:
+def test_show_config_exception(tox_project: ToxProjectCreator, ini, key, expected_outcome) -> None:
     project = tox_project({"tox.ini": dedent(ini)})
     outcome = project.run("c", "-e", "a", "-k", key)
     outcome.assert_success()

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -81,28 +81,26 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
     assert outcome.out == f"[testenv:py]\npy_dot_ver = {py_ver}\npy_impl = {impl}\ndeps = {impl}{py_ver}\n"
 
 
-@pytest.mark.parametrize(
-    "ini,key,expected_outcome",
-    [
-        (
-            """
+@pytest.mark.parametrize("ini,key,expected_outcome", [
+    (
+        """
         [testenv:a]
         base_python = missing-python
         """,
-            "env_site_packages_dir",
-            "\nenv_site_packages_dir = # Exception: "
-            "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'",
-        ),
-        (
-            """
+        "env_site_packages_dir",
+        "\nenv_site_packages_dir = # Exception: "
+        "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'",
+    ),
+    (
+        """
         [testenv:a]
         install_command =
         """,
-            "install_command",
-            "install_command = # Exception: " "ValueError(\"attempting to parse '' into a command failed\")",
-        ),
-    ],
-)
+        "install_command",
+        "install_command = # Exception: "
+        "ValueError(\"attempting to parse \'\' into a command failed\")",
+    ),
+])
 def test_show_config_exception(tox_project: ToxProjectCreator, ini, key, expected_outcome) -> None:
     project = tox_project({"tox.ini": dedent(ini)})
     outcome = project.run("c", "-e", "a", "-k", key)

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -103,7 +103,7 @@ def test_show_config_py_ver_impl_constants(tox_project: ToxProjectCreator) -> No
         ),
     ],
 )
-def test_show_config_exception(tox_project: ToxProjectCreator, ini, key, expected_outcome) -> None:
+def test_show_config_exception(tox_project: ToxProjectCreator, ini: str, key: str, expected_outcome: str) -> None:
     project = tox_project({"tox.ini": dedent(ini)})
     outcome = project.run("c", "-e", "a", "-k", key)
     outcome.assert_success()

--- a/tests/tox_env/python/pip/test_pip_install.py
+++ b/tests/tox_env/python/pip/test_pip_install.py
@@ -9,6 +9,7 @@ import pytest
 from packaging.requirements import Requirement
 
 from tox.pytest import CaptureFixture, ToxProjectCreator
+from tox.tox_env.errors import Fail
 
 
 @pytest.mark.parametrize("arg", [object, [object]])
@@ -41,9 +42,9 @@ def test_pip_install_empty_command_error(tox_project: ToxProjectCreator) -> None
     result = proj.run("l")
     pip = result.state.envs["py"].installer
 
-    with pytest.raises(SystemExit, match="1"):
+    with pytest.raises(Fail) as raised:
         pip.install([Requirement("name")], "section", "type")
-    assert False
+    assert "unable to determine pip install command" in str(raised)
 
 
 def test_pip_install_flags_only_error(tox_project: ToxProjectCreator) -> None:

--- a/tests/tox_env/python/pip/test_pip_install.py
+++ b/tests/tox_env/python/pip/test_pip_install.py
@@ -259,3 +259,10 @@ def test_pip_install_constraint_file_new(tox_project: ToxProjectCreator) -> None
     assert "py: recreate env because changed constraint(s) added a" in result_second.out, result_second.out
     assert execute_calls.call_count == 1
     assert execute_calls.call_args[0][3].cmd == ["python", "-I", "-m", "pip", "install", "a", "-c", "c.txt"]
+
+
+def test_pip_install_empty_command_error(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({"tox.ini": "[testenv]\ninstall_command="})
+    result = proj.run("r")
+    result.assert_failed()
+    assert "unable to determine pip install command" in result.out

--- a/tests/tox_env/python/pip/test_pip_install.py
+++ b/tests/tox_env/python/pip/test_pip_install.py
@@ -42,9 +42,8 @@ def test_pip_install_empty_command_error(tox_project: ToxProjectCreator) -> None
     result = proj.run("l")
     pip = result.state.envs["py"].installer
 
-    with pytest.raises(Fail) as raised:
+    with pytest.raises(Fail, match="unable to determine pip install command") as raised:
         pip.install([Requirement("name")], "section", "type")
-    assert "unable to determine pip install command" in str(raised)
 
 
 def test_pip_install_flags_only_error(tox_project: ToxProjectCreator) -> None:

--- a/tests/tox_env/python/pip/test_pip_install.py
+++ b/tests/tox_env/python/pip/test_pip_install.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from packaging.requirements import Requirement
 
 from tox.pytest import CaptureFixture, ToxProjectCreator
 
@@ -41,7 +42,7 @@ def test_pip_install_empty_command_error(tox_project: ToxProjectCreator, capfd: 
     pip = result.state.envs["py"].installer
 
     with pytest.raises(SystemExit, match="1"):
-        pip.install(object, "section", "type")
+        pip.install([Requirement("name")], "section", "type")
     out, err = capfd.readouterr()
     assert not err
     assert f"pip cannot install {object!r}" in out

--- a/tests/tox_env/python/pip/test_pip_install.py
+++ b/tests/tox_env/python/pip/test_pip_install.py
@@ -36,16 +36,14 @@ def test_pip_install_empty_list(tox_project: ToxProjectCreator) -> None:
     assert execute_calls.call_count == 0
 
 
-def test_pip_install_empty_command_error(tox_project: ToxProjectCreator, capfd: CaptureFixture) -> None:
+def test_pip_install_empty_command_error(tox_project: ToxProjectCreator) -> None:
     proj = tox_project({"tox.ini": "[testenv]\ninstall_command="})
     result = proj.run("l")
     pip = result.state.envs["py"].installer
 
     with pytest.raises(SystemExit, match="1"):
         pip.install([Requirement("name")], "section", "type")
-    out, err = capfd.readouterr()
-    assert not err
-    assert f"pip cannot install {object!r}" in out
+    assert False
 
 
 def test_pip_install_flags_only_error(tox_project: ToxProjectCreator) -> None:

--- a/tests/tox_env/python/pip/test_pip_install.py
+++ b/tests/tox_env/python/pip/test_pip_install.py
@@ -261,8 +261,13 @@ def test_pip_install_constraint_file_new(tox_project: ToxProjectCreator) -> None
     assert execute_calls.call_args[0][3].cmd == ["python", "-I", "-m", "pip", "install", "a", "-c", "c.txt"]
 
 
-def test_pip_install_empty_command_error(tox_project: ToxProjectCreator) -> None:
+def test_pip_install_empty_command_error(tox_project: ToxProjectCreator, capfd: CaptureFixture) -> None:
     proj = tox_project({"tox.ini": "[testenv]\ninstall_command="})
-    result = proj.run("r")
-    result.assert_failed()
-    assert "unable to determine pip install command" in result.out
+    result = proj.run("l")
+    pip = result.state.envs["py"].installer
+
+    with pytest.raises(SystemExit, match="1"):
+        pip.install(object, "section", "type")
+    out, err = capfd.readouterr()
+    assert not err
+    assert f"pip cannot install {object!r}" in out

--- a/tests/tox_env/python/pip/test_pip_install.py
+++ b/tests/tox_env/python/pip/test_pip_install.py
@@ -42,7 +42,7 @@ def test_pip_install_empty_command_error(tox_project: ToxProjectCreator) -> None
     result = proj.run("l")
     pip = result.state.envs["py"].installer
 
-    with pytest.raises(Fail, match="unable to determine pip install command") as raised:
+    with pytest.raises(Fail, match="unable to determine pip install command"):
         pip.install([Requirement("name")], "section", "type")
 
 


### PR DESCRIPTION
This attempts to clarify the error messaging when the `install_command` entry in a `tox` environment configuration is empty.

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

Continues-from #2715.

Relates to #2695, #2798.