### PR TITLE
docs(config): fix default value for install_command

### DIFF
--- a/docs/changelog/3126.doc.rst
+++ b/docs/changelog/3126.doc.rst
@@ -1,0 +1,1 @@
+Fix default value for ``install_command`` - by :user:`hashar`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -795,7 +795,7 @@ Pip installer
 
 .. conf::
    :keys: install_command
-   :default: python -I -m pip install <opts> <packages>
+   :default: python -I -m pip install {opts} {packages}
    :version_added: 1.6
 
    Determines the command used for installing packages into the virtual environment; both the package under test and its


### PR DESCRIPTION
The `install_command` config is documented as having the default value:
```
python -I -m pip install <opts> <packages>
```
The last two arguments are not substituable and are thus passed as is (eg as packages to install) resulting in:
```
py3-test: install_deps> python -I -m pip install -v '<opts>'
'<packages>' '.[test]'
ERROR: Invalid requirement: '<opts>'
```
Adjust the documentation to use the replaceable variables: `{opts}` and `{packages}`.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix (documentation only)
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
