### PR TITLE
Update a test regex to work with Python 3.12+

### DIFF
--- a/docs/changelog/3065.bugfix.rst
+++ b/docs/changelog/3065.bugfix.rst
@@ -1,0 +1,1 @@
+Update a regular expression in tests to match the exception message in both Python 3.12 and older.

--- a/tests/config/loader/test_memory_loader.py
+++ b/tests/config/loader/test_memory_loader.py
@@ -66,7 +66,7 @@ def test_memory_loader(value: Any, of_type: type[Any], outcome: Any) -> None:
         (["m"], List[int], ValueError, "invalid literal for int"),
         ({"m": 1}, Dict[int, int], ValueError, "invalid literal for int"),
         ({1: "m"}, Dict[int, int], ValueError, "invalid literal for int"),
-        (object, Path, TypeError, "expected str, bytes or os.PathLike object"),
+        (object, Path, TypeError, r"str(, bytes)? or (an )?os\.PathLike object"),
         (1, Command, TypeError, "1"),
         (1, EnvList, TypeError, "1"),
     ],


### PR DESCRIPTION
Fixes https://github.com/tox-dev/tox/issues/3065

New message:

    "argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'type'"

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [-] updated/extended the documentation
