### PR TITLE
Fix typos in `{tox_root}` variable name

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -448,7 +448,7 @@ Run
 
 .. conf::
    :keys: change_dir, changedir
-   :default: {tox root}
+   :default: {tox_root}
 
    Change to this working directory when executing the test command. If the directory does not exist yet, it will be
    created (required for Windows to be able to execute any command).
@@ -653,7 +653,7 @@ tox supports operating with externally built packages. External packages might b
 
 .. conf::
    :keys: change_dir, changedir
-   :default: {tox root}
+   :default: {tox_root}
    :ref_suffix: external
 
    Change to this working directory when executing the package build command. If the directory does not exist yet, it


### PR DESCRIPTION
Noticed this while reading the documentation.

I think this change is too small to fill in the checkboxes below, but please let me know if I need to complete those items.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
