### PR TITLE
Fix various issues with missing interpreters

### DIFF
--- a/docs/changelog/2811.bugfix.rst
+++ b/docs/changelog/2811.bugfix.rst
@@ -1,2 +1,2 @@
 The combination of ``usedevelop = true`` and ``--skip-missing-interpreters=false`` will no longer fail for environments
-that were *not* invoked.
+that were *not* invoked - by :user:`stephenfin`.

--- a/docs/changelog/2811.bugfix.rst
+++ b/docs/changelog/2811.bugfix.rst
@@ -1,0 +1,2 @@
+The combination of ``usedevelop = true`` and ``--skip-missing-interpreters=false`` will no longer fail for environments
+that were *not* invoked.

--- a/docs/changelog/2826.bugfix.rst
+++ b/docs/changelog/2826.bugfix.rst
@@ -1,0 +1,2 @@
+Fix an attribute error when ``use_develop = true`` is set and an unsupported interpreter version is requested - by
+:user:`stephenfin`.

--- a/docs/changelog/2827.bugfix.rst
+++ b/docs/changelog/2827.bugfix.rst
@@ -1,2 +1,2 @@
 tox returns a non-zero error code if all envs are skipped. It will now correctly do this if only a single env was
-requested and this was skipped.
+requested and this was skipped - by :user:`stephenfin`.

--- a/docs/changelog/2827.bugfix.rst
+++ b/docs/changelog/2827.bugfix.rst
@@ -1,0 +1,2 @@
+tox returns a non-zero error code if all envs are skipped. It will now correctly do this if only a single env was
+requested and this was skipped.

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -88,6 +88,18 @@ moving to the newly added ``py_impl`` and ``py_dot_ver`` variables, for example:
 
    deps = -r{py_impl}{py_dot_ver}-req.txt
 
+Failure when all environments are skipped
+-----------------------------------------
+
+A run that results in all environments being skipped will no longer result in success. Instead, a failure will be
+reported. For example, consider a host that does not support Python 3.5:
+
+.. code-block:: bash
+
+   tox run --skip-missing-interpreters=true -e py35
+
+This will now result in a failure.
+
 Substitutions removed
 ---------------------
 
@@ -133,7 +145,6 @@ Re-use of environments
 
     [testenv:b]
     deps = pytest<7
