### PR TITLE
Always pass FORCE_COLOR & NO_COLOR to the environment

### DIFF
--- a/docs/changelog/3171.feature.rst
+++ b/docs/changelog/3171.feature.rst
@@ -1,0 +1,1 @@
+Always pass ``FORCE_COLOR`` and ``NO_COLOR`` to the environment

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -219,6 +219,8 @@ class ToxEnv(ABC):
             "LD_LIBRARY_PATH",  # location of libs
             "LDFLAGS",  # linker flags
             "HOME",  # needed for `os.path.expanduser()` on non-Windows systems
+            "FORCE_COLOR",  # force color output
+            "NO_COLOR",  # disable color output
         ]
         if sys.stdout.isatty():  # if we're on a interactive shell pass on the TERM
             env.append("TERM")

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -123,8 +123,11 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
         + (["APPDATA"] if is_win else [])
         + ["CC", "CCSHARED", "CFLAGS"]
         + (["COMSPEC"] if is_win else [])
-        + ["CPPFLAGS", "CURL_CA_BUNDLE", "CXX", "HOME", "LANG", "LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH"]
-        + (["MSYSTEM", "NUMBER_OF_PROCESSORS", "PATHEXT"] if is_win else [])
+        + ["CPPFLAGS", "CURL_CA_BUNDLE", "CXX", "FORCE_COLOR", "HOME", "LANG"]
+        + ["LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH"]
+        + (["MSYSTEM"] if is_win else [])
+        + ["NO_COLOR"]
+        + (["NUMBER_OF_PROCESSORS", "PATHEXT"] if is_win else [])
         + ["PIP_*", "PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_SYSROOT_DIR"]
         + (["PROCESSOR_ARCHITECTURE"] if is_win else [])
         + (["PROGRAMDATA"] if is_win else [])


### PR DESCRIPTION
The environment variables `FORCE_COLOR` and `NO_COLOR`are a popular way to force or disable color output. An example usage is pytest being run under a CI system.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
