### PR TITLE
Fix rendering of `version_added`

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -303,7 +303,7 @@ Base options
 .. conf::
    :keys: parallel_show_output
    :default: False
-    :version_added: 3.7
+   :version_added: 3.7
 
    If set to ``True`` the content of the output will always be shown  when running in parallel mode.
 


### PR DESCRIPTION
Noticed this while reading the documentation. This is currently [rendered as raw text](https://tox.wiki/en/latest/config.html#parallel_show_output) due to the incorrect indentation.

I read the checklist below but think this change is too small to warrant cloning the repo. Please let me know if you think otherwise, though!

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
