### PR TITLE
Update list of maintainers

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -226,5 +226,5 @@ Current maintainers
 -  :user:`Anthony Sottile <asottile>`
 -  :user:`Bernát Gábor <gaborbernat>`
 -  :user:`Jürgen Gmach <jugmac00>`
--  :user:`Miroslav Šedivý <eumiro>`
+-  :user:`Masen Furer <masenf>`
 -  :user:`Oliver Bestwalter <obestwalter>`


### PR DESCRIPTION
Miroslav approached me at PyCon DE to remove him from the maintainers list.

@eumiro, thanks for all your contributions and your dedication!

Masen was announced as a new maintainer in January 2023.

@masenf, thanks for all your contributions, and once again, welcome onboard!