### PR TITLE
Ignore labels when provisioning

### DIFF
--- a/docs/changelog/2916.bugfix.rst
+++ b/docs/changelog/2916.bugfix.rst
@@ -1,0 +1,3 @@
+Ignore labels when tox will provision a runtime environment (``.tox``) so that environment configurations which depend
+on provisioned plugins or specific tox versions are not accessed in the outer tox process where the configuration would
+be invalid - by :user:`masenf`.

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -315,7 +315,8 @@ class EnvSelector:
         if labels or factors:
             for env_info in self._defined_envs_.values():
                 env_info.is_active = False  # if any was selected reset
-            if labels:
+            # ignore labels when provisioning will occur
+            if labels and (self._provision is None or not self._provision[0]):
                 for label in labels:
                     for env_name in self._state.conf.core["labels"].get(label, []):
                         self._defined_envs_[env_name].is_active = True


### PR DESCRIPTION
# Thanks for contribution

Ignore labels when tox will provision a runtime environment (``.tox``) so that environment configurations which depend on provisioned plugins or specific tox versions are not accessed in the outer tox process where the configuration would be invalid.

Extend existing [`test_provision_plugin_runner`](https://github.com/tox-dev/tox/commit/b26a1b95b9aa54d70ba9a1f5bd084a5fe70f08bc) to also run using labels, which catches this regression.

Fix #2916 

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
