### PR TITLE
Allow extending lists with --override foo+=bar

### DIFF
--- a/docs/changelog/3087.feature.rst
+++ b/docs/changelog/3087.feature.rst
@@ -1,3 +1,3 @@
 ``--override`` can now take options in the form of ``foo+=bar`` which
-will append ``bar`` to the end of an existing list, rather than
+will append ``bar`` to the end of an existing list/dict, rather than
 replacing it.

--- a/docs/changelog/3087.feature.rst
+++ b/docs/changelog/3087.feature.rst
@@ -1,0 +1,3 @@
+``--override`` can now take options in the form of ``foo+=bar`` which
+will append ``bar`` to the end of an existing list, rather than
+replacing it.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -958,3 +958,25 @@ Other Substitutions
 
 * ``{}`` - replaced as ``os.pathsep``
 * ``{/}`` - replaced as ``os.sep``
+
+Overriding configuration from the command line
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can override options in the configuration file, from the command
+line.
+
+For example, given this config:
+
+.. code-block:: ini
+
+    [testenv]
+    deps = pytest
+    commands = pytest tests
+
+You could enable ``ignore_errors`` by running::
+
+    tox --override testenv.ignore_errors=True
+
+You could add additional dependencies by running::
+
+    tox --override testenv.deps+=pytest-xdist,pytest-cov

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -971,6 +971,8 @@ For example, given this config:
 
     [testenv]
     deps = pytest
+    setenv =
+      foo=bar
     commands = pytest tests
 
 You could enable ``ignore_errors`` by running::
@@ -980,3 +982,7 @@ You could enable ``ignore_errors`` by running::
 You could add additional dependencies by running::
 
     tox --override testenv.deps+=pytest-xdist,pytest-cov
+
+You could set additional environment variables by running::
+
+    tox --override testenv.setenv+=baz=quux

--- a/src/tox/config/loader/api.py
+++ b/src/tox/config/loader/api.py
@@ -123,6 +123,8 @@ class Loader(Convert[T]):
         :param args: the config load arguments
         :return: the converted type
         """
+        from tox.config.set_env import SetEnv
+
         override = self.overrides.get(key)
         if override and not override.append:
             return _STR_CONVERT.to(override.value, of_type, factory)
@@ -132,8 +134,12 @@ class Loader(Convert[T]):
             appends = _STR_CONVERT.to(override.value, of_type, factory)
             if isinstance(converted, list) and isinstance(appends, list):
                 converted += appends
+            elif isinstance(converted, dict) and isinstance(appends, dict):
+                converted.update(appends)
+            elif isinstance(converted, SetEnv) and isinstance(appends, SetEnv):
+                converted.update(appends, override=True)
             else:
-                msg = "Only able to append to lists"
+                msg = "Only able to append to lists and dicts"
                 raise ValueError(msg)
         return converted
 

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -95,10 +95,11 @@ class SetEnv:
             self._raw.update(sub_raw)
             yield from sub_raw.keys()
 
-    def update(self, param: Mapping[str, str], *, override: bool = True) -> None:
-        for key, value in param.items():
+    def update(self, param: Mapping[str, str] | SetEnv, *, override: bool = True) -> None:
+        for key in param:
             # do not override something already set explicitly
             if override or (key not in self._raw and key not in self._materialized):
+                value = param.load(key) if isinstance(param, SetEnv) else param[key]
                 self._materialized[key] = value
                 self.changed = True
 

--- a/tests/config/loader/test_loader.py
+++ b/tests/config/loader/test_loader.py
@@ -28,6 +28,18 @@ def test_override_add(flag: str) -> None:
     assert value.key == "magic"
     assert value.value == "true"
     assert not value.namespace
+    assert value.append is False
+
+
+@pytest.mark.parametrize("flag", ["-x", "--override"])
+def test_override_append(flag: str) -> None:
+    parsed, _, __, ___, ____ = get_options(flag, "magic+=true")
+    assert len(parsed.override) == 1
+    value = parsed.override[0]
+    assert value.key == "magic"
+    assert value.value == "true"
+    assert not value.namespace
+    assert value.append is True
 
 
 def test_override_equals() -> None:

--- a/tests/config/test_main.py
+++ b/tests/config/test_main.py
@@ -66,7 +66,7 @@ def test_config_override_wins_memory_loader(tox_ini_conf: ToxIniCreator) -> None
     assert conf["c"] == "ok"
 
 
-def test_config_override_appends(tox_ini_conf: ToxIniCreator) -> None:
+def test_config_override_appends_to_list(tox_ini_conf: ToxIniCreator) -> None:
     example = """
     [testenv]
     passenv = foo
