### PR TITLE
Add --list-dependencies options

### DIFF
--- a/docs/changelog/3024.feature.rst
+++ b/docs/changelog/3024.feature.rst
@@ -1,2 +1,2 @@
 Addded ``--list-dependencies`` and ``--no-list-dependencies`` CLI parameters.
-If unspecified, defaults to listing in CI, but not otherwise.
+If unspecified, defaults to listing when in CI, but not otherwise.

--- a/docs/changelog/3024.feature.rst
+++ b/docs/changelog/3024.feature.rst
@@ -1,0 +1,2 @@
+Addded ``--list-dependencies`` and ``--no-list-dependencies`` CLI parameters.
+If unspecified, defaults to listing in CI, but not otherwise.

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -70,6 +70,19 @@ def env_run_create_flags(parser: ArgumentParser, mode: str) -> None:
             default=None,
             help="write a JSON file with detailed information about all commands and results involved",
         )
+        list_deps = parser.add_mutually_exclusive_group()
+        list_deps.add_argument(
+            "--list-dependencies",
+            action="store_true",
+            default=is_ci(),
+            help="list the dependencies installed during environment setup",
+        )
+        list_deps.add_argument(
+            "--no-list-dependencies",
+            action="store_false",
+            dest="list_dependencies",
+            help="never list the dependencies installed during environment setup",
+        )
     if mode not in ("devenv", "depends"):
         parser.add_argument(
             "-s",
@@ -163,19 +176,6 @@ def env_run_create_flags(parser: ArgumentParser, mode: str) -> None:
             dest="skip_pkg_install",
             help="skip package installation for this run",
             action="store_true",
-        )
-        list_deps = parser.add_mutually_exclusive_group()
-        list_deps.add_argument(
-            "--list-dependencies",
-            action="store_true",
-            default=is_ci(),
-            help="list the dependencies installed during environment setup",
-        )
-        list_deps.add_argument(
-            "--no-list-dependencies",
-            action="store_false",
-            dest="list_dependencies",
-            help="never list the dependencies installed during environment setup",
         )
 
 

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -70,19 +70,6 @@ def env_run_create_flags(parser: ArgumentParser, mode: str) -> None:
             default=None,
             help="write a JSON file with detailed information about all commands and results involved",
         )
-        list_deps = parser.add_mutually_exclusive_group()
-        list_deps.add_argument(
-            "--list-dependencies",
-            action="store_true",
-            default=is_ci(),
-            help="list the dependencies installed during environment setup",
-        )
-        list_deps.add_argument(
-            "--no-list-dependencies",
-            action="store_false",
-            dest="list_dependencies",
-            help="never list the dependencies installed during environment setup",
-        )
     if mode not in ("devenv", "depends"):
         parser.add_argument(
             "-s",
@@ -169,6 +156,19 @@ def env_run_create_flags(parser: ArgumentParser, mode: str) -> None:
             dest="no_recreate_pkg",
             help="if recreate is set do not recreate packaging tox environment(s)",
             action="store_true",
+        )
+        list_deps = parser.add_mutually_exclusive_group()
+        list_deps.add_argument(
+            "--list-dependencies",
+            action="store_true",
+            default=is_ci(),
+            help="list the dependencies installed during environment setup",
+        )
+        list_deps.add_argument(
+            "--no-list-dependencies",
+            action="store_false",
+            dest="list_dependencies",
+            help="never list the dependencies installed during environment setup",
         )
     if mode not in ("devenv", "config", "depends"):
         parser.add_argument(

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -22,6 +22,7 @@ from tox.session.cmd.run.single import ToxEnvRunResult, run_one
 from tox.session.state import State
 from tox.tox_env.api import ToxEnv
 from tox.tox_env.runner import RunToxEnv
+from tox.util.ci import is_ci
 from tox.util.graph import stable_topological_sort
 from tox.util.spinner import MISS_DURATION, Spinner
 
@@ -167,7 +168,7 @@ def env_run_create_flags(parser: ArgumentParser, mode: str) -> None:
         list_deps.add_argument(
             "--list-dependencies",
             action="store_true",
-            default="auto",
+            default=is_ci(),
             help="list the dependencies installed during environment setup",
         )
         list_deps.add_argument(

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -163,6 +163,19 @@ def env_run_create_flags(parser: ArgumentParser, mode: str) -> None:
             help="skip package installation for this run",
             action="store_true",
         )
+        list_deps = parser.add_mutually_exclusive_group()
+        list_deps.add_argument(
+            "--list-dependencies",
+            action="store_true",
+            default="auto",
+            help="list the dependencies installed during environment setup",
+        )
+        list_deps.add_argument(
+            "--no-list-dependencies",
+            action="store_false",
+            dest="list_dependencies",
+            help="never list the dependencies installed during environment setup",
+        )
 
 
 def report(start: float, runs: list[ToxEnvRunResult], is_colored: bool, verbosity: int) -> int:

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -15,7 +15,6 @@ from virtualenv.discovery.py_spec import PythonSpec
 from tox.config.main import Config
 from tox.tox_env.api import ToxEnv, ToxEnvCreateArgs
 from tox.tox_env.errors import Fail, Recreate, Skip
-from tox.util.ci import is_ci
 
 
 class VersionInfo(NamedTuple):

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -227,14 +227,11 @@ class Python(ToxEnv, ABC):
     def _done_with_setup(self) -> None:
         """called when setup is done"""
         super()._done_with_setup()
-        list_deps = self.options.list_dependencies
-        if list_deps == "auto":
-            list_deps = is_ci()
-        if self.journal or list_deps:
+        if self.journal or self.options.list_dependencies:
             outcome = self.installer.installed()
             if self.journal:
                 self.journal["installed_packages"] = outcome
-            if list_deps:
+            if self.options.list_dependencies:
                 logging.warning(",".join(outcome))
 
     def python_cache(self) -> dict[str, Any]:

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -227,12 +227,14 @@ class Python(ToxEnv, ABC):
     def _done_with_setup(self) -> None:
         """called when setup is done"""
         super()._done_with_setup()
-        running_in_ci = is_ci()
-        if self.journal or running_in_ci:
+        list_deps = self.options.list_dependencies
+        if list_deps == "auto":
+            list_deps = is_ci()
+        if self.journal or list_deps:
             outcome = self.installer.installed()
             if self.journal:
                 self.journal["installed_packages"] = outcome
-            if running_in_ci:
+            if list_deps:
                 logging.warning(",".join(outcome))
 
     def python_cache(self) -> dict[str, Any]:

--- a/tests/config/cli/test_cli_env_var.py
+++ b/tests/config/cli/test_cli_env_var.py
@@ -10,6 +10,7 @@ from tox.config.loader.api import Override
 from tox.pytest import CaptureFixture, LogCaptureFixture, MonkeyPatch
 from tox.session.env_select import CliEnv
 from tox.session.state import State
+from tox.util.ci import is_ci
 
 
 def test_verbose() -> None:
@@ -63,6 +64,7 @@ def test_verbose_no_test() -> None:
         "factors": [],
         "labels": [],
         "skip_env": "",
+        "list_dependencies": is_ci(),
     }
 
 
