### PR TITLE
Fix `quickstart` command from requiring `root` positional argument

### DIFF
--- a/docs/changelog/3084.bugfix.rst
+++ b/docs/changelog/3084.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``quickstart`` command from requiring ``root`` positional argument

--- a/src/tox/session/cmd/quickstart.py
+++ b/src/tox/session/cmd/quickstart.py
@@ -27,6 +27,7 @@ def tox_add_option(parser: ToxParser) -> None:
         "quickstart_root",
         metavar="root",
         default=Path().absolute(),
+        nargs="?",
         help="folder to create the tox.ini file",
         type=Path,
     )

--- a/tests/session/cmd/test_quickstart.py
+++ b/tests/session/cmd/test_quickstart.py
@@ -53,3 +53,8 @@ def test_quickstart_refuse(tox_project: ToxProjectCreator) -> None:
 def test_quickstart_help(tox_project: ToxProjectCreator) -> None:
     outcome = tox_project({"tox.ini": ""}).run("q", "-h")
     outcome.assert_success()
+
+
+def test_quickstart_no_args(tox_project: ToxProjectCreator) -> None:
+    outcome = tox_project({}).run("q")
+    outcome.assert_success()


### PR DESCRIPTION
Resolves #3084 

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [:heavy_check_mark:  ] ran the linter to address style issues (`tox -e fix`)
- [:heavy_check_mark:  ] wrote descriptive pull request text
- [:heavy_check_mark:  ] ensured there are test(s) validating the fix
- [:heavy_check_mark:  ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
