### PR TITLE
Tests: Don't assume Python 3.10 is always installed, use current Python version

### DIFF
--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
     from tox.pytest import MonkeyPatch, ToxProjectCreator
 
 
+CURRENT_PY_ENV = f"py{sys.version_info[0]}{sys.version_info[1]}"  # e.g. py310
+
+
 def test_label_core_can_define(tox_project: ToxProjectCreator) -> None:
     ini = """
         [tox]
@@ -151,7 +154,7 @@ def test_cli_env_can_be_specified_in_additional_environments(tox_project: ToxPro
     assert not outcome.err
 
 
-@pytest.mark.parametrize("env_name", ["py", "py310", ".pkg"])
+@pytest.mark.parametrize("env_name", ["py", CURRENT_PY_ENV, ".pkg"])
 def test_allowed_implicit_cli_envs(env_name: str, tox_project: ToxProjectCreator) -> None:
     proj = tox_project({"tox.ini": ""})
     outcome = proj.run("r", "-e", env_name)


### PR DESCRIPTION
See https://github.com/tox-dev/tox/pull/3089#pullrequestreview-1603222695

test_allowed_implicit_cli_envs[py310] assumed Python 3.10 is installed.
It failed without it:

    ____________________ test_allowed_implicit_cli_envs[py310] _____________________
    [gw3] linux -- Python 3.12.0 /usr/bin/python3

    env_name = 'py310'
    tox_project = <function init_fixture.<locals>._init at 0x7febd4e1ca40>

        @pytest.mark.parametrize("env_name", ["py", "py310", ".pkg"])
        def test_allowed_implicit_cli_envs(env_name: str, tox_project: ToxProjectCreator) -> None:
            proj = tox_project({"tox.ini": ""})
            outcome = proj.run("r", "-e", env_name)
    >       outcome.assert_success()

    env_name   = 'py310'
    outcome    = code: -1
    cmd: /usr/bin/python3 -m tox r -e py310
    cwd: /tmp/pytest-of-mockbuild/pytest-0/popen-gw3/test_allowed_implici...uld not find python interpreter with spec(s): py310
      py310: SKIP (0.23 seconds)
      evaluation failed :( (0.27 seconds)

    proj       = ToxProject(path=/tmp/pytest-of-mockbuild/pytest-0/popen-gw3/test_allowed_implicit_cli_envs1/p) at 140650867026656
    tox_project = <function init_fixture.<locals>._init at 0x7febd4e1ca40>

    tests/session/test_env_select.py:158:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    self = code: -1
    cmd: /usr/bin/python3 -m tox r -e py310
    cwd: /tmp/pytest-of-mockbuild/pytest-0/popen-gw3/test_allowed_implici...uld not find python interpreter with spec(s): py310
      py310: SKIP (0.23 seconds)
      evaluation failed :( (0.27 seconds)

        def assert_success(self) -> None:
    >       assert self.success, repr(self)  # noqa: S101
    E       AssertionError: code: -1
    E         cmd: /usr/bin/python3 -m tox r -e py310
    E         cwd: /tmp/pytest-of-mockbuild/pytest-0/popen-gw3/test_allowed_implicit_cli_envs1/p
    E         standard output
    E         py310: skipped because could not find python interpreter with spec(s): py310
    E           py310: SKIP (0.23 seconds)
    E           evaluation failed :( (0.27 seconds)
    E
    E       assert False
    E        +  where False = code: -1\ncmd: /usr/bin/python3 -m tox r -e py310\ncwd: /tmp/pytest-of-mockbuild/pytest-0/popen-gw3/test_allowed_implicit_cli_envs1/p\nstandard output\npy310: skipped because could not find python interpreter with spec(s): py310\n  py310: SKIP (0.23 seconds)\n  evaluation failed :( (0.27 seconds)\n.success

    self       = code: -1
    cmd: /usr/bin/python3 -m tox r -e py310
    cwd: /tmp/pytest-of-mockbuild/pytest-0/popen-gw3/test_allowed_implici...uld not find python interpreter with spec(s): py310
      py310: SKIP (0.23 seconds)
      evaluation failed :( (0.27 seconds)

    .../usr/lib/python3.12/site-packages/tox/pytest.py:352: AssertionError

This way, we use an environment that is available (as long as the tests run on CPython).
This could be improved to support PyPy as well, but I decided to take one step at a time.
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
