### PR TITLE
Remove stray colons in `config.rst` left over from #3111

### DIFF
--- a/docs/changelog/3118.bugfix.rst
+++ b/docs/changelog/3118.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug in ``config.rst`` by removing stray colons left over from (:issue:`3111`) - by :user:`posita`. (:issue:`3118`)
+Fix bug in ``config.rst`` by removing stray colons left over from (:issue:`3111`) - by :user:`posita`.

--- a/docs/changelog/3118.bugfix.rst
+++ b/docs/changelog/3118.bugfix.rst
@@ -1,0 +1,2 @@
+- Fix bug in ``config.rst`` by removing stray colons left over from (:issue:`3111`) - by
+  :user:`posita`. (:issue:`3118`)

--- a/docs/changelog/3118.bugfix.rst
+++ b/docs/changelog/3118.bugfix.rst
@@ -1,2 +1,1 @@
-- Fix bug in ``config.rst`` by removing stray colons left over from (:issue:`3111`) - by
-  :user:`posita`. (:issue:`3118`)
+Fix bug in ``config.rst`` by removing stray colons left over from (:issue:`3111`) - by :user:`posita`. (:issue:`3118`)

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1023,19 +1023,19 @@ For example, given this config:
       foo=bar
     commands = pytest tests
 
-You could enable ``ignore_errors`` by running::
+You could enable ``ignore_errors`` by running:
 
 .. code-block:: bash
 
    tox --override testenv.ignore_errors=True
 
-You could add additional dependencies by running::
+You could add additional dependencies by running:
 
 .. code-block:: bash
 
    tox --override testenv.deps+=pytest-xdist,pytest-cov
 
-You could set additional environment variables by running::
+You could set additional environment variables by running:
 
 .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,7 +55,7 @@ Installing an unreleased version is discouraged and should be only done for test
 a pip version of at least ``18.0.0`` and use the following command:
 
 
-.. code-block:: console
+.. code-block:: bash
 
     pip install git+https://github.com/tox-dev/tox.git@rewrite
 


### PR DESCRIPTION
Fixes #3118. (See screenshot below.)

Also addresses small (ab)use of `.. code-block:: console` in `installation.rst`, which is meant for use with interactive sessions.

[![screenshot](https://github.com/tox-dev/tox/assets/222581/bb5f2b1d-d5b2-45fe-8547-720553592f28)](https://github.com/tox-dev/tox/assets/222581/b4f24c23-a3d8-4ffb-aeca-00d4414f9dac)

Also viewable in the [revised `config.rst`](https://github.com/posita/tox/blob/posita/0/revert-breaking-doc-changes/docs/config.rst#overriding-configuration-from-the-command-line) (compared to the [original `config.rst`](https://github.com/tox-dev/tox/blob/main/docs/config.rst#overriding-configuration-from-the-command-line)).

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [X] added news fragment in `docs/changelog` folder
- [X] updated/extended the documentation
