### PR TITLE
Forward `HOME` by default

### DIFF
--- a/docs/changelog/2702.bugfix.rst
+++ b/docs/changelog/2702.bugfix.rst
@@ -1,0 +1,1 @@
+Forward ``HOME`` by default - by :user:`gschaffner`.

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -218,6 +218,7 @@ class ToxEnv(ABC):
             "CPPFLAGS",  # C++ compiler flags
             "LD_LIBRARY_PATH",  # location of libs
             "LDFLAGS",  # linker flags
+            "HOME",  # needed for `os.path.expanduser()` on non-Windows systems
         ]
         if sys.stdout.isatty():  # if we're on a interactive shell pass on the TERM
             env.append("TERM")

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -117,7 +117,7 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
     expected = (
         ["CC", "CCSHARED", "CFLAGS"]
         + (["COMSPEC"] if is_win else [])
-        + ["CPPFLAGS", "CURL_CA_BUNDLE", "CXX", "LANG", "LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH"]
+        + ["CPPFLAGS", "CURL_CA_BUNDLE", "CXX", "HOME", "LANG", "LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH"]
         + (["MSYSTEM", "NUMBER_OF_PROCESSORS", "PATHEXT"] if is_win else [])
         + ["PIP_*", "PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_SYSROOT_DIR"]
         + (["PROCESSOR_ARCHITECTURE"] if is_win else [])


### PR DESCRIPTION
this ensures that `os.path.expanduser` and `pathlib.Path.expanduser` work by default inside a tox environment on non-Windows systems, including those without `/etc/passwd`.

fixes #2702.

this patch is analogous to #519.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
  * i haven't done this because it is nontrivial to add tests that run on a system without `/etc/passwd`. the easiest way to get such a system is an OCI container, e.g.
    ```bash
    #!/usr/bin/env -S sh -c '< "$0" podman run --rm -i -v "$(dirname "$(realpath "$0")")":/tox-ro:ro nixery.dev/bash/coreutils/python311/git bash "$@"'

    set -o errexit -o errtrace -o nounset -o pipefail
    shopt -s inherit_errexit

    cd "$(mktemp -d)"
    python -m venv .venv &> /dev/null
    . .venv/bin/activate
    cp -r /tox-ro /tox

    set -o xtrace

    pip install -q /tox
    mkdir proj
    cd proj
    mkdir -p src/hello
    touch pyproject.toml src/hello/__init__.py
    printenv HOME
    cat /etc/passwd || true
    tox --colored yes
    ```
    but it's perhaps not worth the overhead to do that for this somewhat esoteric test.
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
  * i haven't done this because the default `pass_env` on various platforms is not documented: https://github.com/tox-dev/tox/blob/079f839d819f03413939409c58930d14017fd84f/docs/config.rst?plain=1#L279-L281