### PR TITLE
Adds `/tests/demo_pkg_inline/.tox` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ __pycache__
 *.swp
 *.egg-info
 /tests/demo_pkg_setuptools/build/lib/demo_pkg_setuptools/__init__.py
+/tests/demo_pkg_inline/.tox
 /tests/demo_pkg_inline.lock

--- a/docs/changelog/3121.misc.rst
+++ b/docs/changelog/3121.misc.rst
@@ -1,0 +1,1 @@
+Add ``/tests/demo_pkg_inline/.tox`` to ``.gitignore`` - by :user:`posita`. (:issue:`3121`)

--- a/docs/changelog/3121.misc.rst
+++ b/docs/changelog/3121.misc.rst
@@ -1,1 +1,1 @@
-Add ``/tests/demo_pkg_inline/.tox`` to ``.gitignore`` - by :user:`posita`. (:issue:`3121`)
+Add ``/tests/demo_pkg_inline/.tox`` to ``.gitignore`` - by :user:`posita`.


### PR DESCRIPTION
Previously, `tests/demo_pkg_inline/.tox` (its creation being a side effect of, e.g., `tox -e docs`) would show up as untracked.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [X] ensured there are test(s) validating the fix
- [X] added news fragment in `docs/changelog` folder
- [X] updated/extended the documentation
