### PR TITLE
Fix a incorrect config key name

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -600,7 +600,7 @@ Python run
    :version_added: 4.0
    :default: <package_env>-<python-flavor-lowercase><python-version-no-dot>
 
-   If :ref:`wheel_build_env` is set to ``wheel`` this will be the tox Python environment in which the wheel will be
+   If :ref:`package` is set to ``wheel`` this will be the tox Python environment in which the wheel will be
    built. The value is generated to be unique per Python flavor and version, and prefixed with :ref:`package_env` value.
    This is to ensure the target interpreter and the generated wheel will be compatible. If you have a wheel that can be
    reused across multiple Python versions set this value to the same across them (to avoid building a new wheel for


### PR DESCRIPTION
It appears that the referenced config key should be `package`, not `wheel_build_env`.

I read the checklist below but this change seems too small. Please let me know if these items need to be followed even for this change! 👍

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
