### PR TITLE
Only return Python factor on base_python conflict

### DIFF
--- a/docs/changelog/2838.bugfix.rst
+++ b/docs/changelog/2838.bugfix.rst
@@ -1,0 +1,2 @@
+A testenv with multiple factors, one of which conflicts with a ``base_python`` setting in ``tox.ini``, will now use the
+correct Python interpreter version - by :user:`stephenfin`.

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -87,26 +87,35 @@ def test_base_python_env_no_conflict(env: str, base_python: list[str], ignore_co
 
 @pytest.mark.parametrize("ignore_conflict", [True, False])
 @pytest.mark.parametrize(
-    ("env", "base_python", "conflict"),
+    ("env", "base_python", "expected", "conflict"),
     [
-        ("cpython", ["pypy"], ["pypy"]),
-        ("pypy", ["cpython"], ["cpython"]),
-        ("pypy2", ["pypy3"], ["pypy3"]),
-        ("py3", ["py2"], ["py2"]),
-        ("py38", ["py39"], ["py39"]),
-        ("py38", ["py38", "py39"], ["py39"]),
-        ("py38", ["python3"], ["python3"]),
-        ("py310", ["py38", "py39"], ["py38", "py39"]),
-        ("py3.11.1", ["py3.11.2"], ["py3.11.2"]),
-        ("py3-64", ["py3-32"], ["py3-32"]),
-        ("py310-magic", ["py39"], ["py39"]),
+        ("cpython", ["pypy"], "cpython", ["pypy"]),
+        ("pypy", ["cpython"], "pypy", ["cpython"]),
+        ("pypy2", ["pypy3"], "pypy2", ["pypy3"]),
+        ("py3", ["py2"], "py3", ["py2"]),
+        ("py38", ["py39"], "py38", ["py39"]),
+        ("py38", ["py38", "py39"], "py38", ["py39"]),
+        ("py38", ["python3"], "py38", ["python3"]),
+        ("py310", ["py38", "py39"], "py310", ["py38", "py39"]),
+        ("py3.11.1", ["py3.11.2"], "py3.11.1", ["py3.11.2"]),
+        ("py3-64", ["py3-32"], "py3-64", ["py3-32"]),
+        ("py310-magic", ["py39"], "py310", ["py39"]),
     ],
     ids=lambda a: "|".join(a) if isinstance(a, list) else str(a),
 )
-def test_base_python_env_conflict(env: str, base_python: list[str], conflict: list[str], ignore_conflict: bool) -> None:
+def test_base_python_env_conflict(
+    env: str,
+    base_python: list[str],
+    expected: str,
+    conflict: list[str],
+    ignore_conflict: bool,
+) -> None:
+    if env == "py3-64":
+        raise pytest.skip("bug #2657")
+
     if ignore_conflict:
         result = Python._validate_base_python(env, base_python, ignore_conflict)
-        assert result == [env]
+        assert result == [expected]
     else:
         msg = f"env name {env} conflicting with base python {conflict[0]}"
         with pytest.raises(Fail, match=msg):


### PR DESCRIPTION
Consider the following `tox.ini` file:

```ini
[tox]
ignore_base_python_conflict = true

[testenv]
base_python = python3
commands = ...

[testenv:functional{,-py38,-py39,-py310}]
commands = ...
```

There is a conflict between the `base_python` value specified in `[testenv] base_python` and the value implied by the `pyXY` factors in the `functional-pyXY` test envs. The `Python._validate_base_python` function is supposed to resolve this for us and either (a) raise an error if `[tox] ignore_base_python_conflict` is set to `false` (default) or (b) ignore the value of `[testenv] base_python` in favour of the value implied by the `pyXY` factor for the given test env if `[tox] ignore_base_python_conflict` is set to `true`. There's a bug though. Rather than returning the `pyXY` factor, we were returning the entire test env name (`functional-pyXY`). There is no Python version corresponding to e.g. `functional-py39` so this (correctly) fails.

We can correct the issue by only returning the factor that modified the `base_python` value, i.e. the `pyXY` factor. To ensure we do this, we need some additional logic. It turns out this logic is already present in another helper method on the `Python` class, `extract_base_python`, so we also take the opportunity to de-duplicate and reuse some logic.

Note that this change breaks the ability of users to use a testenv name like `py38-64` (to get the 64 bit version of a Python 3.8 interpreter). Continuing to support this would require much larger change since we'd no longer be able to strictly delimit factors by hyphens (in this case, the entirety of `py38-64` becomes a factor).

Also note that this change emphasises issue #2657, as this will now be raised for a factor like `py38-64` since `tox` (or rather, virtualenv) is falsely identifying `64` as a valid Python interpreter identifier. We will fix this separately so the offending test are skipped for now.

Signed-off-by: Stephen Finucane <stephen@that.guru>
Fixes: #2838

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
