### PR TITLE
Fix the type annotation for `color` param of `Spinner.finalize()`

### DIFF
--- a/docs/changelog/2878.misc.rst
+++ b/docs/changelog/2878.misc.rst
@@ -1,0 +1,1 @@
+* Fix an incorrect type annotation for the ``color`` parameter in ``Spinner.finalize()``.

--- a/src/tox/util/spinner.py
+++ b/src/tox/util/spinner.py
@@ -138,7 +138,7 @@ class Spinner:
     def skip(self, key: str) -> None:
         self.finalize(key, f"SKIP {self.outcome.skip}", Fore.YELLOW)
 
-    def finalize(self, key: str, status: str, color: int) -> None:
+    def finalize(self, key: str, status: str, color: str) -> None:
         start_at = self._envs.pop(key, None)
         if self.enabled:
             self.clear()


### PR DESCRIPTION
Colorama's ANSI class attributes are defined as ints. However, when an ANSI class is instantiated (say, when the `AnsiFore` class is instantiated as `Fore`), instance attributes with identical names are dynamically created, but the attributes are strings containing ANSI escape sequences.

Thus, `AnsiFore.YELLOW` is an int, while `Fore.YELLOW` is a str. mypy 0.991 isn't catching this discrepancy, but PyCharm did.

Closes #2878.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix

  _mypy didn't notice a problem before or after the fix, so I don't see a way to test this._

- [x] added news fragment in `docs/changelog` folder

- [ ] updated/extended the documentation

  _This doesn't seem necessary for this type of change. Please correct me if I'm wrong!_
