### PR TITLE
Fix terminal size in tox commands (#2999)

### DIFF
--- a/docs/changelog/2999.bugfix.rst
+++ b/docs/changelog/2999.bugfix.rst
@@ -1,0 +1,1 @@
+Fix terminal size of tox subcommands (fixes ipython, ipdb, prompt_toolkit, ...).

--- a/src/tox/execute/local_sub_process/__init__.py
+++ b/src/tox/execute/local_sub_process/__init__.py
@@ -314,7 +314,7 @@ def _pty(key: str) -> tuple[int, int] | None:
     # adjust sub-process terminal size
     columns, lines = shutil.get_terminal_size(fallback=(-1, -1))
     if columns != -1 and lines != -1:
-        size = struct.pack("HHHH", columns, lines, 0, 0)
+        size = struct.pack("HHHH", lines, columns, 0, 0)
         fcntl.ioctl(child, termios.TIOCSWINSZ, size)
 
     return main, child


### PR DESCRIPTION
Found it! And because it took me 6 hours to debug it, I'm going to describe how the debugging went.

At first, I started debugging the tox itself. Quickly I managed to discover, the issue can be triggered by `python3 -c "from prompt_toolkit import prompt; prompt('Give me some input: ')"` which behaved differently in tox and outside. After couple of hours trying to navigate the tox internals I landed at `ReadViaThreadUnix` where I noticed it print a significant number of '\r\n' pairs after the prompt. That led me to the `prompt_toolkit`. I spend some time there, until I discovered the screen it renders within tox has an unusual height. A but later I noticed the screen it tries to render have switched values of columns and rows when compared to `COLUMNS` and `ROWS` pass in env values by tox. Bit more digging lead to `os.get_terminal_size()`. The MWE was now just simply:

```ini
[testenv]
deps = ipython
commands =
    python3 -c "import os; print(os.get_terminal_size())"
```

```console
# tox
py: commands[0]> python3 -c 'import os; print(os.get_terminal_size())'
os.terminal_size(columns=54, lines=189)

# .tox/py/bin/python3 -c 'import os; print(os.get_terminal_size())'
os.terminal_size(columns=189, lines=54)
```

I had no idea what to do now, but I didn't want to give up. I realized I could just grep `tox` source code for columns and I finally found match in `_pty` function. I tried to switch the two arguments and voila, works like a charm.

This PR is not yet finished, I haven't found how to design a test for this and I'm too tired at the moment. I hope to add it soon.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] ~~updated/extended the documentation~~
