### PR TITLE
Avoid UnicodeDecodeError from command output

### DIFF
--- a/docs/changelog/2969.bugfix.rst
+++ b/docs/changelog/2969.bugfix.rst
@@ -1,0 +1,3 @@
+Instead of raising ``UnicodeDecodeError`` when command output includes non-utf-8 bytes,
+``tox`` will now use ``surrogateescape`` error handling to convert the unrecognized bytes
+to escape sequences according to :pep:`383` - by :user:`masenf`.

--- a/src/tox/execute/stream.py
+++ b/src/tox/execute/stream.py
@@ -100,7 +100,7 @@ class SyncWrite:
     @property
     def text(self) -> str:
         with self._content_lock:
-            return self._content.decode("utf-8")
+            return self._content.decode("utf-8", errors="surrogateescape")
 
     @property
     def content(self) -> bytearray:

--- a/tests/execute/test_stream.py
+++ b/tests/execute/test_stream.py
@@ -8,3 +8,9 @@ from tox.execute.stream import SyncWrite
 def test_sync_write_repr() -> None:
     sync_write = SyncWrite(name="a", target=None, color=Fore.RED)
     assert repr(sync_write) == f"SyncWrite(name='a', target=None, color={Fore.RED!r})"
+
+
+def test_sync_write_decode_surrogate() -> None:
+    sync_write = SyncWrite(name="a", target=None)
+    sync_write.handler(b"\xed\n")
+    assert sync_write.text == "\udced\n"


### PR DESCRIPTION
Instead of raising ``UnicodeDecodeError`` when command output includes non-utf-8 bytes,
``tox`` will now use ``surrogateescape`` error handling to convert the unrecognized bytes
to escape sequences according to PEP-383.

Tox has no way of knowing that the bytestream emitted by a command will be valid utf-8, even if utf-8 is ostensibly the "correct" encoding for the stream or system. It's always possible for an arbitrary command to return non-utf-8 bytes, and this situation should not break tox.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
