### PR TITLE
Fix error caused by a bad `base_python` path

### DIFF
--- a/docs/changelog/3105.bugfix.rst
+++ b/docs/changelog/3105.bugfix.rst
@@ -1,0 +1,1 @@
+Handle ``FileNotFoundError`` when the ``base_python`` interpreter doesn't exist

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -132,7 +132,7 @@ class VirtualEnv(Python):
         # the base pythons are injected into the virtualenv_env_vars, so we don't need to use it here
         try:
             interpreter = self.creator.interpreter
-        except RuntimeError:  # if can't find
+        except (FileNotFoundError, RuntimeError):  # Unable to find the interpreter
             return None
         return PythonInfo(
             implementation=interpreter.implementation,

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -277,3 +277,13 @@ def test_list_installed_deps_explicit_cli(
         assert "pip==" in result.out
     else:
         assert "pip==" not in result.out
+
+
+def test_usedevelop_with_nonexistent_basepython(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.ini": "[testenv]\nusedevelop = true\n[testenv:unused]\nbasepython = /nonexistent/bin/python",
+        },
+    )
+    result = project.run()
+    assert result.code == 0

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -280,10 +280,7 @@ def test_list_installed_deps_explicit_cli(
 
 
 def test_usedevelop_with_nonexistent_basepython(tox_project: ToxProjectCreator) -> None:
-    project = tox_project(
-        {
-            "tox.ini": "[testenv]\nusedevelop = true\n[testenv:unused]\nbasepython = /nonexistent/bin/python",
-        },
-    )
+    ini = "[testenv]\nusedevelop = true\n[testenv:unused]\nbasepython = /nonexistent/bin/python"
+    project = tox_project({"tox.ini": ini})
     result = project.run()
     assert result.code == 0


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

Resolves #3105 by catching the `FileNotFoundError` that gets raised when `usedevelop=true` in combination with a bad `base_python` path.

- [ :heavy_check_mark: ] ran the linter to address style issues (`tox -e fix`)
- [ :heavy_check_mark: ] wrote descriptive pull request text
- [ :heavy_check_mark: ] ensured there are test(s) validating the fix
- [ :heavy_check_mark: ] added news fragment in `docs/changelog` folder
- [ :heavy_check_mark: ] updated/extended the documentation
