### PR TITLE
Accept environments with defined factors or of python selector form - suggest closest

### DIFF
--- a/docs/changelog/3099.bugfix.rst
+++ b/docs/changelog/3099.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression introduced in ``4.9.0`` affecting hyphenated and combined environments.

--- a/docs/changelog/3099.bugfix.rst
+++ b/docs/changelog/3099.bugfix.rst
@@ -1,1 +1,0 @@
-Fix regression introduced in ``4.9.0`` affecting hyphenated and combined environments.

--- a/docs/changelog/3099.feature.rst
+++ b/docs/changelog/3099.feature.rst
@@ -1,0 +1,3 @@
+Change accepted environment name rule: must be made up of factors defined in configuration or match regex
+``(pypy|py|cython|)((\d(\.\d+(\.\d+)?)?)|\d+)?``. If an environment name does not match this fail, and if a close match
+found suggest that to the user.

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
 
 from tox.config.cli.parse import get_options
-from tox.session.env_select import CliEnv, EnvSelector
+from tox.session.env_select import _DYNAMIC_ENV_FACTORS, CliEnv, EnvSelector
 from tox.session.state import State
 
 if TYPE_CHECKING:
@@ -150,13 +151,6 @@ def test_cli_env_can_be_specified_in_additional_environments(tox_project: ToxPro
     assert not outcome.err
 
 
-def test_cli_env_not_in_tox_config_fails(tox_project: ToxProjectCreator) -> None:
-    proj = tox_project({"tox.ini": ""})
-    outcome = proj.run("r", "-e", "does_not_exist")
-    outcome.assert_failed(code=-2)
-    assert "provided environments not found in configuration file: ['does_not_exist']" in outcome.out, outcome.out
-
-
 @pytest.mark.parametrize("env_name", ["py", "py310", ".pkg"])
 def test_allowed_implicit_cli_envs(env_name: str, tox_project: ToxProjectCreator) -> None:
     proj = tox_project({"tox.ini": ""})
@@ -166,7 +160,7 @@ def test_allowed_implicit_cli_envs(env_name: str, tox_project: ToxProjectCreator
     assert not outcome.err
 
 
-@pytest.mark.parametrize("env_name", ["a", "b", "a-b"])
+@pytest.mark.parametrize("env_name", ["a", "b", "a-b", "b-a"])
 def test_matches_hyphenated_env(env_name: str, tox_project: ToxProjectCreator) -> None:
     tox_ini = """
         [tox]
@@ -185,11 +179,15 @@ def test_matches_hyphenated_env(env_name: str, tox_project: ToxProjectCreator) -
     assert not outcome.err
 
 
-@pytest.mark.parametrize("env_name", ["3.9", "3.9-cov"])
+_MINOR = sys.version_info.minor
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    [f"3.{_MINOR}", f"3.{_MINOR}-cov", "3-cov", "3", f"3.{_MINOR}", f"py3{_MINOR}-cov", f"py3.{_MINOR}-cov"],
+)
 def test_matches_combined_env(env_name: str, tox_project: ToxProjectCreator) -> None:
     tox_ini = """
-        [tox]
-        env_list=3.9
         [testenv]
         package=skip
         commands =
@@ -201,3 +199,50 @@ def test_matches_combined_env(env_name: str, tox_project: ToxProjectCreator) -> 
     outcome.assert_success()
     assert env_name in outcome.out
     assert not outcome.err
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        "py",
+        "pypy",
+        "pypy3",
+        "pypy3.12",
+        "pypy312",
+        "py3",
+        "py3.12",
+        "py312",
+        "3",
+        "3.12",
+        "3.12.0",
+    ],
+)
+def test_dynamic_env_factors_match(env: str) -> None:
+    assert _DYNAMIC_ENV_FACTORS.fullmatch(env)
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        "cy3",
+        "cov",
+        "py10.1",
+    ],
+)
+def test_dynamic_env_factors_not_match(env: str) -> None:
+    assert not _DYNAMIC_ENV_FACTORS.fullmatch(env)
+
+
+def test_suggest_env(tox_project: ToxProjectCreator) -> None:
+    tox_ini = f"[testenv:release]\n[testenv:py3{_MINOR}]\n[testenv:alpha-py3{_MINOR}]\n"
+    proj = tox_project({"tox.ini": tox_ini})
+    outcome = proj.run("r", "-e", f"releas,p3{_MINOR},magic,alph-p{_MINOR}")
+    outcome.assert_failed(code=-2)
+
+    assert not outcome.err
+    msg = (
+        "ROOT: HandledError| provided environments not found in configuration file:\n"
+        f"releas - did you mean release?\np3{_MINOR} - did you mean py3{_MINOR}?\nmagic\n"
+        f"alph-p{_MINOR} - did you mean alpha-py3{_MINOR}?\n"
+    )
+    assert outcome.out == msg


### PR DESCRIPTION
Fixes: #3096 

The `4.9.0` introduced a regression to valid environments:

Hyphenated environments:

```ini
[tox]
env_list=a-b
...
```

Combined environments:

```ini
[tox]
env_list=a
commands = 
    with: python -c 'print("with")'
   !with: python -c 'print("without")'
```

- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [X] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
