### PR TITLE
2442

### DIFF
--- a/docs/changelog/2442.bugfix.rst
+++ b/docs/changelog/2442.bugfix.rst
@@ -1,0 +1,1 @@
+Reuse package_env with ``--installpkg`` - by :user:`q0w`.

--- a/docs/changelog/2796.misc.rst
+++ b/docs/changelog/2796.misc.rst
@@ -1,0 +1,3 @@
+Relax the assertion in ``test_list_installed_deps`` to allow packages
+other than ``pip`` to be present in the fresh venv, to fix tests
+on PyPy.

--- a/docs/changelog/2797.misc.rst
+++ b/docs/changelog/2797.misc.rst
@@ -1,0 +1,2 @@
+Skip the ``time-machine`` dependency and spinner tests on PyPy because
+it segfaults on this implementation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ optional-dependencies.testing = [
   "pytest-mock>=3.10",
   "pytest-xdist>=3.1",
   "re-assert>=1.1",
-  "time-machine>=2.8.2",
+  "time-machine>=2.8.2; implementation_name != \"pypy\"",
 ]
 scripts.tox = "tox.run:run"
 dynamic = ["version"]

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -87,9 +87,8 @@ class RunToxEnv(ToxEnv, ABC):
         self._call_pkg_envs("interrupt")
 
     def get_package_env_types(self) -> tuple[str, str] | None:
-        has_external_pkg = getattr(self.options, "install_pkg", None) is not None
-        if self._register_package_conf() or has_external_pkg:
-            has_external_pkg = has_external_pkg or self.conf["package"] == "external"
+        if self._register_package_conf():
+            has_external_pkg = self.conf["package"] == "external"
             self.core.add_config(
                 keys=["package_env", "isolated_build_env"],
                 of_type=str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,12 @@ else:  # pragma: no cover (<py38)
     from typing_extensions import Protocol
 
 
+collect_ignore = []
+if sys.implementation.name == "pypy":
+    # time-machine causes segfaults on PyPy
+    collect_ignore.append("util/test_spinner.py")
+
+
 class ToxIniCreator(Protocol):
     def __call__(self, conf: str, override: Sequence[Override] | None = None) -> Config:  # noqa: U100
         ...

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -186,6 +186,6 @@ def test_list_installed_deps(in_ci: bool, tox_project: ToxProjectCreator, mocker
     mocker.patch("tox.tox_env.python.api.is_ci", return_value=in_ci)
     result = tox_project({"tox.ini": "[testenv]\nskip_install = true"}).run("r", "-e", "py")
     if in_ci:
-        assert "py: pip==" in result.out
+        assert "pip==" in result.out
     else:
-        assert "py: pip==" not in result.out
+        assert "pip==" not in result.out

--- a/tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py
@@ -147,3 +147,14 @@ def test_tox_install_pkg_bad_wheel(tox_project: ToxProjectCreator, tmp_path: Pat
 
     result.assert_failed()
     assert "failed with no .dist-info inside " in result.out, result.out
+
+
+def test_tox_install_pkg_with_skip_install(
+    tox_project: ToxProjectCreator,
+    demo_pkg_inline: Path,
+    demo_pkg_inline_wheel: Path,
+) -> None:
+    ini = "[testenv:foo]\nskip_install = true"
+    project = tox_project({"tox.ini": ini, "pyproject.toml": (demo_pkg_inline / "pyproject.toml").read_text()})
+    result = project.run("-e", "py", "--installpkg", str(demo_pkg_inline_wheel))
+    result.assert_success()


### PR DESCRIPTION
- Relax test_list_installed_deps() to allow other packages (#2796)
- Skip time-machine dep and spinner tests on PyPy (#2797)
- Reuse package_env with --installpkg
