### PR TITLE
Fix `main` branch used by diff-cover to work in more situations

### DIFF
--- a/src/tox/config/of_type.py
+++ b/src/tox/config/of_type.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 V = TypeVar("V")
 
+def unused_function(x: int, y: int) -> int:
+    ''' Temporary addition to test coverage. '''
+    z = x + y
+    return z
 
 class ConfigDefinition(ABC, Generic[T]):  # noqa: PLW1641
     """Abstract base class for configuration definitions."""

--- a/src/tox/config/of_type.py
+++ b/src/tox/config/of_type.py
@@ -16,10 +16,11 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 V = TypeVar("V")
 
+
 def unused_function(x: int, y: int) -> int:
-    ''' Temporary addition to test coverage. '''
-    z = x + y
-    return z
+    """Temporary addition to test coverage."""
+    return x + y
+
 
 class ConfigDefinition(ABC, Generic[T]):  # noqa: PLW1641
     """Abstract base class for configuration definitions."""

--- a/tests/config/test_of_types.py
+++ b/tests/config/test_of_types.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from tox.config.of_type import ConfigConstantDefinition, ConfigDynamicDefinition
 
 
+def test_unused_function():
+    ''' Temporary addition to test coverage. '''
+    from tox.config.of_type import unused_function
+    assert 5 == unused_function(2,3)
+
+
 def test_config_constant_eq() -> None:
     val_1 = ConfigConstantDefinition(("key",), "description", "value")
     val_2 = ConfigConstantDefinition(("key",), "description", "value")

--- a/tests/config/test_of_types.py
+++ b/tests/config/test_of_types.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from tox.config.of_type import ConfigConstantDefinition, ConfigDynamicDefinition
 
 
-def test_unused_function():
-    ''' Temporary addition to test coverage. '''
+def test_unused_function() -> None:
+    """Temporary addition to test coverage."""
     from tox.config.of_type import unused_function
-    assert 5 == unused_function(2,3)
+
+    assert unused_function(2, 3) == 5
 
 
 def test_config_constant_eq() -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
       --cov-report xml:{toxworkdir}{/}coverage.{envname}.xml \
       -n={env:PYTEST_XDIST_AUTO_NUM_WORKERS:auto} \
       tests --durations 5 --run-integration}
-    diff-cover --compare-branch {env:DIFF_AGAINST:origin/main} {toxworkdir}{/}coverage.{envname}.xml
+    diff-cover --compare-branch {env:DIFF_AGAINST:main@{upstream}} {toxworkdir}{/}coverage.{envname}.xml
 
 [testenv:fix]
 description = format the code base to adhere to our styles, and complain about what we cannot do automatically


### PR DESCRIPTION
__WARNING:__ to make manual checks easier, there is a temporary "test" commit on this dev branch that must be removed before merging. (@0cjs will do this on request, or you can do it yourself if you don't want to wait.)

See the commit message for a detailed description of the change and its rationale.

To see that the change is working, you can run `tox -e py11 -- tests/config/test_of_types.py` or similar; you should see that diff-cover finds that the to-be-removed test commit has 100% coverage of its new code. There were previously no automated tests to show that diff-cover is working correctly, and I have not added any because that seems very difficult to do and not worth the cost.

Checklist:
- linter: not needed; this code is not covered by it
- descriptive PR text: not copied from the commit message because [DRY]
- tests validating fix: see above
- news fragment: per commit message, not needed or wanted because it's not a user-visible change (or change to the tox program at all)
- updated/extended documentation: there's a suggestion in the commit message, but as it requires further discussion, I am leaving that for a separate PR.

[DRY]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
