### PR TITLE
docs: set html_last_updated_fmt to format string

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
-from datetime import date, datetime
+from datetime import date
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from subprocess import check_output
@@ -26,7 +26,7 @@ copyright = f"2010-{date.today().year}, {company}"
 master_doc, source_suffix = "index", ".rst"
 
 html_theme = "furo"
-html_title, html_last_updated_fmt = "tox", datetime.now().isoformat()
+html_title, html_last_updated_fmt = "tox", "%Y-%m-%dT%H:%M:%S"
 pygments_style, pygments_dark_style = "sphinx", "monokai"
 html_static_path, html_css_files = ["_static"], ["custom.css"]
 html_logo, html_favicon = "_static/img/tox.svg", "_static/img/toxfavi.ico"


### PR DESCRIPTION
According to the Sphinx documentation and source code, html_last_updated_fmt is supposed to be a strftime()-like format string, not a literal string with a date.

Instead of datetime.now().isoformat, set this to the equivalent format string (sans microseconds, as Sphinx does not support %f).

This is a no-op generally. However, unlike our implementation here, Sphinx's date generation obeys SOURCE_DATE_EPOCH, which means that the builds will now be able to be built reproducibly.

Also see https://github.com/tox-dev/pyproject-api/issues/53 for context and https://github.com/tox-dev/pyproject-api/pull/54 for the equivalent PR there.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix (not necessary I believe)
- [x] added news fragment in `docs/changelog` folder (too trivial to document?)
- [x] updated/extended the documentation (not needed)
