### PR TITLE
Fix 'open an issue' link in development.rst

### DIFF
--- a/docs/changelog/3179.doc.rst
+++ b/docs/changelog/3179.doc.rst
@@ -1,0 +1,1 @@
+-Fix ``open an issue`` link in development.rst

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -9,7 +9,7 @@ Getting started
 help you get started with development, testing, and documentation. We’re pleased that you are interested in working on
 tox. This document is meant to get you setup to work on tox and to act as a guide and reference to the development
 setup. If you face any issues during this process, please
-:issue:`new?title=Trouble+with+development+environment` about it on the issue tracker.
+:issue:`open an issue <new?title=Trouble+with+development+environment>` about it on the issue tracker.
 
 Setup
 ~~~~~


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

Before:
![image](https://github.com/tox-dev/tox/assets/153674/9d59a4a2-33d9-4289-a5ee-2c7cfb84ab71)

After:
![image](https://github.com/tox-dev/tox/assets/153674/a2b7e760-5f8a-4e91-a9c3-99c145e5910b)


- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
