### PR TITLE
Made issue template have less whitespace

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,30 +8,38 @@ assignees: ""
 
 ## Issue
 
-Describe what's the expected behaviour and what you're observing.
+<!-- Describe what's the expected behaviour and what you're observing. -->
 
 ## Environment
 
 Provide at least:
 
 - OS:
-- `pip list` of the host Python where `tox` is installed:
+- `pip list` of the host Python where `tox` is installed in the dropdown below
+
+<details open>
+<summary>Output of <code>pip list</code></summary>
 
 ```console
 
 ```
+
+</details>
 
 ## Output of running tox
 
-Provide the output of `tox -rvv`:
+<details open>
+<summary>Output of <code>tox -rvv</code></summary>
 
 ```console
 
 ```
 
+</details>
+
 ## Minimal example
 
-If possible, provide a minimal reproducer for the issue:
+<!--  If possible, provide a minimal reproducer for the issue. -->
 
 ```console
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-# Thanks for contribution
+<!-- Thank you for your contribution!
 
 Please, make sure you address all the checklists (for details on how see
-[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))!
+[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->
 
 - [ ] ran the linter to address style issues (`tox -e fix`)
 - [ ] wrote descriptive pull request text


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

Made the PR template and bug templates use `<!-- Markdown comment -->` and Markdown dropdowns so the details of the PR/issue are easier to read (less visual noise)