### PR TITLE
Support recursive extras defined in pyproject.toml 

### DIFF
--- a/docs/changelog/2904.bugfix.rst
+++ b/docs/changelog/2904.bugfix.rst
@@ -1,0 +1,3 @@
+Tox will now expand self-referential extras discovered in package deps to respect local modifications to package
+metadata. This allows a package extra to explicitly depend on another package extra, which previously only worked with
+non-static metadata - by :user:`masenf`.

--- a/src/tox/tox_env/python/virtual_env/package/util.py
+++ b/src/tox/tox_env/python/virtual_env/package/util.py
@@ -8,7 +8,14 @@ from packaging.requirements import Requirement
 
 
 def dependencies_with_extras(deps: list[Requirement], extras: set[str], package_name: str) -> list[Requirement]:
-    deps_with_markers = extract_extra_markers(deps)
+    return dependencies_with_extras_from_markers(extract_extra_markers(deps), extras, package_name)
+
+
+def dependencies_with_extras_from_markers(
+    deps_with_markers: list[tuple[Requirement, set[str | None]]],
+    extras: set[str],
+    package_name: str,
+) -> list[Requirement]:
     result: list[Requirement] = []
     found: set[str] = set()
     todo: set[str | None] = extras | {None}

--- a/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 
@@ -91,6 +92,33 @@ def test_package_root_via_testenv(tox_project: ToxProjectCreator, demo_pkg_inlin
             "",
             ["A"],
             id="deps_with_dynamic_optional_no_extra",
+        ),
+        pytest.param(
+            dedent(
+                """
+                [project]
+                name='foo'
+                dependencies=['A']
+                optional-dependencies.alpha=['B']
+                optional-dependencies.beta=['foo[alpha]']""",
+            ),
+            "beta",
+            ["A", "B"],
+            id="deps_with_recursive_extra",
+        ),
+        pytest.param(
+            dedent(
+                """
+                [project]
+                name='foo'
+                dependencies=['A']
+                optional-dependencies.alpha=['B']
+                optional-dependencies.beta=['foo[alpha]']
+                optional-dependencies.delta=['foo[beta]', 'D']""",
+            ),
+            "delta",
+            ["A", "B", "D"],
+            id="deps_with_two_recursive_extra",
         ),
     ],
 )

--- a/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
@@ -98,6 +98,18 @@ def test_package_root_via_testenv(tox_project: ToxProjectCreator, demo_pkg_inlin
                 """
                 [project]
                 name='foo'
+                dependencies=['foo[alpha]']
+                optional-dependencies.alpha=['A']""",
+            ),
+            "",
+            ["A"],
+            id="deps_reference_extra",
+        ),
+        pytest.param(
+            dedent(
+                """
+                [project]
+                name='foo'
                 dependencies=['A']
                 optional-dependencies.alpha=['B']
                 optional-dependencies.beta=['foo[alpha]']""",

--- a/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
@@ -132,6 +132,18 @@ def test_package_root_via_testenv(tox_project: ToxProjectCreator, demo_pkg_inlin
             ["A", "B", "D"],
             id="deps_with_two_recursive_extra",
         ),
+        pytest.param(
+            dedent(
+                """
+                [project]
+                name='foo'
+                optional-dependencies.alpha=['foo[beta]', 'A']
+                optional-dependencies.beta=['foo[alpha]', 'B']""",
+            ),
+            "alpha",
+            ["A", "B"],
+            id="deps_with_circular_recursive_extra",
+        ),
     ],
 )
 def test_pyproject_deps_from_static(


### PR DESCRIPTION
With this change, tox will now expand self-referential extras discovered in package deps to respect local modifications to package metadata. This allows a package extra to explicitly depend on another package extra, which previously only worked with non-static metadata.

Fix #2904 

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
