### PR TITLE
Avoid race conditions in tests using the demo_pkg_inline fixture

### DIFF
--- a/docs/changelog/2985.bugfix.rst
+++ b/docs/changelog/2985.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid race conditions in tests using the ``demo_pkg_inline`` fixture.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch  # cannot import from tox.pytest yet
 from _pytest.tmpdir import TempPathFactory
 from distlib.scripts import ScriptMaker
+from filelock import FileLock
 from pytest_mock import MockerFixture
 from virtualenv import cli_run
 
@@ -77,8 +78,10 @@ def demo_pkg_setuptools() -> Path:
 
 
 @pytest.fixture(scope="session")
-def demo_pkg_inline() -> Path:
-    return HERE / "demo_pkg_inline"
+def demo_pkg_inline() -> Iterator[Path]:
+    demo_path = HERE / "demo_pkg_inline"
+    with FileLock(f"{demo_path}.lock"):
+        yield demo_path
 
 
 @pytest.fixture()


### PR DESCRIPTION
By using FileLock (already used as a dependency),
we ensure only one test uses the demo_pkg at a time.

This avoids race conditions happening with `pytest -n=auto`.

Fixes https://github.com/tox-dev/tox/issues/2985

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix (fix in tests)
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation (not relevant)