@@ -76,6 +76,17 @@ def test_config_override_appends(tox_ini_conf: ToxIniCreator) -> None:
     assert conf["passenv"] == ["foo", "bar"]
 
 
+def test_config_override_appends_to_setenv(tox_ini_conf: ToxIniCreator) -> None:
+    example = """
+    [testenv]
+    setenv =
+      foo = bar
+    """
+    conf = tox_ini_conf(example, override=[Override("testenv.setenv+=baz=quux")]).get_env("testenv")
+    assert conf["setenv"].load("foo") == "bar"
+    assert conf["setenv"].load("baz") == "quux"
+
+
 def test_config_override_cannot_append(tox_ini_conf: ToxIniCreator) -> None:
     example = """
     [testenv]
@@ -83,7 +94,7 @@ def test_config_override_cannot_append(tox_ini_conf: ToxIniCreator) -> None:
     """
     conf = tox_ini_conf(example, override=[Override("testenv.foo+=2")]).get_env("testenv")
     conf.add_config("foo", of_type=int, default=0, desc="desc")
-    with pytest.raises(ValueError, match="Only able to append to lists"):
+    with pytest.raises(ValueError, match="Only able to append to lists and dicts"):
         conf["foo"]
 
 

--- a/tests/config/test_main.py
+++ b/tests/config/test_main.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
+
+import pytest
 
 from tox.config.loader.api import Override
 from tox.config.loader.memory import MemoryLoader
@@ -62,6 +64,27 @@ def test_config_override_wins_memory_loader(tox_ini_conf: ToxIniCreator) -> None
     conf = main_conf.get_env("py", loaders=[MemoryLoader(c="something_else")])
     conf.add_config("c", of_type=str, default="d", desc="desc")
     assert conf["c"] == "ok"
+
+
+def test_config_override_appends(tox_ini_conf: ToxIniCreator) -> None:
+    example = """
+    [testenv]
+    passenv = foo
+    """
+    conf = tox_ini_conf(example, override=[Override("testenv.passenv+=bar")]).get_env("testenv")
+    conf.add_config("passenv", of_type=List[str], default=[], desc="desc")
+    assert conf["passenv"] == ["foo", "bar"]
+
+
+def test_config_override_cannot_append(tox_ini_conf: ToxIniCreator) -> None:
+    example = """
+    [testenv]
+    foo = 1
+    """
+    conf = tox_ini_conf(example, override=[Override("testenv.foo+=2")]).get_env("testenv")
+    conf.add_config("foo", of_type=int, default=0, desc="desc")
+    with pytest.raises(ValueError, match="Only able to append to lists"):
+        conf["foo"]
 
 
 def test_args_are_paths_when_disabled(tox_project: ToxProjectCreator) -> None:

--- a/tests/config/test_set_env.py
+++ b/tests/config/test_set_env.py
@@ -34,6 +34,22 @@ def test_set_env_explicit() -> None:
     assert "MISS" not in set_env
 
 
+def test_set_env_merge() -> None:
+    a = SetEnv("\nA=1\nB = 2\nC= 3\nD= 4", "py", "py", Path())
+    b = SetEnv("\nA=2\nE = 5", "py", "py", Path())
+    a.update(b, override=False)
+
+    keys = list(a)
+    assert keys == ["E", "A", "B", "C", "D"]
+    values = [a.load(k) for k in keys]
+    assert values == ["5", "1", "2", "3", "4"]
+
+    a.update(b, override=True)
+
+    values = [a.load(k) for k in keys]
+    assert values == ["5", "2", "2", "3", "4"]
+
+
 def test_set_env_bad_line() -> None:
     with pytest.raises(ValueError, match="A"):
         SetEnv("A", "py", "py", Path())


### PR DESCRIPTION
Allow appending to a list with `+=` syntax, instead of replacing the existing value.

Fixes: #3087 

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
