### PR TITLE
PoC to fix posargs issue.

### DIFF
--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -265,7 +265,8 @@ class EnvSelector:
                 package_tox_env = self._get_package_env(core_type, name, active.get(name, missing_active))
                 self._pkg_env_counter[name] += 1
                 run_env: RunToxEnv = self._defined_envs_[run_env_name].env  # type: ignore
-                child_package_envs = package_tox_env.register_run_env(run_env)
+                is_active: bool = self._defined_envs_[run_env_name].is_active
+                child_package_envs = package_tox_env.register_run_env(run_env, is_active)
                 try:
                     name_type = next(child_package_envs)
                     while True:

--- a/src/tox/tox_env/package.py
+++ b/src/tox/tox_env/package.py
@@ -91,7 +91,9 @@ class PackageToxEnv(ToxEnv, ABC):
     def perform_packaging(self, for_env: EnvConfigSet) -> list[Package]:
         raise NotImplementedError
 
-    def register_run_env(self, run_env: RunToxEnv, is_active: bool=True) -> Generator[tuple[str, str], PackageToxEnv, None]:  # noqa: U100
+    def register_run_env(
+        self, run_env: RunToxEnv, is_active: bool = True
+    ) -> Generator[tuple[str, str], PackageToxEnv, None]:  # noqa: U100
         yield from ()  # empty generator by default
 
     def mark_active_run_env(self, run_env: RunToxEnv) -> None:

--- a/src/tox/tox_env/package.py
+++ b/src/tox/tox_env/package.py
@@ -91,7 +91,7 @@ class PackageToxEnv(ToxEnv, ABC):
     def perform_packaging(self, for_env: EnvConfigSet) -> list[Package]:
         raise NotImplementedError
 
-    def register_run_env(self, run_env: RunToxEnv) -> Generator[tuple[str, str], PackageToxEnv, None]:  # noqa: U100
+    def register_run_env(self, run_env: RunToxEnv, is_active: bool=True) -> Generator[tuple[str, str], PackageToxEnv, None]:  # noqa: U100
         yield from ()  # empty generator by default
 
     def mark_active_run_env(self, run_env: RunToxEnv) -> None:

--- a/src/tox/tox_env/python/package.py
+++ b/src/tox/tox_env/python/package.py
@@ -4,6 +4,7 @@ A tox build environment that handles Python packages.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator, Iterator, List, Sequence, cast
 
@@ -16,7 +17,6 @@ from ..package import Package, PackageToxEnv, PathPackage
 from ..runner import RunToxEnv
 from .api import NoInterpreter, Python
 from .pip.req_file import PythonDeps
-from functools import partial
 
 if TYPE_CHECKING:
     from tox.config.main import Config
@@ -63,7 +63,9 @@ class PythonPackageToxEnv(Python, PackageToxEnv, ABC):
     def requires(self) -> tuple[Requirement, ...] | PythonDeps:
         raise NotImplementedError
 
-    def register_run_env(self, run_env: RunToxEnv, is_active: bool=True) -> Generator[tuple[str, str], PackageToxEnv, None]:
+    def register_run_env(
+        self, run_env: RunToxEnv, is_active: bool = True
+    ) -> Generator[tuple[str, str], PackageToxEnv, None]:
         yield from super().register_run_env(run_env, is_active)
         if run_env.conf["package"] != "skip" and "deps" not in self.conf:
             self.conf.add_config(

--- a/src/tox/tox_env/python/virtual_env/package/cmd_builder.py
+++ b/src/tox/tox_env/python/virtual_env/package/cmd_builder.py
@@ -119,8 +119,8 @@ class VirtualEnvCmdBuilder(PythonPackageToxEnv, VirtualEnv):
             package = SdistPackage(path, dependencies_with_extras(deps, extras, name))
         return [package]
 
-    def register_run_env(self, run_env: RunToxEnv) -> Generator[tuple[str, str], PackageToxEnv, None]:
-        yield from super().register_run_env(run_env)
+    def register_run_env(self, run_env: RunToxEnv, is_active:bool=True) -> Generator[tuple[str, str], PackageToxEnv, None]:
+        yield from super().register_run_env(run_env, is_active)
         # in case the outcome is a sdist we'll use this to find out its metadata
         result = yield f"{self.conf.name}_sdist_meta", Pep517VirtualEnvPackager.id()
         self._sdist_meta_tox_env = cast(Pep517VirtualEnvPackager, result)

--- a/src/tox/tox_env/python/virtual_env/package/cmd_builder.py
+++ b/src/tox/tox_env/python/virtual_env/package/cmd_builder.py
@@ -119,7 +119,9 @@ class VirtualEnvCmdBuilder(PythonPackageToxEnv, VirtualEnv):
             package = SdistPackage(path, dependencies_with_extras(deps, extras, name))
         return [package]
 
-    def register_run_env(self, run_env: RunToxEnv, is_active:bool=True) -> Generator[tuple[str, str], PackageToxEnv, None]:
+    def register_run_env(
+        self, run_env: RunToxEnv, is_active: bool = True
+    ) -> Generator[tuple[str, str], PackageToxEnv, None]:
         yield from super().register_run_env(run_env, is_active)
         # in case the outcome is a sdist we'll use this to find out its metadata
         result = yield f"{self.conf.name}_sdist_meta", Pep517VirtualEnvPackager.id()

--- a/src/tox/tox_env/python/virtual_env/package/pyproject.py
+++ b/src/tox/tox_env/python/virtual_env/package/pyproject.py
@@ -137,7 +137,9 @@ class Pep517VirtualEnvPackager(PythonPackageToxEnv, VirtualEnv):
         meta_folder.mkdir(exist_ok=True)
         return meta_folder
 
-    def register_run_env(self, run_env: RunToxEnv, is_active: bool=True) -> Generator[tuple[str, str], PackageToxEnv, None]:
+    def register_run_env(
+        self, run_env: RunToxEnv, is_active: bool = True
+    ) -> Generator[tuple[str, str], PackageToxEnv, None]:
         yield from super().register_run_env(run_env, is_active)
         build_type = run_env.conf["package"]
         self.builds[build_type].append(run_env.conf)

--- a/src/tox/tox_env/python/virtual_env/package/pyproject.py
+++ b/src/tox/tox_env/python/virtual_env/package/pyproject.py
@@ -137,8 +137,8 @@ class Pep517VirtualEnvPackager(PythonPackageToxEnv, VirtualEnv):
         meta_folder.mkdir(exist_ok=True)
         return meta_folder
 
-    def register_run_env(self, run_env: RunToxEnv) -> Generator[tuple[str, str], PackageToxEnv, None]:
-        yield from super().register_run_env(run_env)
+    def register_run_env(self, run_env: RunToxEnv, is_active: bool=True) -> Generator[tuple[str, str], PackageToxEnv, None]:
+        yield from super().register_run_env(run_env, is_active)
         build_type = run_env.conf["package"]
         self.builds[build_type].append(run_env.conf)
 


### PR DESCRIPTION
This is a PoC PR to demonstrates the problem and a possible quick fix of the `posargs` replacement issue mentioned in https://github.com/tox-dev/tox/issues/2860. It propagates the `active` flag to the `default_wheel_tag` function to avoid `posargs` replacement.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
