### PR TITLE
Create a `.gitignore` in `work_dir` and info file directories

### DIFF
--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -413,6 +413,9 @@ class EnvSelector:
             yield name
 
     def ensure_only_run_env_is_active(self) -> None:
+        if not self._state.conf.core["work_dir"].exists():
+            self._state.conf.core["work_dir"].mkdir()
+            (self._state.conf.core["work_dir"] / ".gitignore").write_text("*", encoding="utf-8")
         envs, active = self._defined_envs, self._env_name_to_active()
         invalid = [n for n, a in active.items() if a and isinstance(envs[n].env, PackageToxEnv)]
         if invalid:

--- a/src/tox/tox_env/info.py
+++ b/src/tox/tox_env/info.py
@@ -63,6 +63,8 @@ class Info:
 
     def _write(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        if not (self._path.parent / ".gitignore").exists():
+            (self._path.parent / ".gitignore").write_text("*", encoding="utf-8")
         self._path.write_text(json.dumps(self._content, indent=2))
 
 


### PR DESCRIPTION
> ## NOTE:
>
> Tests, and possibly documentation, are still needed for this work. Please confirm the implementation is acceptable (for example, perhaps a helper function is desirable).

This PR introduces blanket `.gitignore` files that are created in the following locations:

* In the `work_dir` (such as `.tox/`)
* Wherever an info JSON file is written

This addresses several issues I found when running tox under the following circumstances:

```bash
# Create a completely empty directory, then initialize git.
mkdir test-tox
cd test-tox
git init

# Run `tox` with an environment for an interpreter that IS NOT installed.
# RESULT: `.tox/py40/.tox-info.json` visible to git
tox -e py40

# Run `tox devenv` with an environment for an interpreter that IS NOT installed.
# RESULT: `venv/.tox-info.json` visible to git
tox devenv -e py40

# Run `tox devenv` with an environment for an interpreter that IS installed.
# RESULT: `.tox/py/log/1-install_package.log` is visible to git
tox devenv -e py
```

The changes introduced in this PR address the visibility of these files in git.

Closes #2530

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text

Still to do:

- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
