### PR TITLE
Allow plugins to set `tox_root`

### DIFF
--- a/docs/changelog/2966.bugfix.rst
+++ b/docs/changelog/2966.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where a tox plugin couldn't change the value of ``tox_root``.

--- a/src/tox/provision.py
+++ b/src/tox/provision.py
@@ -84,6 +84,11 @@ def provision(state: State) -> int | bool:
         desc="Name of the virtual environment used to provision a tox.",
         post_process=add_tox_requires_min_version,
     )
+
+    from tox.plugin.manager import MANAGER
+
+    MANAGER.tox_add_core_config(state.conf.core, state)
+
     requires: list[Requirement] = state.conf.core["requires"]
     missing = _get_missing(requires)
 
@@ -99,10 +104,6 @@ def provision(state: State) -> int | bool:
     provision_tox_env: str = state.conf.core["provision_tox_env"]
     state.conf.memory_seed_loaders[provision_tox_env].append(loader)
     state.envs._mark_provision(bool(missing), provision_tox_env)
-
-    from tox.plugin.manager import MANAGER
-
-    MANAGER.tox_add_core_config(state.conf.core, state)
 
     if not missing:
         return False


### PR DESCRIPTION
# Description

This pull request fixes a bug where a tox plugin was unable to modify the value of `tox_root`. Resolves #2966 

The only code change involved moving the call to `MANAGER.tox_add_core_config` to before any of the core config is accessed during provisioning. `provision` loads the value of `tox_root` which caches it and makes unchangeable afterwards.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
