### PR TITLE
Fix skip_missing_interpreters with package=wheel

### DIFF
--- a/docs/changelog/3152.bugfix.rst
+++ b/docs/changelog/3152.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``skip_missing_interpreters`` with ``package=wheel``

--- a/src/tox/tox_env/python/package.py
+++ b/src/tox/tox_env/python/package.py
@@ -119,7 +119,13 @@ class PythonPackageToxEnv(Python, PackageToxEnv, ABC):
 
     def child_pkg_envs(self, run_conf: EnvConfigSet) -> Iterator[PackageToxEnv]:
         if run_conf["package"] == "wheel":
-            env = self._wheel_build_envs.get(run_conf["wheel_build_env"])
+            try:
+                env = self._wheel_build_envs.get(run_conf["wheel_build_env"])
+            except Skip:
+                if self.core["skip_missing_interpreters"]:
+                    return
+                else:
+                    raise
             if env is not None and env.name != self.name:
                 yield env
 

--- a/tests/session/cmd/test_depends.py
+++ b/tests/session/cmd/test_depends.py
@@ -16,6 +16,7 @@ def test_depends(tox_project: ToxProjectCreator, patch_prev_py: Callable[[bool],
     ini = f"""
     [tox]
     env_list = py,{py},{prev_py},py31,cov2,cov
+    skip_missing_interpreters = false
     [testenv]
     package = wheel
     [testenv:cov]

--- a/tests/tox_env/python/test_python_runner.py
+++ b/tests/tox_env/python/test_python_runner.py
@@ -152,6 +152,17 @@ def test_config_skip_missing_interpreters(
     assert result.code == (0 if expected else -1)
 
 
+def test_config_skip_missing_interpreters_package_wheel(
+    tox_project: ToxProjectCreator,
+) -> None:
+    py_ver = ".".join(str(i) for i in sys.version_info[0:2])
+    project = tox_project(
+        {"tox.ini": f"[tox]\nenvlist=py4,py{py_ver}\nskip_missing_interpreters=true\n[testenv]\npackage=wheel"}
+    )
+    result = project.run()
+    assert result.code == 0
+
+
 @pytest.mark.parametrize(
     ("skip", "env", "retcode"),
     [


### PR DESCRIPTION
`skip_missing_interpreters` is broken when using `package=wheel`.

### To reproduce
**tox.ini**
```ini
[tox]
skip_missing_interpreters = true
envlist = py{37,38,39,310,311,312}

[testenv]
package = wheel
allowlist_externals = echo
commands =
  echo "hey"
```

### Note

This issue was basically already reported in https://github.com/tox-dev/tox/issues/2811 under a slight different variation. I'm worried that there are still 30 other badly-tested edge cases where `skip_missing_interpreters` breaks.

#### Checks

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
