### PR TITLE
Add release notes project URL for quick access in PyPI web

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = "MIT"
 urls.Homepage = "http://tox.readthedocs.org"
 urls.Source = "https://github.com/tox-dev/tox"
 urls.Tracker = "https://github.com/tox-dev/tox/issues"
+urls."Release Notes" = "https://tox.wiki/en/latest/changelog.html"
 authors = [{ name = "Bernát Gábor", email = "gaborjbernat@gmail.com" }]
 maintainers = [
   { name = "Anthony Sottile", email = "asottile@umich.edu" },


### PR DESCRIPTION
Use "Release Notes" as the link title instead of the document's "Release History" title to get a representative icon shown for it.

https://github.com/pypi/warehouse/blob/04ee9be504caa89345617b2795ff53fc22631297/warehouse/templates/packaging/detail.html#L24
