### PR TITLE
Recursive replace

### DIFF
--- a/docs/changelog/2863.bugfix.rst
+++ b/docs/changelog/2863.bugfix.rst
@@ -1,0 +1,5 @@
+Fix regression introduced in 4.3.0 by expanding substitution expressions
+(``{...}``) that result from a previous subsitution's replacement value (up to
+100 times). Note that recursive expansion is strictly depth-first; no
+replacement value will ever affect adjacent characters nor will expansion ever
+occur over the result of more than one replacement. - by :user:`masenf`

--- a/docs/changelog/2863.bugfix.rst
+++ b/docs/changelog/2863.bugfix.rst
@@ -2,4 +2,4 @@ Fix regression introduced in 4.3.0 by expanding substitution expressions
 (``{...}``) that result from a previous subsitution's replacement value (up to
 100 times). Note that recursive expansion is strictly depth-first; no
 replacement value will ever affect adjacent characters nor will expansion ever
-occur over the result of more than one replacement. - by :user:`masenf`
+occur over the result of more than one replacement - by :user:`masenf`.

--- a/tests/config/loader/ini/replace/test_replace_env_var.py
+++ b/tests/config/loader/ini/replace/test_replace_env_var.py
@@ -102,7 +102,7 @@ def test_replace_env_var_circular_flip_flop(replace_one: ReplaceOne, monkeypatch
     monkeypatch.setenv("TRAGIC", "{env:MAGIC}")
     monkeypatch.setenv("MAGIC", "{env:TRAGIC}")
     result = replace_one("{env:MAGIC}")
-    assert result == "{env:TRAGIC}"
+    assert result == "{env:MAGIC}"
 
 
 @pytest.mark.parametrize("fallback", [True, False])

--- a/tests/config/loader/ini/replace/test_replace_tox_env.py
+++ b/tests/config/loader/ini/replace/test_replace_tox_env.py
@@ -31,6 +31,23 @@ def test_replace_within_tox_env(example: EnvConfigCreator) -> None:
     assert result == "1"
 
 
+def test_replace_within_tox_env_chain(example: EnvConfigCreator) -> None:
+    env_config = example("r = 1\no = {r}/2\np = {r} {o}")
+    env_config.add_config(keys="r", of_type=str, default="r", desc="r")
+    env_config.add_config(keys="o", of_type=str, default="o", desc="o")
+    env_config.add_config(keys="p", of_type=str, default="p", desc="p")
+    result = env_config["p"]
+    assert result == "1 1/2"
+
+
+def test_replace_within_section_chain(tox_ini_conf: ToxIniCreator) -> None:
+    config = tox_ini_conf("[vars]\na = 1\nb = {[vars]a}/2\nc = {[vars]a}/3\n[testenv:a]\nd = {[vars]b} {[vars]c}")
+    env_config = config.get_env("a")
+    env_config.add_config(keys="d", of_type=str, default="d", desc="d")
+    result = env_config["d"]
+    assert result == "1/2 1/3"
+
+
 def test_replace_within_tox_env_missing_raises(example: EnvConfigCreator) -> None:
     env_config = example("o = {p}")
     env_config.add_config(keys="o", of_type=str, default="o", desc="o")

--- a/tests/config/loader/ini/replace/test_replace_tox_env.py
+++ b/tests/config/loader/ini/replace/test_replace_tox_env.py
@@ -7,7 +7,9 @@ import pytest
 
 from tests.config.loader.ini.replace.conftest import ReplaceOne
 from tests.conftest import ToxIniCreator
+from tox.config.loader.ini.replace import MAX_REPLACE_DEPTH
 from tox.config.sets import ConfigSet
+from tox.pytest import LogCaptureFixture
 from tox.report import HandledError
 
 EnvConfigCreator = Callable[[str], ConfigSet]
@@ -46,6 +48,30 @@ def test_replace_within_section_chain(tox_ini_conf: ToxIniCreator) -> None:
     env_config.add_config(keys="d", of_type=str, default="d", desc="d")
     result = env_config["d"]
     assert result == "1/2 1/3"
+
+
+@pytest.mark.parametrize("depth", [5, 99, 100, 101, 150, 256])
+def test_replace_within_section_chain_deep(caplog: LogCaptureFixture, tox_ini_conf: ToxIniCreator, depth: int) -> None:
+    config = tox_ini_conf(
+        "\n".join(
+            [
+                "[vars]",
+                "a0 = 1",
+                *(f"a{ix} = {{[vars]a{ix - 1}}}" for ix in range(1, depth + 1)),
+                "[testenv:a]",
+                "b = {[vars]a%s}" % depth,
+            ],
+        ),
+    )
+    env_config = config.get_env("a")
+    env_config.add_config(keys="b", of_type=str, default="b", desc="b")
+    result = env_config["b"]
+    if depth > MAX_REPLACE_DEPTH:
+        exp_stopped_at = "{[vars]a%s}" % (depth - MAX_REPLACE_DEPTH - 1)
+        assert result == exp_stopped_at
+        assert f"Could not expand {exp_stopped_at} after recursing {MAX_REPLACE_DEPTH + 1} frames" in caplog.messages
+    else:
+        assert result == "1"
 
 
 def test_replace_within_tox_env_missing_raises(example: EnvConfigCreator) -> None:

--- a/tests/config/test_set_env.py
+++ b/tests/config/test_set_env.py
@@ -108,7 +108,7 @@ def test_set_env_circular_use_os_environ(tox_project: ToxProjectCreator) -> None
     prj = tox_project({"tox.ini": "[testenv]\npackage=skip\nset_env=a={env:b}\n b={env:a}"})
     result = prj.run("c", "-e", "py")
     result.assert_success()
-    assert "replace failed in py.set_env with ValueError" in result.out, result.out
+    assert "replace failed in py.set_env with MatchRecursionError" in result.out, result.out
     assert "circular chain between set env a, b" in result.out, result.out
 
 


### PR DESCRIPTION
# Recursive Replace

Expand substitution expressions that result from a previous substitution expression replacement value (up to 100 times).

Add a new `MatchRecursionError` and stack depth tracking to avoid infinite recursion or python throwing a RecursionError and blowing up tox. Instead, log an error and take the last value as-is, which is what tox did prior to 4.3.0.

The behavior with this patch is more similar to pre-4.3.0 parser changes with the **large caveat** that replacement values are themselves expanded _within their own context only_, previously the value was replaced into the original string and the entire result was re-expanded, which led to some strange edge cases when expansions contained un-escaped special characters.

Fix #2863 

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
