### PR TITLE
docs(plugin): explain plugin registration

### DIFF
--- a/docs/changelog/3116.doc.rst
+++ b/docs/changelog/3116.doc.rst
@@ -1,0 +1,1 @@
+Explain how plugins are registered and discovered - by :user:`hashar`.

--- a/src/tox/plugin/__init__.py
+++ b/src/tox/plugin/__init__.py
@@ -1,6 +1,19 @@
 """
-tox uses `pluggy <https://pluggy.readthedocs.io/en/stable/>`_ to customize the default behaviour. For example the
-following code snippet would define a new ``--magic`` command line interface flag the user can specify:
+tox uses `pluggy <https://pluggy.readthedocs.io/en/stable/>`_ to customize the default behaviour. It provides an
+extension mechanism for plugin management an calling hooks.
+
+Pluggy discovers a plugin by looking up for entry-points named ``tox``, for example in a pyproject.toml:
+
+.. code-block:: toml
+
+    [project.entry-points.tox]
+    your_plugin = "your_plugin.hooks"
+
+Therefore, to start using a plugin, you solely need to install it in the same environment tox is running in and it will
+be discovered via the defined entry-point (in the example above, tox will load ``your_plugin.hooks``).
+
+A plugin is created by implementing extension points in the form of hooks. For example the following code snippet would
+define a new ``--magic`` command line interface flag the user can specify:
 
 .. code-block:: python
 


### PR DESCRIPTION
In the legacy branch, the plugin documentation described plugins get discovered by being in the same environment. That documentation was not ported to the new branch. The doc was originally added by hff7143e7c991b1a80e7ec1ea6836ef3a21b5a812

Notably https://tox.wiki/en/3.27.1/plugins.html#using-plugins had:

> To start using a plugin you need to install it in the same environment where the tox host is installed.

Which gives a hint.

I also wondered how the discoverability works via Pluggy, that is done by having the plugin to register a `tox` entry-point which allows tox to find the plugin module. Document that.

While writing a plugin, that would have helped me find out how to install or enable it when it is indeed automatic (as long as a tox entry-point is defined by the plugin).

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix  (documentation only, so not applicable?)
- [x] added news fragment in `docs/changelog` folder (~~not sure whether it is worth mentioning~~, turns out that is required by CI)
- [x] updated/extended the documentation
