### PR TITLE
The tests actually require wheel

### DIFF
--- a/docs/changelog/2843.bugfix.rst
+++ b/docs/changelog/2843.bugfix.rst
@@ -1,0 +1,1 @@
+Explicitly list ``wheel`` as requirement for the tests, as some of the tests error without it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ optional-dependencies.testing = [
   "pytest-mock>=3.10",
   "pytest-xdist>=3.1",
   "re-assert>=1.1",
+  "wheel>=0.38.4",
   "time-machine>=2.8.2; implementation_name != \"pypy\"",
 ]
 scripts.tox = "tox.run:run"


### PR DESCRIPTION
When wheel is not installed, several tests error like this:

    distutils.errors.DistutilsModuleError: invalid command 'bdist_wheel'
    ...
    SystemExit: error: invalid command 'bdist_wheel'

Or like this:

    ERROR Missing dependencies:
    	wheel

When the tests are executed in a virtualenv, wheel is implicitly installed, which is why this have never happened on the CI.

List of tests that error:

     ERROR tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py::test_tox_install_pkg_wheel
     ERROR tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py::test_tox_install_pkg_sdist
     ERROR tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py::test_install_pkg_via[p]
     ERROR tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py::test_install_pkg_via[le]
     ERROR tests/tox_env/python/virtual_env/package/test_python_package_util.py::test_load_dependency_no_extra
     ERROR tests/tox_env/python/virtual_env/package/test_python_package_util.py::test_load_dependency_many_extra

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [-] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [-] updated/extended the documentation
