### PR TITLE
Windows shlex: use `posix=True`

### DIFF
--- a/docs/changelog/2635.bugfix.rst
+++ b/docs/changelog/2635.bugfix.rst
@@ -1,0 +1,13 @@
+When parsing command lines, use ``shlex(..., posix=True)``, even on windows
+platforms, since non-POSIX mode does not handle escape characters and quoting
+like a shell would. This improves cross-platform configurations without hacks
+or esoteric quoting.
+
+To make this transition easier, on windows, the backslash path separator will
+not treated as an escape character unless it preceeds a quote, whitespace, or
+another backslash chracter. This allows paths to mostly be written in single or
+double backslash style.
+
+In some instances superfluous double or single quote characters may be stripped
+from arg arrays in ways that do not occur in the default windows ``cmd.exe``
+shell.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -433,6 +433,16 @@ Run
 
    .. note::
 
+       ``shlex`` POSIX-mode quoting rules are used to split the command line into arguments on all
+       supported platforms as of tox 4.4.0.
+
+       The backslash ``\`` character can be used to escape quotes, whitespace, itself, and
+       other characters (except on Windows, where a backslash in a path will not be interpreted as an escape).
+       Unescaped single quote will disable the backslash escape until closed by another unescaped single quote.
+       For more details, please see :doc:`shlex parsing rules <python:library/shlex>`.
+
+   .. note::
+
      Inline scripts can be used, however note these are discovered from the project root directory, and is not
      influenced by :ref:`change_dir` (this only affects the runtime current working directory). To make this behaviour
      explicit we recommend that you make inline scripts absolute paths by prepending ``{tox_root}``, instead of


### PR DESCRIPTION
This change only affects windows platforms.

Switch away from non-standard and confusing `shlex.shlex` semantics in favor of using POSIX-mode everywhere (almost). On windows, there is a routine that checks for backslashes that look like path separators, and then explicitly escapes those before passing off to `shlex`.

Before this change, it was frustratingly difficult to write any sort of complex command with substitutions and quoting and have it work well cross platform. Now that both windows and non-windows split the args the same way, it's easier to have commands mostly work the same way.

See changelog and doc update for more exposition.

Fix #2635 (windows)

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
