### PR TITLE
fix assertions in test_graph to actually test results

### DIFF
--- a/tests/util/test_graph.py
+++ b/tests/util/test_graph.py
@@ -33,7 +33,7 @@ def test_topological_order_cycle() -> None:
     graph: dict[str, set[str]] = OrderedDict()
     graph["A"] = {"B", "C"}
     graph["B"] = {"A"}
-    with pytest.raises(ValueError, match="A | B"):
+    with pytest.raises(ValueError, match=r"^A \| B$"):
         stable_topological_sort(graph)
 
 
@@ -68,5 +68,5 @@ def test_two_sub_graph_circle() -> None:
     graph["A"] = {"B", "C"}
     graph["B"] = {"A"}
     graph["C"] = set()
-    with pytest.raises(ValueError, match="A | B"):
+    with pytest.raises(ValueError, match=r"^A \| B$"):
         stable_topological_sort(graph)


### PR DESCRIPTION
I used this as an example in an upcoming video -- the current code doesn't properly validate the exception messages for two reasons (1) the `|` character allows it to unintentionally match a substring (for example `raise ValueError("A cycle was detected")` passes the test) and (2) the `match` argument uses `re.search` to find the substring match

personally I recommend not using `match=` at all and instead assert based on the `excinfo` object -- but this is the minimal "correct" change without annoying the PT011 linter