### PR TITLE
Exclude bots from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [n/a] ensured there are test(s) validating the fix
- [n/a] added news fragment in `docs/changelog` folder
- [n/a] updated/extended the documentation

Like https://github.com/tox-dev/tox-ini-fmt/pull/120, will help releases like https://github.com/tox-dev/tox/releases/tag/4.11.4.

![image](https://github.com/tox-dev/tox/assets/1324225/e8cd289b-8b35-4706-a977-59b4d89f9752)
