### PR TITLE
Rewrite substitution parser

### DIFF
--- a/docs/changelog/2372.bugfix.rst
+++ b/docs/changelog/2372.bugfix.rst
@@ -1,0 +1,7 @@
+Rewrite substitution replacement parser - by :user:`masenf`
+
+* ``\`` acts as a proper escape for ``\`` in ini-style substitutions
+* The resulting value of a substitution is no longer reprocessed in the context
+  of the broader string. (Prior to this change, ini-values were repeatedly re-substituted until
+  the expression no longer had modifications)
+* Migrate and update "Substitutions" section of Configuration page from v3 docs.

--- a/docs/changelog/2732.feature.rst
+++ b/docs/changelog/2732.feature.rst
@@ -5,3 +5,10 @@ Rewrite substitution replacement parser - by :user:`masenf`
   of the broader string. (Prior to this change, ini-values were repeatedly re-substituted until
   the expression no longer had modifications)
 * Migrate and update "Substitutions" section of Configuration page from v3 docs.
+* ```find_replace_part`` is removed from ``tox.config.loader.ini.replace``
+* New names exported from ``tox.config.loader.ini.replace``:
+    * ``find_replace_expr``
+    * ``MatchArg``
+    * ``MatchError``
+    * ``MatchExpression``
+    * Note: the API for ``replace`` itself is unchanged.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -763,3 +763,144 @@ Example configuration:
 
     [tox]
     skip_missing_interpreters = true
+
+Substitutions
+-------------
+
+Any ``key=value`` setting in an ini-file can make use of **value substitution**
+through the ``{...}`` string-substitution pattern.
+
+The string inside the curly braces may reference a global or per-environment config key as described above.
+
+The backslash character ``\`` will act as an escape for a following: ``\``,
+``{``, ``}``, ``:``, ``[``, or ``]``, otherwise the backslash will be
+reproduced literally::
+
+    commands =
+        python -c 'print("\{posargs} = \{}".format("{posargs}"))'
+        python -c 'print("host: \{}".format("{env:HOSTNAME:host\: not set}")'
+
+Special substitutions that accept additional colon-delimited ``:`` parameters
+cannot have a space after the ``:`` at the beginning of line (e.g.  ``{posargs:
+magic}`` would be parsed as factorial ``{posargs``, having value magic).
+
+Environment variable substitutions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you specify a substitution string like this::
+
+    {env:KEY}
+
+then the value will be retrieved as ``os.environ['KEY']``
+and raise an Error if the environment variable
+does not exist.
+
+
+Environment variable substitutions with default values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you specify a substitution string like this::
+
+    {env:KEY:DEFAULTVALUE}
+
+then the value will be retrieved as ``os.environ['KEY']``
+and replace with DEFAULTVALUE if the environment variable does not
+exist.
+
+If you specify a substitution string like this::
+
+    {env:KEY:}
+
+then the value will be retrieved as ``os.environ['KEY']``
+and replace with an empty string if the environment variable does not
+exist.
+
+Substitutions can also be nested. In that case they are expanded starting
+from the innermost expression::
+
+    {env:KEY:{env:DEFAULT_OF_KEY}}
+
+the above example is roughly equivalent to
+``os.environ.get('KEY', os.environ['DEFAULT_OF_KEY'])``
+
+Interactive shell substitution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 3.4.0
+
+It's possible to inject a config value only when tox is running in interactive shell (standard input)::
+
+    {tty:ON_VALUE:OFF_VALUE}
+
+The first value is the value to inject when the interactive terminal is
+available, the second value is the value to use when it's not (optiona). A good
+use case for this is e.g. passing in the ``--pdb`` flag for pytest.
+
+.. _`command positional substitution`:
+.. _`positional substitution`:
+
+Substitutions for positional arguments in commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.0
+
+If you specify a substitution string like this::
+
+    {posargs:DEFAULTS}
+
+then the value will be replaced with positional arguments as provided
+to the tox command::
+
+    tox arg1 arg2
+
+In this instance, the positional argument portion will be replaced with
+``arg1 arg2``. If no positional arguments were specified, the value of
+DEFAULTS will be used instead. If DEFAULTS contains other substitution
+strings, such as ``{env:*}``, they will be interpreted.,
+
+Use a double ``--`` if you also want to pass options to an underlying
+test command, for example::
+
+    tox -- --opt1 ARG1
+
+will make the ``--opt1 ARG1`` appear in all test commands where ``[]`` or
+``{posargs}`` was specified.  By default (see ``args_are_paths``
+setting), ``tox`` rewrites each positional argument if it is a relative
+path and exists on the filesystem to become a path relative to the
+``changedir`` setting.
+
+Substitution for values from other sections
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.4
+
+Values from other sections can be referred to via::
+
+   {[sectionname]valuename}
+
+which you can use to avoid repetition of config values.
+You can put default values in one section and reference them in others to avoid repeating the same values:
+
+.. code-block:: ini
+
+    [base]
+    deps =
+        pytest
+        mock
+        pytest-xdist
+
+    [testenv:dulwich]
+    deps =
+        dulwich
+        {[base]deps}
+
+    [testenv:mercurial]
+    deps =
+        mercurial
+        {[base]deps}
+
+Other Substitutions
+~~~~~~~~~~~~~~~~~~~
+
+* ``{}`` - replaced as ``os.pathsep``
+* ``{/}`` - replaced as ``os.sep``

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -42,7 +42,7 @@ def replace(conf: Config, loader: IniLoader, value: str, args: ConfigLoadArgs) -
 
 
 class MatchError(Exception):
-    pass
+    """Could not find end terminator in MatchExpression."""
 
 
 class MatchExpression:

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -18,7 +18,7 @@ class SetEnv:
         self._env_files: list[str] = []
         self._replacer: Replacer = lambda s, c: s  # noqa: U100
         self._name, self._env_name, self._root = name, env_name, root
-        from .loader.ini.replace import find_replace_part
+        from .loader.ini.replace import MatchExpression, find_replace_expr
 
         for line in raw.splitlines():
             if line.strip():
@@ -30,9 +30,10 @@ class SetEnv:
                         if "{" in key:
                             raise ValueError(f"invalid line {line!r} in set_env")
                     except ValueError:
-                        _, __, match = find_replace_part(line, 0)
-                        if match:
-                            self._needs_replacement.append(line)
+                        for expr in find_replace_expr(line):
+                            if isinstance(expr, MatchExpression):
+                                self._needs_replacement.append(line)
+                                break
                         else:
                             raise
                     else:

--- a/tests/config/loader/ini/replace/test_replace.py
+++ b/tests/config/loader/ini/replace/test_replace.py
@@ -57,7 +57,7 @@ from tox.report import HandledError
         (r"C:\WINDOWS\foo\bar", [r"C:\WINDOWS\foo\bar"]),
     ],
 )
