### PR TITLE
docs(config): Fix base_python default reference

### DIFF
--- a/docs/changelog/3156.doc.rst
+++ b/docs/changelog/3156.doc.rst
@@ -1,0 +1,1 @@
+Fix default value for ``base_python`` - by :user:`rpatterson`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -530,7 +530,7 @@ Python options
 ~~~~~~~~~~~~~~
 .. conf::
    :keys: base_python, basepython
-   :default: {package_root}
+   :default: <{env_name} python factor> or <python version of tox>
 
    Name or path to a Python interpreter which will be used for creating the virtual environment, first one found wins.
    This determines in practice the Python for what we'll create a virtual isolated environment. Use this to specify the


### PR DESCRIPTION
The previous description of `{package_root}` doesn't make much sense because it doesn't have anything to do with Python versions.  I'm guessing it was a copy and paste that wasn't updated.

Change it to a value that tries to be both short and accurate matching the conventions observed in other options.

- [ ] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- ~~[ ] ensured there are test(s) validating the fix~~
- [x] added news fragment in `docs/changelog` folder
- [X] updated/extended the documentation
