### PR TITLE
docs: remove (dynamic) years from copyright

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
-from datetime import date
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from subprocess import check_output
@@ -22,7 +21,7 @@ from tox import __version__
 
 company, name = "tox-dev", "tox"
 release, version = __version__, ".".join(__version__.split(".")[:2])
-copyright = f"2010-{date.today().year}, {company}"
+copyright = f"{company}"
 master_doc, source_suffix = "index", ".rst"
 
 html_theme = "furo"


### PR DESCRIPTION
Setting copyright programatically to a range up to datetime.today() is legally dubious. It effectively signals that the copyright changes/extends whenever a downstream (perhaps even not holding no copyright of their own) builds the documentation, rather than when the code was authored. I do not believe this to be the case in any jurisdiction.

Rather than replace it with a static year (2023 currently) and then keep updating it on a yearly basis, remove the years altogether, as they serve little purpose: the dates are readily available through git, changelogs, PyPI etc. This follows what other projects have done or are in the process of doing as well; for example, see:
  https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/
  https://hynek.me/til/copyright-years/

As a side-effect and primary motivation for this commit, this resolves a rather small build reproducibility (FTBR) issue, where builds in different years would yield different outputs.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
