### PR TITLE
git: Ignore the .lock file for demo_pkg_inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 *.swp
 *.egg-info
 /tests/demo_pkg_setuptools/build/lib/demo_pkg_setuptools/__init__.py
+/tests/demo_pkg_inline.lock


### PR DESCRIPTION
I hope this can go in without a changelog entry.