@@ -121,6 +123,7 @@ def test_env_var_exhaustive_parallel_values(
         "labels": [],
         "exit_and_dump_after": 0,
         "skip_env": "",
+        "list_dependencies": is_ci(),
     }
     assert options.parsed.verbosity == 4
     assert options.cmd_handlers == core_handlers

--- a/tests/config/cli/test_cli_ini.py
+++ b/tests/config/cli/test_cli_ini.py
@@ -19,6 +19,7 @@ from tox.config.source import discover_source
 from tox.pytest import CaptureFixture, LogCaptureFixture, MonkeyPatch
 from tox.session.env_select import CliEnv
 from tox.session.state import State
+from tox.util.ci import is_ci
 
 
 @pytest.fixture()
@@ -102,6 +103,7 @@ def default_options() -> dict[str, Any]:
         "labels": [],
         "exit_and_dump_after": 0,
         "skip_env": "",
+        "list_dependencies": is_ci(),
     }
 
 
@@ -139,6 +141,7 @@ def test_ini_exhaustive_parallel_values(core_handlers: dict[str, Callable[[State
         "labels": [],
         "exit_and_dump_after": 0,
         "skip_env": "",
+        "list_dependencies": is_ci(),
     }
     assert options.parsed.verbosity == 4
     assert options.cmd_handlers == core_handlers

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -218,7 +218,7 @@ def test_python_set_hash_seed_incorrect(tox_project: ToxProjectCreator) -> None:
 
 @pytest.mark.parametrize("in_ci", [True, False])
 def test_list_installed_deps(in_ci: bool, tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
-    mocker.patch("tox.tox_env.python.api.is_ci", return_value=in_ci)
+    mocker.patch("tox.session.cmd.run.common.is_ci", return_value=in_ci)
     result = tox_project({"tox.ini": "[testenv]\nskip_install = true"}).run("r", "-e", "py")
     if in_ci:
         assert "pip==" in result.out
@@ -228,13 +228,13 @@ def test_list_installed_deps(in_ci: bool, tox_project: ToxProjectCreator, mocker
 
 @pytest.mark.parametrize("list_deps", ["--list-dependencies", "--no-list-dependencies"])
 @pytest.mark.parametrize("in_ci", [True, False])
-def test_cli_list_installed_deps(
+def test_list_installed_deps_explicit_cli(
     list_deps: str,
     in_ci: bool,
     tox_project: ToxProjectCreator,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch("tox.tox_env.python.api.is_ci", return_value=in_ci)
+    mocker.patch("tox.session.cmd.run.common.is_ci", return_value=in_ci)
     result = tox_project({"tox.ini": "[testenv]\nskip_install = true"}).run(list_deps, "r", "-e", "py")
     if list_deps == "--list-dependencies":
         assert "pip==" in result.out

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -224,3 +224,19 @@ def test_list_installed_deps(in_ci: bool, tox_project: ToxProjectCreator, mocker
         assert "pip==" in result.out
     else:
         assert "pip==" not in result.out
+
+
+@pytest.mark.parametrize("list_deps", ["--list-dependencies", "--no-list-dependencies"])
+@pytest.mark.parametrize("in_ci", [True, False])
+def test_cli_list_installed_deps(
+    list_deps: str,
+    in_ci: bool,
+    tox_project: ToxProjectCreator,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("tox.tox_env.python.api.is_ci", return_value=in_ci)
+    result = tox_project({"tox.ini": "[testenv]\nskip_install = true"}).run(list_deps, "r", "-e", "py")
+    if list_deps == "--list-dependencies":
+        assert "pip==" in result.out
+    else:
+        assert "pip==" not in result.out


### PR DESCRIPTION
This pair of options allows a user to either explicitly list dependencies after setup or explicitly silence listing of dependencies if it would be automatically done.

# Thanks for contribution

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation (N/A: documentation changes are automatically generated)

Fixes #3023 