### PR TITLE
GitHub Actions: Install multiple versions of Python in a single job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,12 +16,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py:
-          - "3.11"
-          - "3.10"
-          - "3.9"
-          - "3.8"
-          - "3.7"
         os:
           - ubuntu-22.04
           - windows-2022
@@ -30,20 +24,21 @@ jobs:
       - name: Setup python for tox
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: |
+            3.7
+            3.8
+            3.9
+            3.10
+            3.11
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install self-tox
         run: python -m pip install .
-      - name: Setup python for test ${{ matrix.py }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.py }}
       - name: Setup test suite
-        run: tox r -e py${{ matrix.py }} -vv --notest
+        run: tox r -e ALL -vv --notest
       - name: Run test suite
-        run: tox r -e py${{ matrix.py }} --skip-pkg-install
+        run: tox r -e ALL --skip-pkg-install
         env:
           CI_RUN: "yes"
           DIFF_AGAINST: HEAD


### PR DESCRIPTION
https://github.com/actions/setup-python/releases/tag/v4.4.0

This should be much faster without all the repeated setup and teardown. 
```
Run actions/setup-python@v4
Installed versions
  Successfully set up CPython (3.7.16)
  Successfully set up CPython (3.8.16)
  Successfully set up CPython (3.9.16)
  Successfully set up CPython (3.10.10)
  Successfully set up CPython (3.11.2)
```
The process of using `tox -e ALL` seems to work perfectly but the long build and test times are the deal breaker.
We end up with a single long-running process instead of multiple processes running in parallel.

# Thanks for your contribution

Please, make sure you address all the checklists (for details on how, see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added a news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
