### PR TITLE
Remove docs about colour regression

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -54,14 +54,6 @@ Changed INI rules
 - tox 4 requires the ``install_command`` to evaluate to a non-empty value for each target environment.  In tox 3, an
   empty value would be substituted for the default install command.
 
-Known regressions
------------------
-
-- With tox 4 the tty trait of the caller environment is no longer passed through. The most notable impact of this is
-  that some tools no longer print colored output. A PR to address this is welcomed, in the meantime you can use the
-  ``tty`` substitution to force color mode for these tools, see for example tox itself with pytest and mypy
-  `here in tox.ini <https://github.com/tox-dev/tox/blob/main/tox.ini#L28>`_.
-
 New plugin system
 -----------------
 


### PR DESCRIPTION
This section is outdated since #2711 / v4.0.12 which added the pseudo-tty and fixed colourization for tools.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix_lint`)
- [x] wrote descriptive pull request text
- [n/a] ensured there are test(s) validating the fix
- [n/a] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
