### PR TITLE
pip_install: constrain_package_deps is now False by default

### DIFF
--- a/docs/changelog/2897.bugfix.rst
+++ b/docs/changelog/2897.bugfix.rst
@@ -1,0 +1,2 @@
+In tox 4.4.0 ``constrain_package_deps`` was introduced with a default value of ``True``. This has been changed back to
+``False``, which restores the original behavior of tox 4.3.5 - by :user:`masenf`.

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -42,7 +42,7 @@ class Pip(Installer[Python]):
         self._env.conf.add_config(
             keys=["constrain_package_deps"],
             of_type=bool,
-            default=True,
+            default=False,
             desc="If true, apply constraints during install_package_deps.",
         )
         self._env.conf.add_config(


### PR DESCRIPTION
workaround for #2897 and #2898

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
