### PR TITLE
Set the --parallel default to "auto", not CPU count

### DIFF
--- a/src/tox/session/cmd/run/parallel.py
+++ b/src/tox/session/cmd/run/parallel.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 ENV_VAR_KEY = "TOX_PARALLEL_ENV"
 OFF_VALUE = 0
-DEFAULT_PARALLEL = OFF_VALUE
+DEFAULT_PARALLEL = "auto"
 
 
 @impl
@@ -27,7 +27,7 @@ def tox_add_option(parser: ToxParser) -> None:
     our = parser.add_command("run-parallel", ["p"], "run environments in parallel", run_parallel)
     register_env_select_flags(our, default=CliEnv())
     env_run_create_flags(our, mode="run-parallel")
-    parallel_flags(our, default_parallel=auto_detect_cpus())
+    parallel_flags(our, default_parallel=DEFAULT_PARALLEL)
 
 
 def parse_num_processes(str_value: str) -> int | None:
@@ -46,7 +46,11 @@ def parse_num_processes(str_value: str) -> int | None:
     return value
 
 
-def parallel_flags(our: ArgumentParser, default_parallel: int, no_args: bool = False) -> None:  # noqa: FBT001, FBT002
+def parallel_flags(
+    our: ArgumentParser,
+    default_parallel: int | str,
+    no_args: bool = False,  # noqa: FBT001, FBT002
+) -> None:
     our.add_argument(
         "-p",
         "--parallel",


### PR DESCRIPTION
There is no functional reason to have the ArgumentParser default be `auto_detect_cpus()`, as the option goes through a parser, `parse_num_processes()`, that replaces "auto" with `auto_detect_cpus()`, i.e. the CPU count.

Making the default "auto" makes the documentation clearer and reproducible. Currently the [tox docs](https://tox.wiki/en/latest/cli_interface.html#tox-run-parallel-(p)) say:
>   -p VAL, --parallel VAL - run tox environments in parallel, the
>   argument controls limit: all, auto - cpu count, some positive number,
>   zero is turn off (default: 2)

That is misleading to end users: the default is not `2`, but `auto`; 2 just happens to be the CPU count of the machine that generated these docs.

Note that there was a DEFAULT_PARALLEL constant, that was however unused, as a result of an earlier refactoring. Reuse that constant for "auto" here.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder (too minor)
- [ ] updated/extended the documentation (too minor)