### PR TITLE
Change stderr color to grey instead of red

### DIFF
--- a/src/tox/execute/api.py
+++ b/src/tox/execute/api.py
@@ -121,7 +121,11 @@ class Execute(ABC):
             # collector is what forwards the content from the file streams to the standard streams
             out, err = out_err[0].buffer, out_err[1].buffer
             out_sync = SyncWrite(out.name, out if show else None)
-            err_sync = SyncWrite(err.name, err if show else None, Fore.RED if self._colored else None)
+            err_sync = SyncWrite(
+                err.name,
+                err if show else None,
+                Fore.LIGHTBLACK_EX if self._colored else None,  # noqa: SC200
+            )
             with out_sync, err_sync:
                 instance = self.build_instance(request, self._option_class(env), out_sync, err_sync)
                 with instance as status:
@@ -254,7 +258,7 @@ class Outcome:
                 if not self.out.endswith("\n"):
                     sys.stdout.write("\n")
             if self.err:
-                sys.stderr.write(Fore.RED)
+                sys.stderr.write(Fore.LIGHTBLACK_EX)  # noqa: SC200
                 sys.stderr.write(self.err)
                 sys.stderr.write(Fore.RESET)
                 if not self.err.endswith("\n"):

--- a/tests/execute/local_subprocess/test_local_subprocess.py
+++ b/tests/execute/local_subprocess/test_local_subprocess.py
@@ -67,7 +67,7 @@ def test_local_execute_basic_pass(
     out_got, err_got = out_err.read_out_err()
     if show:
         assert out_got == out
-        expected = (f"{Fore.RED}{err}{Fore.RESET}" if color else err) if err else ""
+        expected = (f"{Fore.LIGHTBLACK_EX}{err}{Fore.RESET}" if color else err) if err else ""
         assert err_got == expected
     else:
         assert not out_got
@@ -179,7 +179,7 @@ def test_local_execute_basic_fail(capsys: CaptureFixture, caplog: LogCaptureFixt
 
     out, err = capsys.readouterr()
     assert out == "out\n"
-    expected = f"{Fore.RED}err{Fore.RESET}\n"
+    expected = f"{Fore.LIGHTBLACK_EX}err{Fore.RESET}\n"
     assert err == expected
 
     assert len(caplog.records) == 1


### PR DESCRIPTION
As stderr is more use for logging than display errors, we better avoid using red and go for a neutral gray color.

This should avoid visual strain on users or confusions about presence of red colour on logs, which is almost always a sign of a important, usually fatal, error.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

# Before

![](https://sbarnea.com/ss/Screen-Shot-2023-03-14-15-05-41.56.png)

# After
![](https://sbarnea.com/ss/Screen-Shot-2023-03-14-15-05-14.02.png)