### PR TITLE
session.env_select.CliEnv: Document and test spaces behaviour

### DIFF
--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -27,13 +27,15 @@ LOGGER = logging.getLogger(__name__)
 
 
 class CliEnv:  # noqa: PLW1641
-    """A `CliEnv` is the user's selection of tox test environments, usually supplied via the ``-e`` command-line
-    option. It may be treated as a sequence if it's not a "default" or "all" selection.
+    """A `CliEnv` is the user's selection of tox test environments, usually supplied via the ``-e`` command-line option
+    or in a TOML file (typically ``env_list`` in ``tox.ini``). It may be treated as a sequence if it's not a "default"
+    or "all" selection.
 
     It is in one of three forms:
 
     - A list of specific environments, instantiated with a string that is a comma-separated list of the environment
-      names. As a sequence this will be a sequence of those names.
+      names. (These may have spaces on either side of the commas which are removed.) As a sequence this will be a
+      sequence of those names.
 
     - "ALL" which is all environments defined by the tox configuration. This is instantiated with ``ALL`` either
       alone or as any element of a comma-separated list; any other environment names are ignored. `is_all()` will be

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -23,6 +23,7 @@ CURRENT_PY_ENV = f"py{sys.version_info[0]}{sys.version_info[1]}"  # e.g. py310
         ("", (), False, True),
         ("a1", ("a1",), False, False),
         ("a1,b2,c3", ("a1", "b2", "c3"), False, False),
+        (" a1, b2 ,  c3  ", ("a1", "b2", "c3"), False, False),
         #   If the user gives "ALL" as any envname, this becomes an "is_all" and other envnames are ignored.
         ("ALL", (), True, False),
         ("a1,ALL,b2", (), True, False),


### PR DESCRIPTION
It turns out that spaces on either side of environment names in a comma-separated list are considered not part of the environment name and removed. This was neither documented nor tested directly; that's now fixed. (It was and is still also tested in `config.cli.test_cli_ini.test_ini_exhaustive_parallel_values` as well.)

The discovery of this was documented in issue #3207.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [✓] ran the linter to address style issues (`tox -e fix`)
- [✓] wrote descriptive pull request text
- [✓] ensured there are test(s) validating the fix
- [n/a] added news fragment in `docs/changelog` folder
- [✓] updated/extended the documentation