-
 
 CLI command compatibility
 -------------------------

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -187,7 +187,9 @@ def report(start: float, runs: list[ToxEnvRunResult], is_colored: bool, verbosit
         _print(Fore.GREEN, f"  congratulations :) ({duration:.2f} seconds)")
         return Outcome.OK
     _print(Fore.RED, f"  evaluation failed :( ({duration:.2f} seconds)")
-    return runs[0].code if len(runs) == 1 else -1
+    if len(runs) == 1:
+        return runs[0].code if not runs[0].skipped else -1
+    return -1
 
 
 def _get_outcome_message(run: ToxEnvRunResult) -> tuple[str, int]:

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -248,13 +248,12 @@ class Python(ToxEnv, ABC):
         return cast(PythonInfo, self._base_python)
 
     def _get_env_journal_python(self) -> dict[str, Any]:
-        assert self._base_python is not None
         return {
-            "implementation": self._base_python.implementation,
+            "implementation": self.base_python.implementation,
             "version_info": tuple(self.base_python.version_info),
-            "version": self._base_python.version,
-            "is_64": self._base_python.is_64,
-            "sysplatform": self._base_python.platform,
+            "version": self.base_python.version,
+            "is_64": self.base_python.is_64,
+            "sysplatform": self.base_python.platform,
             "extra_version_info": None,
         }
 

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -231,17 +231,20 @@ class Python(ToxEnv, ABC):
     @property
     def base_python(self) -> PythonInfo:
         """Resolve base python"""
+        base_pythons: list[str] = self.conf["base_python"]
+
         if self._base_python_searched is False:
-            base_pythons: list[str] = self.conf["base_python"]
             self._base_python_searched = True
             self._base_python = self._get_python(base_pythons)
-            if self._base_python is None:
-                if self.core["skip_missing_interpreters"]:
-                    raise Skip(f"could not find python interpreter with spec(s): {', '.join(base_pythons)}")
-                raise NoInterpreter(base_pythons)
-            if self.journal:
+            if self._base_python is not None and self.journal:
                 value = self._get_env_journal_python()
                 self.journal["python"] = value
+
+        if self._base_python is None:
+            if self.core["skip_missing_interpreters"]:
+                raise Skip(f"could not find python interpreter with spec(s): {', '.join(base_pythons)}")
+            raise NoInterpreter(base_pythons)
+
         return cast(PythonInfo, self._base_python)
 
     def _get_env_journal_python(self) -> dict[str, Any]:

--- a/src/tox/tox_env/python/package.py
+++ b/src/tox/tox_env/python/package.py
@@ -14,7 +14,7 @@ from ..api import ToxEnvCreateArgs
 from ..errors import Skip
 from ..package import Package, PackageToxEnv, PathPackage
 from ..runner import RunToxEnv
-from .api import Python
+from .api import NoInterpreter, Python
 from .pip.req_file import PythonDeps
 
 if TYPE_CHECKING:
@@ -87,7 +87,11 @@ class PythonPackageToxEnv(Python, PackageToxEnv, ABC):
             # python only code are often compatible at major level (unless universal wheel in which case both 2/3)
             # c-extension codes are trickier, but as of today both poetry/setuptools uses pypa/wheels logic
             # https://github.com/pypa/wheel/blob/master/src/wheel/bdist_wheel.py#L234-L280
-            run_py = cast(Python, run_env).base_python
+            try:
+                run_py = cast(Python, run_env).base_python
+            except NoInterpreter:
+                run_py = None
+
             if run_py is None:
                 base = ",".join(run_env.conf["base_python"])
                 raise Skip(f"could not resolve base python with {base}")

--- a/tests/session/cmd/test_depends.py
+++ b/tests/session/cmd/test_depends.py
@@ -34,18 +34,18 @@ def test_depends(tox_project: ToxProjectCreator, patch_prev_py: Callable[[bool],
        py ~ .pkg
        {py} ~ .pkg
        {prev_py} ~ .pkg | .pkg-{impl}{prev_ver}
-       py31 ~ .pkg | ... (could not resolve base python with py31)
+       py31 ~ .pkg | ... (could not find python interpreter with spec(s): py31)
        cov2
           cov
              py ~ .pkg
              {py} ~ .pkg
              {prev_py} ~ .pkg | .pkg-{impl}{prev_ver}
-             py31 ~ .pkg | ... (could not resolve base python with py31)
+             py31 ~ .pkg | ... (could not find python interpreter with spec(s): py31)
        cov
           py ~ .pkg
           {py} ~ .pkg
           {prev_py} ~ .pkg | .pkg-{impl}{prev_ver}
-          py31 ~ .pkg | ... (could not resolve base python with py31)
+          py31 ~ .pkg | ... (could not find python interpreter with spec(s): py31)
     """
     assert outcome.out == dedent(expected).lstrip()
 

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -224,7 +224,7 @@ def test_missing_interpreter_skip_on(tox_project: ToxProjectCreator) -> None:
     proj = tox_project({"tox.ini": ini})
 
     result = proj.run("r")
-    result.assert_success()
+    result.assert_failed()
     assert "py: SKIP" in result.out
 
 
@@ -367,7 +367,7 @@ def test_platform_does_not_match_run_env(tox_project: ToxProjectCreator) -> None
     proj = tox_project({"tox.ini": ini})
 
     result = proj.run("r")
-    result.assert_success()
+    result.assert_failed()
     exp = f"py: skipped because platform {sys.platform} does not match wrong_platform"
     assert exp in result.out
 

--- a/tests/tox_env/python/test_python_runner.py
+++ b/tests/tox_env/python/test_python_runner.py
@@ -128,8 +128,39 @@ def test_extras_are_normalized(
     ("config", "cli", "expected"),
     [("false", "true", True), ("true", "false", False), ("false", "config", False), ("true", "config", True)],
 )
-def test_config_skip_missing_interpreters(tox_project: ToxProjectCreator, config: str, cli: str, expected: str) -> None:
+def test_config_skip_missing_interpreters(
+    tox_project: ToxProjectCreator,
+    config: str,
+    cli: str,
+    expected: bool,
+) -> None:
     py_ver = ".".join(str(i) for i in sys.version_info[0:2])
     project = tox_project({"tox.ini": f"[tox]\nenvlist=py4,py{py_ver}\nskip_missing_interpreters={config}"})
-    result = project.run("--skip-missing-interpreters", cli)
-    assert result.code == 0 if expected else 1
+    result = project.run(f"--skip-missing-interpreters={cli}")
+    assert result.code == (0 if expected else -1)
+
+
+@pytest.mark.parametrize(
+    ("skip", "env", "retcode"),
+    [
+        ("true", f"py{''.join(str(i) for i in sys.version_info[0:2])}", 0),
+        ("false", f"py{''.join(str(i) for i in sys.version_info[0:2])}", 0),
+        ("true", "py31", 0),
+        ("false", "py31", 1),
+        ("true", None, 0),
+        ("false", None, -1),
+    ],
+)
+def test_skip_missing_interpreters_specified_env(
+    tox_project: ToxProjectCreator,
+    skip: str,
+    env: str | None,
+    retcode: int,
+) -> None:
+    py_ver = "".join(str(i) for i in sys.version_info[0:2])
+    project = tox_project({"tox.ini": f"[tox]\nenvlist=py31,py{py_ver}\n[testenv]\nusedevelop=true"})
+    args = [f"--skip-missing-interpreters={skip}"]
+    if env:
+        args += ["-e", env]
+    result = project.run(*args)
+    assert result.code == retcode

--- a/tests/tox_env/python/test_python_runner.py
+++ b/tests/tox_env/python/test_python_runner.py
@@ -145,7 +145,7 @@ def test_config_skip_missing_interpreters(
     [
         ("true", f"py{''.join(str(i) for i in sys.version_info[0:2])}", 0),
         ("false", f"py{''.join(str(i) for i in sys.version_info[0:2])}", 0),
-        ("true", "py31", 0),
+        ("true", "py31", -1),
         ("false", "py31", 1),
         ("true", None, 0),
         ("false", None, -1),

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -142,6 +142,7 @@ replacer
 repo
 reqs
 retann
+retcode
 rfind
 rpartition
 rreq


### PR DESCRIPTION
This is a somewhat hefty PR that resolves a number of issues related to missing interpreters. Full details are provided in the commit messages and I would recommend reading these separately. These commits are:

- `Correctly skip/fail env for cached base_python values`
- `Remove unnecessary assert`
- `Note change in behaviour when all envs are skipped`
- `Ignore missing interpreters when classifying env type`
- `Return non-zero error code on skipped env`

In summary, we fix #2811, #2826, and #2827. Tests are provided for all of these fixes. We also add a note to the documentation highlighting the change in behavior introduced in #2206, which I initially took to be a bug.

This PR could be split into multiple PRs but all three fixes are required to get a sane configuration for projects that set `usedevelop=true` and request missing Python interpreters somehow.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
