### PR TITLE
Fix hang and zombie process on interrupt (CTRL-C).

### DIFF
--- a/docs/changelog/3056.bugfix.rst
+++ b/docs/changelog/3056.bugfix.rst
@@ -1,0 +1,1 @@
+Fix hang and zombie process on interrupt (CTRL-C).

--- a/src/tox/execute/local_sub_process/__init__.py
+++ b/src/tox/execute/local_sub_process/__init__.py
@@ -63,6 +63,8 @@ class LocalSubprocessExecuteStatus(ExecuteStatus):
 
     @property
     def exit_code(self) -> int | None:
+        # need to poll here, to make sure the returncode we get is current
+        self._process.poll()
         return self._process.returncode
 
     def interrupt(self) -> None:


### PR DESCRIPTION
Fixes #3056

I'm not sure how to construct a test case for this...

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
