### PR TITLE
Fixed 'AppData' not passed to env by default (#3151)

### DIFF
--- a/docs/changelog/3151.bugfix.rst
+++ b/docs/changelog/3151.bugfix.rst
@@ -1,1 +1,1 @@
-Added 'AppData' to the default passed enviroment variables on Windows. 
+Added 'AppData' to the default passed enviroment variables on Windows.

--- a/docs/changelog/3151.bugfix.rst
+++ b/docs/changelog/3151.bugfix.rst
@@ -1,0 +1,1 @@
+Added 'AppData' to the default passed enviroment variables on Windows. 

--- a/docs/changelog/3151.bugfix.rst
+++ b/docs/changelog/3151.bugfix.rst
@@ -1,1 +1,1 @@
-Added 'AppData' to the default passed enviroment variables on Windows.
+Added 'AppData' to the default passed environment variables on Windows.

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -118,6 +118,7 @@ class Python(ToxEnv, ABC):
         if sys.platform == "win32":  # pragma: win32 cover
             env.extend(
                 [
+                    "APPDATA",  # Needed for PIP platformsdirs.windows
                     "PROGRAMDATA",  # needed for discovering the VS compiler
                     "PROGRAMFILES(x86)",  # needed for discovering the VS compiler
                     "PROGRAMFILES",  # needed for discovering the VS compiler

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -264,7 +264,7 @@ def test_show_config_matching_env_section(tox_project: ToxProjectCreator) -> Non
 
 
 def test_package_env_inherits_from_pkgenv(tox_project: ToxProjectCreator, demo_pkg_inline: Path) -> None:
-    project = tox_project({"tox.ini": "[pkgenv]\npass_env = A, B\ndeps=C\n D"})
+    project = tox_project({"tox.ini": "[pkgenv]\npass_env = A, AA\ndeps=C\n D"})
     outcome = project.run("c", "--root", str(demo_pkg_inline), "-k", "deps", "pass_env", "-e", "py,.pkg")
     outcome.assert_success()
     exp = """
@@ -274,7 +274,7 @@ def test_package_env_inherits_from_pkgenv(tox_project: ToxProjectCreator, demo_p
       D
     pass_env =
       A
-      B
+      AA
     """
     exp = dedent(exp)
     assert exp in outcome.out

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -119,7 +119,9 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
     pass_env = outcome.env_conf("py")["pass_env"]
     is_win = sys.platform == "win32"
     expected = (
-        ["CC", "CCSHARED", "CFLAGS"]
+        []
+        + (["APPDATA"] if is_win else [])
+        + ["CC", "CCSHARED", "CFLAGS"]
         + (["COMSPEC"] if is_win else [])
         + ["CPPFLAGS", "CURL_CA_BUNDLE", "CXX", "HOME", "LANG", "LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH"]
         + (["MSYSTEM", "NUMBER_OF_PROCESSORS", "PATHEXT"] if is_win else [])


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

Fixes AppData missing in environment variables by default.
It was found in setuptools_scm that on some machines it was not able to find the version in HG as AppData is required. I assume it is related to where Pythons packages are placed per default.

I have not updated documentation as I did not see any documentation about what environment variables are passed per default. 

Issue where problem was found:
https://github.com/pypa/setuptools_scm/issues/861

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
