### PR TITLE
Add tests for CliEnv

### DIFF
--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -17,25 +17,26 @@ CURRENT_PY_ENV = f"py{sys.version_info[0]}{sys.version_info[1]}"  # e.g. py310
 
 
 @pytest.mark.parametrize(
-    ("user_input",      "env_names",            "is_all",   "is_default" ), [
-    (None,              (),                     False,      True         ),
-    ("",                (),                     False,      True         ),
-    ("a1",              ("a1",),                False,      False        ),
-    ("a1,b2,c3",        ("a1", "b2", "c3"),     False,      False        ),
-    #   If the user gives "ALL" as any envname, this becomes an "is_all" and other envnames are ignored.
-    ("ALL",             (),                     True,       False        ),
-    ("a1,ALL,b2",       (),                     True,       False        ),
-    #   Zero-length envnames are ignored as being not present. This is not intentional.
-    (",,a1,,,b2,,",     ("a1", "b2"),           False,      False        ),
-    (",,",              (),                     False,      True         ),
-    #   Environment names with "invalid" characters are accepted here; the client is expected to deal with this.
-    ("\x01.-@\x02,xxx", ("\x01.-@\x02", "xxx"), False,      False        ),
+    ("user_input", "env_names", "is_all", "is_default"),
+    [
+        (None, (), False, True),
+        ("", (), False, True),
+        ("a1", ("a1",), False, False),
+        ("a1,b2,c3", ("a1", "b2", "c3"), False, False),
+        #   If the user gives "ALL" as any envname, this becomes an "is_all" and other envnames are ignored.
+        ("ALL", (), True, False),
+        ("a1,ALL,b2", (), True, False),
+        #   Zero-length envnames are ignored as being not present. This is not intentional.
+        (",,a1,,,b2,,", ("a1", "b2"), False, False),
+        (",,", (), False, True),
+        #   Environment names with "invalid" characters are accepted here; the client is expected to deal with this.
+        ("\x01.-@\x02,xxx", ("\x01.-@\x02", "xxx"), False, False),
     ],
 )
 def test_clienv(user_input: str, env_names: tuple[str], is_all: bool, is_default: bool) -> None:
     ce = CliEnv(user_input)
-    assert (ce.is_all, ce.is_default_list, tuple(ce)) \
-        == (is_all,    is_default,         tuple(env_names))
+    assert (ce.is_all, ce.is_default_list, tuple(ce)) == (is_all, is_default, tuple(env_names))
+
 
 @pytest.mark.parametrize(
     ("user_input", "expected"),

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -16,6 +16,14 @@ if TYPE_CHECKING:
 CURRENT_PY_ENV = f"py{sys.version_info[0]}{sys.version_info[1]}"  # e.g. py310
 
 
+def test_env_select_lazily_looks_at_envs() -> None:
+    state = State(get_options(), [])
+    env_selector = EnvSelector(state)
+    # late-assigning env should be reflected in env_selector
+    state.conf.options.env = CliEnv("py")
+    assert set(env_selector.iter()) == {"py"}
+
+
 def test_label_core_can_define(tox_project: ToxProjectCreator) -> None:
     ini = """
         [tox]
@@ -128,14 +136,6 @@ def test_tox_skip_env_logs(tox_project: ToxProjectCreator, monkeypatch: MonkeyPa
     outcome = project.run("l", "--no-desc")
     outcome.assert_success()
     outcome.assert_out_err("ROOT: skip environment mypy, matches filter 'm[y]py'\npy310\npy39\n", "")
-
-
-def test_env_select_lazily_looks_at_envs() -> None:
-    state = State(get_options(), [])
-    env_selector = EnvSelector(state)
-    # late-assigning env should be reflected in env_selector
-    state.conf.options.env = CliEnv("py")
-    assert set(env_selector.iter()) == {"py"}
 
 
 def test_cli_env_can_be_specified_in_default(tox_project: ToxProjectCreator) -> None:

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -16,6 +16,41 @@ if TYPE_CHECKING:
 CURRENT_PY_ENV = f"py{sys.version_info[0]}{sys.version_info[1]}"  # e.g. py310
 
 
+@pytest.mark.parametrize(
+    ("user_input",      "env_names",            "is_all",   "is_default" ), [
+    (None,              (),                     False,      True         ),
+    ("",                (),                     False,      True         ),
+    ("a1",              ("a1",),                False,      False        ),
+    ("a1,b2,c3",        ("a1", "b2", "c3"),     False,      False        ),
+    #   If the user gives "ALL" as any envname, this becomes an "is_all" and other envnames are ignored.
+    ("ALL",             (),                     True,       False        ),
+    ("a1,ALL,b2",       (),                     True,       False        ),
+    #   Zero-length envnames are ignored as being not present. This is not intentional.
+    (",,a1,,,b2,,",     ("a1", "b2"),           False,      False        ),
+    (",,",              (),                     False,      True         ),
+    #   Environment names with "invalid" characters are accepted here; the client is expected to deal with this.
+    ("\x01.-@\x02,xxx", ("\x01.-@\x02", "xxx"), False,      False        ),
+    ],
+)
+def test_clienv(user_input: str, env_names: tuple[str], is_all: bool, is_default: bool) -> None:
+    ce = CliEnv(user_input)
+    assert (ce.is_all, ce.is_default_list, tuple(ce)) \
+        == (is_all,    is_default,         tuple(env_names))
+
+@pytest.mark.parametrize(
+    ("user_input", "expected"),
+    [
+        ("", False),
+        ("all", False),
+        ("All", False),
+        ("ALL", True),
+        ("a,ALL,b", True),
+    ],
+)
+def test_clienv_is_all(user_input: str, expected: bool) -> None:
+    assert CliEnv(user_input).is_all is expected
+
+
 def test_env_select_lazily_looks_at_envs() -> None:
     state = State(get_options(), [])
     env_selector = EnvSelector(state)


### PR DESCRIPTION
This is a start on issue #3199. The plan for that involves changing CliEnv; this starts documenting its current behaviour by adding tests for it.

The final reformatting commit may need to be squashed into the previous commit; see that commit message for details.

No news fragment because this isn't a user-visible change. No documentation yet because that will be informed by review of this commit.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
