### PR TITLE
Include `tox.ini` in sdist to fix tests

### DIFF
--- a/docs/changelog/2939.bugfix.rst
+++ b/docs/changelog/2939.bugfix.rst
@@ -1,0 +1,1 @@
+``tox.ini`` is now included in source distributions in order to make all tests pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ scripts.tox = "tox.run:run"
 [tool.hatch]
 build.dev-mode-dirs = ["src"]
 build.hooks.vcs.version-file = "src/tox/version.py"
-build.targets.sdist.include = ["/src", "/tests"]
+build.targets.sdist.include = ["/src", "/tests", "/tox.ini"]
 version.source = "vcs"
 
 [tool.black]


### PR DESCRIPTION
Include the `tox.ini` file in sdist, in order to fix a few test failures due to an additional error message printed by tox, i.e.:

    FAILED tests/config/cli/test_parse.py::test_verbosity_guess_miss_match - AssertionError: assert 'ROOT: No tox.ini or setup.cfg or pyproject.toml found, assuming empty tox.ini at /tmp/portage/dev-python/t...
    FAILED tests/config/loader/test_loader.py::test_override_incorrect[-x] - AssertionError: assert not 'ROOT: No tox.ini or setup.cfg or pyproject.toml found, assuming empty tox.ini at /tmp/portage/dev-pyth...
    FAILED tests/config/loader/test_loader.py::test_override_incorrect[--override] - AssertionError: assert not 'ROOT: No tox.ini or setup.cfg or pyproject.toml found, assuming empty tox.ini at /tmp/portage/dev-pyth...

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix (existing tests suffice)
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation (n/a)
