### PR TITLE
Be stricter about our Python factors

### DIFF
--- a/docs/changelog/2657.bugfix.rst
+++ b/docs/changelog/2657.bugfix.rst
@@ -1,0 +1,2 @@
+Python factors should now be prefixed with ``py`` or a specific interpreter name such as ``pypy``. Simple factors like
+``310`` will not be supported in a future release. This aligns tox 4 closer to tox 3 behavior - by :user:`stephenfin`.

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -147,7 +147,22 @@ class Python(ToxEnv, ABC):
             ):
                 continue
 
-            impl = spec.implementation or "python"
+            impl = spec.implementation
+
+            # TODO: Drop in a future version
+            # PythonSpec.from_string_spec set implementation to None for py and python
+            if impl is None and not factor.startswith("py") and not factor.startswith("python"):
+                logging.warning(
+                    "identified the %s factor in the %s testenv as a Python spec but the interpreter implementation "
+                    "was not specified. This will be a ignored in future versions of tox. Please prefix this factor "
+                    "with an interpreter short name (one of: %s)",
+                    factor,
+                    env_name,
+                    ", ".join(INTERPRETER_SHORT_NAMES + ["py"]),
+                )
+
+            impl = impl or "python"
+
             if impl.lower() in INTERPRETER_SHORT_NAMES and spec.path is None:
                 candidates.append(factor)
 

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -158,7 +158,7 @@ class Python(ToxEnv, ABC):
                     "with an interpreter short name (one of: %s)",
                     factor,
                     env_name,
-                    ", ".join(INTERPRETER_SHORT_NAMES + ["py"]),
+                    ", ".join(list(INTERPRETER_SHORT_NAMES) + ["py"]),
                 )
 
             impl = impl or "python"

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -88,7 +88,7 @@ def test_diff_msg_no_diff() -> None:
     ],
     ids=lambda a: "|".join(a) if isinstance(a, list) else str(a),
 )
-def test_extract_base_python(env: str, base_python: str | None):
+def test_extract_base_python(env: str, base_python: str | None) -> None:
     result = Python.extract_base_python(env)
     assert result == base_python
 

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -71,6 +71,28 @@ def test_diff_msg_no_diff() -> None:
     assert Python._diff_msg({}, {}) == "python "
 
 
+@pytest.mark.parametrize(
+    ("env", "base_python"),
+    [
+        ("py3", "py3"),
+        ("py311", "py311"),
+        ("pypy2", "pypy2"),
+        ("functional-py310", "py310"),
+        ("bar-pypy2-foo", "pypy2"),
+        ("310", "310"),
+        ("5", None),
+        # TODO: This is acceptable to 'PythonSpec.from_string_spec' but is
+        # clearly not valid :(
+        ("2000", "2000"),
+        ("4000", None),
+    ],
+    ids=lambda a: "|".join(a) if isinstance(a, list) else str(a),
+)
+def test_extract_base_python(env: str, base_python: str | None):
+    result = Python.extract_base_python(env)
+    assert result == base_python
+
+
 @pytest.mark.parametrize("ignore_conflict", [True, False])
 @pytest.mark.parametrize(
     ("env", "base_python"),

--- a/tests/tox_env/python/test_python_runner.py
+++ b/tests/tox_env/python/test_python_runner.py
@@ -135,7 +135,7 @@ def test_config_skip_missing_interpreters(
     expected: bool,
 ) -> None:
     py_ver = ".".join(str(i) for i in sys.version_info[0:2])
-    project = tox_project({"tox.ini": f"[tox]\nenvlist=py4,py{py_ver}\nskip_missing_interpreters={config}"})
+    project = tox_project({"tox.ini": f"[tox]\nenvlist=py31,py{py_ver}\nskip_missing_interpreters={config}"})
     result = project.run(f"--skip-missing-interpreters={cli}")
     assert result.code == (0 if expected else -1)
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -129,6 +129,7 @@ pycharm
 pygments
 pypa
 pyproject
+pythonspec
 quickstart
 readline
 readouterr


### PR DESCRIPTION
Fixes #2657 by only using non-prefixed factors that look like Python versions, rather than accepting virtually anything.

We also opt to discourage non-prefixed factors since these are far too likely to conflict with other non-Python factors and the current behavior is very magical. We can fully remove this functionality in a future release.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
