### PR TITLE
Disallow command line environments which are not explicitly specified in the config file

### DIFF
--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -152,6 +152,14 @@ class EnvSelector:
         elif self._cli_envs.is_all:
             everything_active = True
         else:
+            if cli_envs_not_in_config := (set(self._cli_envs) - set(self._state.conf)):
+                # allow cli_envs matching ".pkg" and starting with "py" to be implicitly created.
+                cli_envs_not_in_config = [
+                    env for env in cli_envs_not_in_config if not env.startswith("py") and env not in (".pkg",)
+                ]
+                if cli_envs_not_in_config:
+                    msg = f"provided environments not found in configuration file: {cli_envs_not_in_config}"
+                    raise HandledError(msg)
             yield self._cli_envs, True
         yield self._state.conf, everything_active
         label_envs = dict.fromkeys(chain.from_iterable(self._state.conf.core["labels"].values()))

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -76,7 +76,16 @@ def test_plugin_hooks_and_order(tox_project: ToxProjectCreator, mocker: MockerFi
     plugins = tuple(v for v in locals().values() if callable(v) and hasattr(v, "tox_impl"))
     assert len(plugins) == 8
     register_inline_plugin(mocker, *plugins)
-    project = tox_project({"tox.ini": "[testenv]\npackage=skip\ncommands=python -c 'print(1)'"})
+
+    tox_ini = """
+        [tox]
+        env_list=a,b
+        [testenv]
+        package=skip
+        commands=python -c 'print(1)'
+        env_list=a,b
+    """
+    project = tox_project({"tox.ini": tox_ini})
     result = project.run("r", "-e", "a,b")
     result.assert_success()
     cmd = "print(1)" if sys.platform == "win32" else "'print(1)'"

--- a/tests/session/cmd/test_devenv.py
+++ b/tests/session/cmd/test_devenv.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 def test_devenv_fail_multiple_target(tox_project: ToxProjectCreator) -> None:
-    outcome = tox_project({"tox.ini": ""}).run("d", "-e", "a,b")
+    outcome = tox_project({"tox.ini": "[tox]\nenv_list=a,b"}).run("d", "-e", "a,b")
     outcome.assert_failed()
     msg = "ROOT: HandledError| exactly one target environment allowed in devenv mode but found a, b\n"
     outcome.assert_out_err(msg, "")

--- a/tests/session/cmd/test_parallel.py
+++ b/tests/session/cmd/test_parallel.py
@@ -141,7 +141,7 @@ def test_keyboard_interrupt(tox_project: ToxProjectCreator, demo_pkg_inline: Pat
     )
     cmd = ["-c", str(proj.path / "tox.ini"), "p", "-p", "1", "-e", f"py,py{sys.version_info[0]},dep"]
     process = Popen([sys.executable, "-m", "tox", *cmd], stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    while not marker.exists():
+    while not marker.exists() and (process.poll() is None):
         sleep(0.05)
     process.send_signal(SIGINT)
     out, err = process.communicate()

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -394,7 +394,7 @@ def test_platform_matches_run_env(tox_project: ToxProjectCreator) -> None:
 def test_platform_does_not_match_package_env(tox_project: ToxProjectCreator, demo_pkg_inline: Path) -> None:
     toml = (demo_pkg_inline / "pyproject.toml").read_text()
     build = (demo_pkg_inline / "build.py").read_text()
-    ini = "[testenv]\npackage=wheel\n[testenv:.pkg]\nplatform=wrong_platform"
+    ini = "[tox]\nenv_list=a,b\n[testenv]\npackage=wheel\n[testenv:.pkg]\nplatform=wrong_platform"
     proj = tox_project({"tox.ini": ini, "pyproject.toml": toml, "build.py": build})
     result = proj.run("r", "-e", "a,b")
     result.assert_failed()  # tox run fails as all envs are skipped
@@ -430,7 +430,7 @@ def test_sequential_help(tox_project: ToxProjectCreator) -> None:
 
 
 def test_sequential_clears_pkg_at_most_once(tox_project: ToxProjectCreator, demo_pkg_inline: Path) -> None:
-    project = tox_project({"tox.ini": ""})
+    project = tox_project({"tox.ini": "[tox]\nenv_list=a,b"})
     result = project.run("r", "--root", str(demo_pkg_inline), "-e", "a,b", "-r")
     result.assert_success()
 

--- a/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
@@ -228,7 +228,7 @@ def test_pyproject_deps_static_with_dynamic(  # noqa: PLR0913
 
 
 def test_pyproject_no_build_editable_fallback(tox_project: ToxProjectCreator, demo_pkg_inline: Path) -> None:
-    proj = tox_project({"tox.ini": ""}, base=demo_pkg_inline)
+    proj = tox_project({"tox.ini": "[tox]\nenv_list=a,b"}, base=demo_pkg_inline)
     execute_calls = proj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
     result = proj.run("r", "-e", "a,b", "--notest", "--develop")
     result.assert_success()


### PR DESCRIPTION
Checks that all command line provided environments correspond with an environment in the configuration file.

This does not apply to configurations starting with `py*` or `.pkg` (I don't know what the latter is perhaps it shouldn't be special cased).

I'd love to update/extend the documentation but could use some help finding a home for this.

Fixes: #2858. 

- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
