### PR TITLE
Ensure `get_requires*` hook is called before `prepare_metadata*`

### DIFF
--- a/docs/changelog/3043.bugfix.rst
+++ b/docs/changelog/3043.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure that ``get_requires*`` build hooks are called before ``prepare_metadata*``

--- a/docs/changelog/3043.bugfix.rst
+++ b/docs/changelog/3043.bugfix.rst
@@ -1,1 +1,2 @@
-Ensure that ``get_requires*`` build hooks are called before ``prepare_metadata*``
+Ensure that ``get_requires_for_build_wheel`` is called before ``prepare_metadata_for_build_wheel``, and
+``get_requires_for_build_editable`` is called before ``prepare_metadata_for_build_editable`` - by :user:`abravalheri`.

--- a/src/tox/tox_env/python/virtual_env/package/pyproject.py
+++ b/src/tox/tox_env/python/virtual_env/package/pyproject.py
@@ -165,12 +165,10 @@ class Pep517VirtualEnvPackager(PythonPackageToxEnv, VirtualEnv):
         if "sdist" in self.builds or "external" in self.builds:
             self._setup_build_requires("sdist")
 
-    def _setup_build_requires(self, of_type: str):
+    def _setup_build_requires(self, of_type: str) -> None:
         hook = getattr(self._frontend, f"get_requires_for_build_{of_type}")
         build_requires = hook().requires  # already cached via Pep517VirtualEnvFrontend
-        pending = [
-            req for req in build_requires if req not in self._installed_build_requirements
-        ]
+        pending = [req for req in build_requires if req not in self._installed_build_requirements]
         if pending:
             self._install(pending, PythonPackageToxEnv.__name__, f"requires_for_build_{of_type}")
             self._installed_build_requirements.update(pending)
@@ -347,7 +345,7 @@ class Pep517VirtualEnvFrontend(Frontend):
         for hook in chain(
             (f"build_{build_type}" for build_type in build_types),
             (f"get_requires_for_build_{build_type}" for build_type in build_types),
-            (f"prepare_metadata_for_build_{build_type}" for build_type in build_types)
+            (f"prepare_metadata_for_build_{build_type}" for build_type in build_types),
         ):  # wrap build methods in a cache wrapper
             if not hasattr(self, hook):
                 continue

--- a/src/tox/tox_env/python/virtual_env/package/pyproject.py
+++ b/src/tox/tox_env/python/virtual_env/package/pyproject.py
@@ -321,8 +321,10 @@ class Pep517VirtualEnvPackager(PythonPackageToxEnv, VirtualEnv):
         self.setup()
         end = self._frontend
         if for_env["package"] == "editable":
+            self._setup_build_requires("editable")
             dist_info = end.prepare_metadata_for_build_editable(self.meta_folder, self._wheel_config_settings).metadata
         else:
+            self._setup_build_requires("wheel")
             dist_info = end.prepare_metadata_for_build_wheel(self.meta_folder, self._wheel_config_settings).metadata
         self._distribution_meta = Distribution.at(str(dist_info))
 

--- a/tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py
@@ -56,6 +56,8 @@ def test_tox_install_pkg_sdist(tox_project: ToxProjectCreator, pkg_with_extras_p
         (".pkg_external_sdist_meta", "install_requires", ["setuptools", "wheel"]),
         (".pkg_external_sdist_meta", "_optional_hooks", []),
         (".pkg_external_sdist_meta", "get_requires_for_build_sdist", []),
+        (".pkg_external_sdist_meta", "get_requires_for_build_wheel", []),  # required before prepare_metadata*
+        (".pkg_external_sdist_meta", "install_requires_for_build_wheel", ["wheel"]),
         (".pkg_external_sdist_meta", "prepare_metadata_for_build_wheel", []),
         ("py", "install_package_deps", deps),
         ("py", "install_package", ["--force-reinstall", "--no-deps", str(pkg_with_extras_project_sdist)]),

--- a/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
@@ -213,6 +213,7 @@ def test_pyproject_deps_static_with_dynamic(  # noqa: PLR0913
     expected_calls = [
         (".pkg", "_optional_hooks"),
         (".pkg", "get_requires_for_build_sdist"),
+        (".pkg", "get_requires_for_build_wheel"),
         (".pkg", "build_wheel"),
         (".pkg", "build_sdist"),
         ("py", "install_package_deps"),
@@ -239,10 +240,10 @@ def test_pyproject_no_build_editable_fallback(tox_project: ToxProjectCreator, de
 
     expected_calls = [
         (".pkg", "_optional_hooks"),
+        (".pkg", "get_requires_for_build_wheel"),
         (".pkg", "build_wheel"),
         (".pkg", "get_requires_for_build_sdist"),
         ("a", "install_package"),
-        (".pkg", "get_requires_for_build_sdist"),
         ("b", "install_package"),
         (".pkg", "_exit"),
     ]

--- a/tests/tox_env/test_tox_env_runner.py
+++ b/tests/tox_env/test_tox_env_runner.py
@@ -24,6 +24,7 @@ def test_package_only(
     expected_calls = [
         (".pkg", "_optional_hooks"),
         (".pkg", "get_requires_for_build_sdist"),
+        (".pkg", "get_requires_for_build_wheel"),
         (".pkg", "build_wheel"),
         (".pkg", "build_sdist"),
         (".pkg", "_exit"),


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

As described in #3043, it seems that for some circumstances the `prepare_metadata*` hook is not called before `get_requires*`, which result in errors on Python 3.12b2 for the `setuptools` backend.

The changes implemented in this PR are:

- Add caching to the `get_requires*` and `prepare_metadata*` hooks in `Pep517VirtualEnvPackager` (these methods may be called multiple times).
- Ensure `get_requires*` is called and that the requirements are installed before `prepare_metadata*`.

This seem to be required according to PEP 517, see last phrase on the paragraph below (copied from the PEP):

> [get_requires_for_build_wheel](https://peps.python.org/pep-0517/#get-requires-for-build-wheel)
> This hook MUST return an additional list of strings containing [PEP 508](https://peps.python.org/pep-0508) dependency specifications, above and beyond those specified in the `pyproject.toml` file, to be installed when calling the `build_wheel` or `prepare_metadata_for_build_wheel` hooks.



- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

Fix #3043
