### PR TITLE
Docs link of env var subs section to `set_env`

### DIFF
--- a/docs/changelog/3039.doc.rst
+++ b/docs/changelog/3039.doc.rst
@@ -1,0 +1,2 @@
+Linked environment variable substitutions docs in
+``set_env`` and ``pass_env`` config docs.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -300,6 +300,9 @@ Base options
        - each line is in KEY=VALUE format; both the key and the value are stripped,
        - there is no special handling of quotation marks, they are part of the key or value.
 
+   Also read `environment variable substitutions`_
+   for extended information on working with environment variables.
+
 .. conf::
    :keys: parallel_show_output
    :default: False
@@ -829,6 +832,8 @@ whitespace, or backslash character (since it normally acts as a path delimiter).
 Special substitutions that accept additional colon-delimited ``:`` parameters
 cannot have a space after the ``:`` at the beginning of line (e.g.  ``{posargs:
 magic}`` would be parsed as factorial ``{posargs``, having value magic).
+
+.. _`environment variable substitutions`:
 
 Environment variable substitutions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -285,6 +285,9 @@ Base options
    tox invocation environment it is ignored. The list of environment variable names is not case sensitive, for example:
    passing ``A`` or ``a`` will pass through both ``A`` and ``a``.
 
+   More environment variable-related information
+   can be found in `environment variable substitutions`_.
+
 .. conf::
    :keys: set_env, setenv
 
@@ -300,8 +303,8 @@ Base options
        - each line is in KEY=VALUE format; both the key and the value are stripped,
        - there is no special handling of quotation marks, they are part of the key or value.
 
-   Also read `environment variable substitutions`_
-   for extended information on working with environment variables.
+   More environment variable-related information
+   can be found in `environment variable substitutions`_.
 
 .. conf::
    :keys: parallel_show_output

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -286,7 +286,7 @@ Base options
    passing ``A`` or ``a`` will pass through both ``A`` and ``a``.
 
    More environment variable-related information
-   can be found in `environment variable substitutions`_.
+   can be found in :ref:`environment variable substitutions`.
 
 .. conf::
    :keys: set_env, setenv
@@ -304,7 +304,7 @@ Base options
        - there is no special handling of quotation marks, they are part of the key or value.
 
    More environment variable-related information
-   can be found in `environment variable substitutions`_.
+   can be found in :ref:`environment variable substitutions`.
 
 .. conf::
    :keys: parallel_show_output


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

Closes https://github.com/tox-dev/tox/issues/3036.