### PR TITLE
Replace undefined settings with overrides when appending

### DIFF
--- a/docs/changelog/3100.bugfix.rst
+++ b/docs/changelog/3100.bugfix.rst
@@ -1,0 +1,1 @@
+``--override foo+=bar`` appending syntax will now work correctly when ``foo`` wasn't defined in ``tox.ini``.

--- a/src/tox/config/loader/api.py
+++ b/src/tox/config/loader/api.py
@@ -130,18 +130,24 @@ class Loader(Convert[T]):
         from tox.config.set_env import SetEnv
 
         override = self.overrides.get(key)
-        if override and not override.append:
-            return _STR_CONVERT.to(override.value, of_type, factory)
-        raw = self.load_raw(key, conf, args.env_name)
+        if override:
+            converted_override = _STR_CONVERT.to(override.value, of_type, factory)
+            if not override.append:
+                return converted_override
+        try:
+            raw = self.load_raw(key, conf, args.env_name)
+        except KeyError:
+            if override:
+                return converted_override
+            raise
         converted = self.build(key, of_type, factory, conf, raw, args)
         if override and override.append:
-            appends = _STR_CONVERT.to(override.value, of_type, factory)
-            if isinstance(converted, list) and isinstance(appends, list):
-                converted += appends
-            elif isinstance(converted, dict) and isinstance(appends, dict):
-                converted.update(appends)
-            elif isinstance(converted, SetEnv) and isinstance(appends, SetEnv):
-                converted.update(appends, override=True)
+            if isinstance(converted, list) and isinstance(converted_override, list):
+                converted += converted_override
+            elif isinstance(converted, dict) and isinstance(converted_override, dict):
+                converted.update(converted_override)
+            elif isinstance(converted, SetEnv) and isinstance(converted_override, SetEnv):
+                converted.update(converted_override, override=True)
             else:
                 msg = "Only able to append to lists and dicts"
                 raise ValueError(msg)

--- a/src/tox/config/loader/api.py
+++ b/src/tox/config/loader/api.py
@@ -80,7 +80,7 @@ class Loader(Convert[T]):
 
     def __init__(self, section: Section, overrides: list[Override]) -> None:
         self._section = section
-        self.overrides = {o.key: o for o in overrides}
+        self.overrides: dict[str, Override] = {o.key: o for o in overrides}
         self.parent: Loader[Any] | None = None
 
     @property

--- a/tests/config/test_main.py
+++ b/tests/config/test_main.py
@@ -76,6 +76,12 @@ def test_config_override_appends_to_list(tox_ini_conf: ToxIniCreator) -> None:
     assert conf["passenv"] == ["foo", "bar"]
 
 
+def test_config_override_appends_to_empty_list(tox_ini_conf: ToxIniCreator) -> None:
+    conf = tox_ini_conf("[testenv]", override=[Override("testenv.passenv+=bar")]).get_env("testenv")
+    conf.add_config("passenv", of_type=List[str], default=[], desc="desc")
+    assert conf["passenv"] == ["bar"]
+
+
 def test_config_override_appends_to_setenv(tox_ini_conf: ToxIniCreator) -> None:
     example = """
     [testenv]
@@ -85,6 +91,11 @@ def test_config_override_appends_to_setenv(tox_ini_conf: ToxIniCreator) -> None:
     conf = tox_ini_conf(example, override=[Override("testenv.setenv+=baz=quux")]).get_env("testenv")
     assert conf["setenv"].load("foo") == "bar"
     assert conf["setenv"].load("baz") == "quux"
+
+
+def test_config_override_appends_to_empty_setenv(tox_ini_conf: ToxIniCreator) -> None:
+    conf = tox_ini_conf("[testenv]", override=[Override("testenv.setenv+=foo=bar")]).get_env("testenv")
+    assert conf["setenv"].load("foo") == "bar"
 
 
 def test_config_override_cannot_append(tox_ini_conf: ToxIniCreator) -> None:


### PR DESCRIPTION
The override logic in #3088 didn't work quite correctly, because I'd missed that KeyError would be raised early in the `load()` method, before the appending logic.

Handle this, and test!

Fixes: #3100

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] ~~updated/extended the documentation~~