### PR TITLE
Fix for requirements.txt using both --index-url and --find-links

### DIFF
--- a/docs/changelog/2959.bugfix.rst
+++ b/docs/changelog/2959.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``--index-url`` and ``--find-links`` being used together in ``requirements.txt`` files.

--- a/src/tox/tox_env/python/pip/req/file.py
+++ b/src/tox/tox_env/python/pip/req/file.py
@@ -323,14 +323,14 @@ class RequirementsFile:
         if opt.find_links:
             # FIXME: it would be nice to keep track of the source of the find_links: support a find-links local path
             # relative to a requirements file.
-            if not hasattr(base_opt, "index_url"):  # pragma: no branch
+            if not hasattr(base_opt, "find_links"):
                 base_opt.find_links = []
             value = opt.find_links[0]
             req_dir = os.path.dirname(os.path.abspath(filename))
             relative_to_reqs_file = os.path.join(req_dir, value)
             if os.path.exists(relative_to_reqs_file):
                 value = relative_to_reqs_file  # pragma: no cover
-            if value not in base_opt.find_links:  # pragma: no branch
+            if value not in base_opt.find_links:
                 base_opt.find_links.append(value)
         if opt.pre:
             base_opt.pre = True

--- a/tests/tox_env/python/pip/req/test_file.py
+++ b/tests/tox_env/python/pip/req/test_file.py
@@ -59,6 +59,16 @@ _REQ_FILE_TEST_CASES = [
         ["-f", "http://some.archives.com/archives"],
         id="find-links url",
     ),
+    pytest.param(
+        "--index-url a --find-links http://some.archives.com/archives",
+        {
+            "index_url": ["a"],
+            "find_links": ["http://some.archives.com/archives"],
+        },
+        [],
+        ["-i", "a", "-f", "http://some.archives.com/archives"],
+        id="index and find",
+    ),
     pytest.param("-i a", {"index_url": ["a"]}, [], ["-i", "a"], id="index url short"),
     pytest.param("--index-url a", {"index_url": ["a"]}, [], ["-i", "a"], id="index url long"),
     pytest.param("-i a -i b\n-i c", {"index_url": ["c"]}, [], ["-i", "c"], id="index url multiple"),


### PR DESCRIPTION
Without the fix, installation would fail with:

    AttributeError: 'Namespace' object has no attribute 'find_links'

when having both `--index-url` (or `--extra-index-url`) and `--find-links` in a `requirements.txt` file. Order could also be important, I didn't check.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
