### PR TITLE
docs/config.rst: State in config directive sections their ini file sections

### DIFF
--- a/docs/changelog/3194.doc.rst
+++ b/docs/changelog/3194.doc.rst
@@ -1,0 +1,1 @@
+Configuration: state in config directive sections their ini file sections - by :user:`0cjs`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -102,6 +102,8 @@ examples first and use this page as a reference.
 Core
 ----
 
+The following options are set in the ``[tox]`` section of ``tox.ini`` or the ``[tox:tox]`` section of ``setup.cfg``.
+
 .. conf::
    :keys: requires
    :default: <empty list>
@@ -236,6 +238,8 @@ Python language core options
 
 tox environment
 ---------------
+
+The following options are set in the ``[testenv]`` or ``[testenv:*]`` sections of ``tox.ini`` or ``setup.cfg``.
 
 Base options
 ~~~~~~~~~~~~


### PR DESCRIPTION
[Full description in the commit message(s).]

- [x] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

I did not copy the commit messages into the pull request because [Say everything once and only once][once].

The tests validating the fix are `tox -e docs`; these pass. (And these are useful; they caught an RST syntax error.)

I did not add a new fragment to the changelog because this seems too small to bother readers of that file with.

The full set of tests (`tox`) has at least one failure; this occurs on the `main` branch also.


[once]: https://www.oreilly.com/library/view/extreme-programming-installed/0201708426/0201708426_art03lev1sec3.html