### PR TITLE
Removed duplicate text in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -15,10 +15,9 @@ assignees: ""
 Provide at least:
 
 - OS:
-- `pip list` of the host Python where `tox` is installed in the dropdown below
 
 <details open>
-<summary>Output of <code>pip list</code></summary>
+<summary>Output of <code>pip list</code> of the host Python, where <code>tox</code> is installed</summary>
 
 ```console
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

In https://github.com/tox-dev/tox/pull/3038 the bug report's template was streamlined. I realized the bullet became redundant with the dropdown title, and a bit of a run-on sentence.  This PR combines them:

Here's what the Environment section looks like (rendered in PyCharm):

![image](https://github.com/tox-dev/tox/assets/8990777/8b465438-9fdc-4430-b9bd-7696c37e6868)

Sorry for the spam, just wanted to get it right 👌 