### PR TITLE
Highlight environment names when listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 *.egg-info
 /tests/demo_pkg_setuptools/build/lib/demo_pkg_setuptools/__init__.py
 /tests/demo_pkg_inline.lock
+**/.tox

--- a/docs/changelog/3181.bugfix.rst
+++ b/docs/changelog/3181.bugfix.rst
@@ -1,0 +1,1 @@
+environment names are colored when running ``tox list``

--- a/src/tox/session/cmd/list_env.py
+++ b/src/tox/session/cmd/list_env.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from itertools import chain
 from typing import TYPE_CHECKING
 
+from colorama import Fore, Style
+
 from tox.plugin import impl
 from tox.session.env_select import register_env_select_flags
 
@@ -20,7 +22,7 @@ def tox_add_option(parser: ToxParser) -> None:
     d.add_argument("-d", action="store_true", help="list just default envs", dest="list_default_only")
 
 
-def list_env(state: State) -> int:
+def list_env(state: State) -> int:  # noqa: C901
     option = state.conf.options
     has_group_select = bool(option.factors or option.labels)
     active_only = has_group_select or option.list_default_only
@@ -39,7 +41,12 @@ def list_env(state: State) -> int:
             if not text.strip():
                 text = "[no description]"
             text = text.replace("\n", " ")
-            msg = f"{env.ljust(max_length)} -> {text}".strip()
+            color: int | str = Fore.CYAN if state.conf.options.is_colored else ""
+
+            def _c(val: int) -> str:
+                return str(val) if color else ""
+
+            msg = f"{color}{env.ljust(max_length)}{_c(Style.RESET_ALL)} -> {text}".strip()
         else:
             msg = env
         print(msg)  # noqa: T201


### PR DESCRIPTION
This change makes is easier to read the environment names when they are listed by adding a color highlight.


![](https://sbarnea.com/ss/Screen-Shot-2024-01-03-11-17-42.26.png)

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
