### PR TITLE
Revert previous "precommit autoupdate (#3214)" commit; it's broken

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black==23.12.1]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.1.14
     hooks:
       - id: ruff-format
       - id: ruff

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -189,7 +189,7 @@ class EnvSelector:
         for env in self._cli_envs or []:
             if env.startswith(".pkg_external"):  # external package
                 continue
-            factors: dict[str, str | None] = dict.fromkeys(env.split("-"))
+            factors: dict[str, str | None] = {k: None for k in env.split("-")}
             found_factors: set[str] = set()
             for factor in factors:
                 if (

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -139,7 +139,7 @@ class ToxEnv(ABC):
 
         def pass_env_post_process(values: list[str]) -> list[str]:
             values.extend(self._default_pass_env())
-            result = sorted(dict.fromkeys(values).keys())
+            result = sorted({k: None for k in values}.keys())
             invalid_chars = set(string.whitespace)
             invalid = [v for v in result if any(c in invalid_chars for c in v)]
             if invalid:


### PR DESCRIPTION
The top-level linter setting names in pyproject.toml have changed, and while this _could_ accept the old names until they're fixed, it choses not to and fails the build.

Fixing that is easy, but results in yet more failures that were not previously appearing in unchanged code.

- Revert "[pre-commit.ci] pre-commit autoupdate (#3214)"
- This reverts commit 3347933a4e3d5cda8f993ffccc3f79b5a01a819c.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [n/a] ensured there are test(s) validating the fix
- [n/a] added news fragment in `docs/changelog` folder
- [n/a] updated/extended the documentation
