### PR TITLE
issue 2695/tox4 install command breaking change docs

### DIFF
--- a/docs/changelog/2695.doc.rst
+++ b/docs/changelog/2695.doc.rst
@@ -1,0 +1,1 @@
+Add breaking-change documentation for empty ``install_command`` values

--- a/docs/changelog/2695.doc.rst
+++ b/docs/changelog/2695.doc.rst
@@ -1,1 +1,1 @@
-Add breaking-change documentation for empty ``install_command`` values
+Add breaking-change documentation for empty ``install_command`` values - by :user:`jayaddison`.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -48,6 +48,9 @@ tox 4 - changed INI rules
   this worked in tox 3, it was never supported officially. Additionally, in the context of a new virtual environment
   this flag makes no sense anyway.
 
+- tox 4 requires the ``install_command`` to evaluate to a non-empty value for each target environment.  In tox 3, an
+  empty value would be substituted for the default install command.
+
 tox 4 - known regressions
 +++++++++++++++++++++++++
 


### PR DESCRIPTION
- Add breaking-change documentation about empty 'install_command' values in tox4
- PR feedback
