### PR TITLE
Remove unnecessary Future usage

### DIFF
--- a/docs/changelog/3020.misc.rst
+++ b/docs/changelog/3020.misc.rst
@@ -1,0 +1,1 @@
+Remove unnecessary usage of ``Future`` from ``tox.config.api.Loader.load()``.


### PR DESCRIPTION
As discussed in #2972, the `tox.config.api.Loader.load()` method was manually creating a `Future` and passing it to the `.build()` context manager method, but no executor was involved and nothing was asynchronous.  This commit moves the call to `self.to()` from the `.load()` method to the `.build()` method. This allows dropping the `Future` and changing `.build()` from a context manager to a regular method.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
