### PR TITLE
Add Documentation URL for quick access via PyPI web

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme.content-type = "text/markdown"
 keywords = ["virtual", "environments", "isolated", "testing"]
 license = "MIT"
 urls.Homepage = "http://tox.readthedocs.org"
+urls.Documentation = "https://tox.wiki"
 urls.Source = "https://github.com/tox-dev/tox"
 urls.Tracker = "https://github.com/tox-dev/tox/issues"
 urls."Release Notes" = "https://tox.wiki/en/latest/changelog.html"


### PR DESCRIPTION
This PR adds a link to the Documentation in the pyproject.toml. This link will be shown in the PyPI web quick links, rendered with a book icon.