-def test_match(value: str, exp_output: list[str | MatchExpression]) -> None:
+def test_match_expr(value: str, exp_output: list[str | MatchExpression]) -> None:
     assert find_replace_expr(value) == exp_output
 
 
@@ -78,3 +78,16 @@ def test_dont_replace(replace_one: ReplaceOne, value: str, exp_exception: str | 
             replace_one(value)
     else:
         assert replace_one(value) == value
+
+
+@pytest.mark.parametrize(
+    ("match_expression", "exp_repr"),
+    [
+        (MatchExpression([["posargs"]]), "MatchExpression(expr=[['posargs']], term_pos=None)"),
+        (MatchExpression([["posargs"]], 1), "MatchExpression(expr=[['posargs']], term_pos=1)"),
+        (MatchExpression("foo", -42), "MatchExpression(expr='foo', term_pos=-42)"),
+    ],
+)
+def test_match_expression_repr(match_expression: MatchExpression, exp_repr: str) -> None:
+    print(match_expression)
+    assert repr(match_expression) == exp_repr

--- a/tests/config/loader/ini/replace/test_replace.py
+++ b/tests/config/loader/ini/replace/test_replace.py
@@ -2,26 +2,79 @@ from __future__ import annotations
 
 import pytest
 
+from tests.config.loader.ini.replace.conftest import ReplaceOne
 from tox.config.loader.ini.replace import MatchExpression, find_replace_expr
+from tox.report import HandledError
 
 
 @pytest.mark.parametrize(
     ("value", "exp_output"),
     [
-        ("[]", [[MatchExpression([["posargs"]])]]),
-        ("123[]", [["123", MatchExpression([["posargs"]])]]),
-        ("[]123", [[MatchExpression([["posargs"]]), "123"]]),
-        (r"\[\] []", [["[] ", MatchExpression([["posargs"]])]]),
-        (r"[\] []", [["[] ", MatchExpression([["posargs"]])]]),
-        (r"\[] []", [["[] ", MatchExpression([["posargs"]])]]),
-        ("{foo}", [[MatchExpression([["foo"]])]]),
-        (r"\{foo} {bar}", [["{foo} ", MatchExpression([["bar"]])]]),
-        ("{foo} {bar}", [[MatchExpression([["foo"]]), " ", MatchExpression([["bar"]])]]),
-        (r"{foo\} {bar}", [["{foo} ", MatchExpression([["bar"]])]]),
-        (r"{foo:{bar}}", [[MatchExpression([["foo"], [MatchExpression([["bar"]])]])]]),
-        (r"{\{}", [[MatchExpression([["{"]])]]),
-        (r"{\}}", [[MatchExpression([["}"]])]]),
+        ("[]", [MatchExpression([["posargs"]])]),
+        ("123[]", ["123", MatchExpression([["posargs"]])]),
+        ("[]123", [MatchExpression([["posargs"]]), "123"]),
+        (r"\[\] []", ["[] ", MatchExpression([["posargs"]])]),
+        (r"[\] []", ["[] ", MatchExpression([["posargs"]])]),
+        (r"\[] []", ["[] ", MatchExpression([["posargs"]])]),
+        ("{foo}", [MatchExpression([["foo"]])]),
+        (r"\{foo} {bar}", ["{foo} ", MatchExpression([["bar"]])]),
+        ("{foo} {bar}", [MatchExpression([["foo"]]), " ", MatchExpression([["bar"]])]),
+        (r"{foo\} {bar}", ["{foo} ", MatchExpression([["bar"]])]),
+        (r"{foo:{bar}}", [MatchExpression([["foo"], [MatchExpression([["bar"]])]])]),
+        (r"{foo\::{bar}}", [MatchExpression([["foo:"], [MatchExpression([["bar"]])]])]),
+        (r"{foo:B:c:D:e}", [MatchExpression([["foo"], ["B"], ["c"], ["D"], ["e"]])]),
+        (r"{\{}", [MatchExpression([["{"]])]),
+        (r"{\}}", [MatchExpression([["}"]])]),
+        (
+            r"p{foo:b{a{r}:t}:{ba}z}s",
+            [
+                "p",
+                MatchExpression(
+                    [
+                        ["foo"],
+                        [
+                            "b",
+                            MatchExpression(
+                                [
+                                    ["a", MatchExpression([["r"]])],
+                                    ["t"],
+                                ],
+                            ),
+                        ],
+                        [
+                            MatchExpression(
+                                [["ba"]],
+                            ),
+                            "z",
+                        ],
+                    ],
+                ),
+                "s",
+            ],
+        ),
+        ("\\", ["\\"]),
+        (r"\d", ["\\d"]),
+        (r"C:\WINDOWS\foo\bar", [r"C:\WINDOWS\foo\bar"]),
     ],
 )
 def test_match(value: str, exp_output: list[str | MatchExpression]) -> None:
-    assert find_replace_expr(value) == (exp_output, len(value))
+    assert find_replace_expr(value) == exp_output
+
+
+@pytest.mark.parametrize(
+    ("value", "exp_exception"),
+    [
+        ("py-{foo,bar}", None),
+        ("py37-{base,i18n},b", None),
+        ("py37-{i18n,base},b", None),
+        ("{toxinidir,}", None),
+        ("{env}", r"MatchError\('No variable name was supplied in {env} substitution'\)"),
+    ],
+)
+def test_dont_replace(replace_one: ReplaceOne, value: str, exp_exception: str | None) -> None:
+    """Test that invalid expressions are not replaced."""
+    if exp_exception:
+        with pytest.raises(HandledError, match=exp_exception):
+            replace_one(value)
+    else:
+        assert replace_one(value) == value

--- a/tests/config/loader/ini/replace/test_replace.py
+++ b/tests/config/loader/ini/replace/test_replace.py
@@ -2,26 +2,26 @@ from __future__ import annotations
 
 import pytest
 
-from tox.config.loader.ini.replace import find_replace_part
+from tox.config.loader.ini.replace import MatchExpression, find_replace_expr
 
 
 @pytest.mark.parametrize(
-    ("value", "result"),
+    ("value", "exp_output"),
     [
-        ("[]", (0, 1, "posargs")),
-        ("123[]", (3, 4, "posargs")),
-        ("[]123", (0, 1, "posargs")),
-        (r"\[\] []", (5, 6, "posargs")),
-        (r"[\] []", (4, 5, "posargs")),
-        (r"\[] []", (4, 5, "posargs")),
-        ("{foo}", (0, 4, "foo")),
-        (r"\{foo} {bar}", (7, 11, "bar")),
-        ("{foo} {bar}", (0, 4, "foo")),
-        (r"{foo\} {bar}", (7, 11, "bar")),
-        (r"{foo:{bar}}", (5, 9, "bar")),
-        (r"{\{}", (0, 3, r"\{")),
-        (r"{\}}", (0, 3, r"\}")),
+        ("[]", [[MatchExpression([["posargs"]])]]),
+        ("123[]", [["123", MatchExpression([["posargs"]])]]),
+        ("[]123", [[MatchExpression([["posargs"]]), "123"]]),
+        (r"\[\] []", [["[] ", MatchExpression([["posargs"]])]]),
+        (r"[\] []", [["[] ", MatchExpression([["posargs"]])]]),
+        (r"\[] []", [["[] ", MatchExpression([["posargs"]])]]),
+        ("{foo}", [[MatchExpression([["foo"]])]]),
+        (r"\{foo} {bar}", [["{foo} ", MatchExpression([["bar"]])]]),
+        ("{foo} {bar}", [[MatchExpression([["foo"]]), " ", MatchExpression([["bar"]])]]),
+        (r"{foo\} {bar}", [["{foo} ", MatchExpression([["bar"]])]]),
+        (r"{foo:{bar}}", [[MatchExpression([["foo"], [MatchExpression([["bar"]])]])]]),
+        (r"{\{}", [[MatchExpression([["{"]])]]),
+        (r"{\}}", [[MatchExpression([["}"]])]]),
     ],
 )
-def test_match(value: str, result: tuple[int, int, str]) -> None:
-    assert find_replace_part(value, 0) == result
+def test_match(value: str, exp_output: list[str | MatchExpression]) -> None:
+    assert find_replace_expr(value) == (exp_output, len(value))

--- a/tests/config/loader/ini/replace/test_replace_env_var.py
+++ b/tests/config/loader/ini/replace/test_replace_env_var.py
@@ -11,6 +11,27 @@ def test_replace_env_set(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> N
     assert result == "something good"
 
 
+def test_replace_env_set_double_bs(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """Double backslash should escape to single backslash and not affect surrounding replacements."""
+    monkeypatch.setenv("MAGIC", "something good")
+    result = replace_one(r"{env:MAGIC}\\{env:MAGIC}")
+    assert result == r"something good\something good"
+
+
+def test_replace_env_set_triple_bs(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """Triple backslash should escape to single backslash also escape subsequent replacement."""
+    monkeypatch.setenv("MAGIC", "something good")
+    result = replace_one(r"{env:MAGIC}\\\{env:MAGIC}")
+    assert result == r"something good\{env:MAGIC}"
+
+
+def test_replace_env_set_quad_bs(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """Quad backslash should escape to two backslashes and not affect surrounding replacements."""
+    monkeypatch.setenv("MAGIC", "something good")
+    result = replace_one(r"\\{env:MAGIC}\\\\{env:MAGIC}\\")
+    assert result == r"\something good\\something good" + "\\"
+
+
 def test_replace_env_missing(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
     """If we have a factor that is not specified within the core env-list then that's also an environment"""
     monkeypatch.delenv("MAGIC", raising=False)

--- a/tests/config/loader/ini/replace/test_replace_env_var.py
+++ b/tests/config/loader/ini/replace/test_replace_env_var.py
@@ -32,6 +32,22 @@ def test_replace_env_set_quad_bs(replace_one: ReplaceOne, monkeypatch: MonkeyPat
     assert result == r"\something good\\something good" + "\\"
 
 
+def test_replace_env_when_value_is_backslash(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """When the replacement value is backslash, it shouldn't affect the next replacement."""
+    monkeypatch.setenv("MAGIC", "tragic")
+    monkeypatch.setenv("BS", "\\")
+    result = replace_one(r"{env:BS}{env:MAGIC}")
+    assert result == r"\tragic"
+
+
+def test_replace_env_when_value_is_stuff_then_backslash(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """When the replacement value is a string containing backslash, it can affect the next replacement."""
+    monkeypatch.setenv("MAGIC", "tragic")
+    monkeypatch.setenv("BS", "stuff\\")
+    result = replace_one(r"{env:BS}{env:MAGIC}")
+    assert result == r"stuff{env:MAGIC}"
+
+
 def test_replace_env_missing(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
     """If we have a factor that is not specified within the core env-list then that's also an environment"""
     monkeypatch.delenv("MAGIC", raising=False)

--- a/tests/config/loader/ini/replace/test_replace_env_var.py
+++ b/tests/config/loader/ini/replace/test_replace_env_var.py
@@ -105,6 +105,22 @@ def test_replace_env_var_circular_flip_flop(replace_one: ReplaceOne, monkeypatch
     assert result == "{env:TRAGIC}"
 
 
+@pytest.mark.parametrize("fallback", [True, False])
+def test_replace_env_var_chase(replace_one: ReplaceOne, monkeypatch: MonkeyPatch, fallback: bool) -> None:
+    """Resolve variable to be replaced and default value via indirection."""
+    monkeypatch.setenv("WALK", "THIS")
+    def_val = "or that one"
+    monkeypatch.setenv("DEF", def_val)
+    if fallback:
+        monkeypatch.delenv("THIS", raising=False)
+        exp_result = def_val
+    else:
+        this_val = "path"
+        monkeypatch.setenv("THIS", this_val)
+        exp_result = this_val
+    result = replace_one("{env:{env:WALK}:{env:DEF}}")
+    assert result == exp_result
+
 
 def test_replace_env_default_with_colon(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
     """If we have a factor that is not specified within the core env-list then that's also an environment"""

--- a/tests/config/loader/ini/replace/test_replace_env_var.py
+++ b/tests/config/loader/ini/replace/test_replace_env_var.py
@@ -46,11 +46,11 @@ def test_replace_env_when_value_is_backslash(replace_one: ReplaceOne, monkeypatc
 
 
 def test_replace_env_when_value_is_stuff_then_backslash(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
-    """When the replacement value is a string containing backslash, it can affect the next replacement."""
+    """When the replacement value is a string containing backslash, it shouldn't affect the next replacement."""
     monkeypatch.setenv("MAGIC", "tragic")
     monkeypatch.setenv("BS", "stuff\\")
     result = replace_one(r"{env:BS}{env:MAGIC}")
-    assert result == r"stuff{env:MAGIC}"
+    assert result == r"stuff\tragic"
 
 
 def test_replace_env_missing(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:

--- a/tests/config/loader/ini/replace/test_replace_env_var.py
+++ b/tests/config/loader/ini/replace/test_replace_env_var.py
@@ -111,3 +111,9 @@ def test_replace_env_default_with_colon(replace_one: ReplaceOne, monkeypatch: Mo
     monkeypatch.delenv("MAGIC", raising=False)
     result = replace_one("{env:MAGIC:https://some.url.org}")
     assert result == "https://some.url.org"
+
+
+def test_replace_env_default_deep(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """Get the value through a long tree of nested defaults."""
+    monkeypatch.delenv("M", raising=False)
+    assert replace_one("{env:M:{env:M:{env:M:{env:M:{env:M:foo}}}}}") == "foo"

--- a/tests/config/loader/ini/replace/test_replace_os_sep.py
+++ b/tests/config/loader/ini/replace/test_replace_os_sep.py
@@ -2,9 +2,29 @@ from __future__ import annotations
 
 import os
 
+import pytest
+
 from tests.config.loader.ini.replace.conftest import ReplaceOne
+from tox.pytest import MonkeyPatch
 
 
 def test_replace_os_sep(replace_one: ReplaceOne) -> None:
     result = replace_one("{/}")
     assert result == os.sep
+
+
+@pytest.mark.parametrize("sep", ["/", "\\"])
+def test_replace_os_sep_before_curly(monkeypatch: MonkeyPatch, replace_one: ReplaceOne, sep: str) -> None:
+    """Explicit test case for issue #2732 (windows only)."""
+    monkeypatch.setattr(os, "sep", sep)
+    monkeypatch.delenv("_", raising=False)
+    result = replace_one("{/}{env:_:foo}")
+    assert result == os.sep + "foo"
+
+
+@pytest.mark.parametrize("sep", ["/", "\\"])
+def test_replace_os_sep_sub_exp_regression(monkeypatch: MonkeyPatch, replace_one: ReplaceOne, sep: str) -> None:
+    monkeypatch.setattr(os, "sep", sep)
+    monkeypatch.delenv("_", raising=False)
+    result = replace_one("{env:_:{posargs}{/}.{posargs}}", ["foo"])
+    assert result == f"foo{os.sep}.foo"


### PR DESCRIPTION
* Fix issue #2732 by rewriting the regex-based substitution expression parser with a recursive-style parser.
* Substitutions are processed left to right, inner-most to outer-most.
* After a replacement is made in a string, the replaced part of the string will NOT affect characters after it. the result of a replacement will never be used in further substitution parsing.
  * On windows `{/}` will expand to a literal backslash `\`, which will NOT act as an escape for the next character.
* Additional test cases and regression tests are added. 
* Migrate and update "Substitutions" section of the "Configuration" doc from tox 3

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
