### PR TITLE
Fix regression with multiple env substitutions for the same key

### DIFF
--- a/docs/changelog/2869.bugfix.rst
+++ b/docs/changelog/2869.bugfix.rst
@@ -1,0 +1,5 @@
+Fix regression introduced in 4.3.0 which occured when a substitution expression
+for an environment variable that had previously been substituted appears in the
+ini file after a substitution expression for a different environment variable.
+This situation erroneously resulted in an exception about "circular chain
+between set" of those variables - by :user:`masenf`.

--- a/tests/config/loader/ini/replace/test_replace_env_var.py
+++ b/tests/config/loader/ini/replace/test_replace_env_var.py
@@ -75,6 +75,20 @@ def test_replace_env_missing_default_from_env(replace_one: ReplaceOne, monkeypat
     assert result == "yes"
 
 
+def test_replace_env_var_multiple(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
+    """Multiple env substitutions on a single line."""
+    monkeypatch.setenv("MAGIC", "MAGIC")
+    monkeypatch.setenv("TRAGIC", "TRAGIC")
+    result = replace_one("{env:MAGIC} {env:TRAGIC} {env:MAGIC}")
+    assert result == "MAGIC TRAGIC MAGIC"
+
+
+def test_replace_env_var_multiple_default(replace_one: ReplaceOne) -> None:
+    """Multiple env substitutions on a single line with default values."""
+    result = replace_one("{env:MAGIC:foo} {env:TRAGIC:bar} {env:MAGIC:baz}")
+    assert result == "foo bar baz"
+
+
 def test_replace_env_var_circular(replace_one: ReplaceOne, monkeypatch: MonkeyPatch) -> None:
     """Replacement values will not infinitely loop"""
     monkeypatch.setenv("MAGIC", "{env:MAGIC}")


### PR DESCRIPTION
Fix regression introduced in 4.3.0 which occured when a substitution expression for an environment variable that had previously been substituted appears in the ini file after a substitution expression for a different environment variable.

This situation erroneously resulted in an exception about "circular chain between set" of those variables.

Before the [substitution parser rewrite](https://github.com/tox-dev/tox/pull/2861), args was being copied in the `replace` function: https://github.com/tox-dev/tox/blob/955a7fb8864a9e682ec91589e0c10115ab6fa6a5/src/tox/config/loader/ini/replace.py#L35

This patch restores the previous behavior by copying `conf_args` at the beginning of `_replace_match`.

This change also preserves recursive chain detection logic by passing the copied `conf_args` back into `replace` when recursively expanding a previous replacement so that any values saved in the chain during the previous replace are present for the recursive replace (test case added in [previous commit](https://github.com/tox-dev/tox/commit/52fed1072f9d0ef36042f605fa2377963aababb4)).

Fix #2869 

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
