### PR TITLE
Provision cwd

### DIFF
--- a/docs/changelog/2876.bugfix.rst
+++ b/docs/changelog/2876.bugfix.rst
@@ -1,0 +1,7 @@
+When executing via the provisioning environment (``.tox`` by default), run
+``tox`` in working directory of the parent process.
+
+Prior to this change (from tox 4.0.0), the provisioned ``tox`` would execute with
+``{tox_root}`` as the working directory, which breaks when a relative path is
+passed to ``-c`` or ``--conf`` and ``tox`` is executed in a working directory
+other than ``{tox_root}`` - by :user:`masenf`.

--- a/src/tox/provision.py
+++ b/src/tox/provision.py
@@ -150,5 +150,5 @@ def run_provision(name: str, state: State) -> int:
         raise HandledError(f"cannot provision tox environment {tox_env.conf['env_name']} because {exception}")
     args: list[str] = [str(env_python), "-m", "tox"]
     args.extend(state.args)
-    outcome = tox_env.execute(cmd=args, stdin=StdinSource.user_only(), show=True, run_id="provision")
+    outcome = tox_env.execute(cmd=args, stdin=StdinSource.user_only(), show=True, run_id="provision", cwd=Path.cwd())
     return cast(int, outcome.exit_code)

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -212,3 +212,17 @@ def test_provision_plugin_runner_in_provision(tox_project: ToxProjectCreator, tm
     proj = tox_project({"tox.ini": "[tox]\nrequires=somepkg123xyz\n[testenv:.tox]\nrunner=example"})
     with pytest.raises(KeyError, match="example"):
         proj.run("r", "-e", "py", "--result-json", str(log))
+
+
+@pytest.mark.integration()
+@pytest.mark.usefixtures("_pypi_index_self")
+@pytest.mark.parametrize("relative_path", [True, False], ids=["relative", "absolute"])
+def test_provision_conf_file(tox_project: ToxProjectCreator, tmp_path: Path, relative_path: bool) -> None:
+    ini = "[tox]\nrequires = demo-pkg-inline\nskipsdist=true\n"
+    project = tox_project({"tox.ini": ini}, prj_path=tmp_path / "sub")
+    if relative_path:
+        conf_path = os.path.join(project.path.name, "tox.ini")
+    else:
+        conf_path = str(project.path / "tox.ini")
+    result = project.run("c", "--conf", conf_path, "-e", "py", from_cwd=tmp_path)
+    result.assert_success()


### PR DESCRIPTION
When executing via the provisioning environment, run ``tox`` in working directory of the parent process.

Prior to this change (from tox 4.0.0), the provisioned ``tox`` would execute with ``{tox_root}`` as the working directory, which breaks when a relative path is passed to ``-c`` or ``--conf`` and ``tox`` is executed in a working directory other than ``{tox_root}``.

Fix #2876

# Testing

The included integration test passes with the absolute path and fails with the relative path prior to this change.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
