### PR TITLE
Add link to our own disucssion board

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 # Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: true # default
 contact_links:
-  - name: 🤷💻🤦 Discourse
-    url: https://discuss.python.org/c/packaging
+  - name: 🤷💻🤦 Discussions
+    url: https://github.com/tox-dev/tox/discussions
     about: |
-      Please ask typical Q&A here: general ideas for Python packaging, questions about structuring projects and so on
+      Ask typical Q&A here. Please note that we cannot give support about Python packaging in general, questions about structuring projects and so on.
   - name: 📝 PyPA Code of Conduct
     url: https://www.pypa.io/en/latest/code-of-conduct/
     about: ❤ Be nice to other members of the community. ☮ Behave.


### PR DESCRIPTION
Previously, we had a link to Python's discourse board which caused some confusion.

Instead, now there is a link to our own discussion board, but also a clear note that we cannot give support for general packaging related questions.