### PR TITLE
docs(config): fix temp_dir default value

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -174,7 +174,7 @@ Core
 
 .. conf::
    :keys: temp_dir
-   :default: {tox_root}/.tmp
+   :default: {work_dir}/.tmp
 
    Directory where to put tox temporary files. For example: we create a hard link (if possible, otherwise new copy) in
    this directory for the project package. This ensures tox works correctly when having parallel runs (as each session


### PR DESCRIPTION
I noticed an error in the docs regarding `temp_dir` and created a discussion for it.

Ref: https://github.com/tox-dev/tox/discussions/2930