### PR TITLE
Update documentation regarding ``homedir`` variable (upgrade to tox 4)

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -110,7 +110,7 @@ This will now result in a failure.
 Substitutions removed
 ---------------------
 
-- The ``distshare`` substitution has been removed.
+- The ``distshare`` and ``homedir`` substitutions have been removed.
 
 Disallowed env names
 --------------------


### PR DESCRIPTION
Seems like the ``homedir`` variable is not available anymore ([doc 3.27.1](compare https://tox.wiki/en/3.27.1/config.html#globally-available-substitutions) vs [doc 4.4.7](https://tox.wiki/en/4.4.7/config.html))
