### PR TITLE
pyproject.toml: Move certain tool.ruff settings to tool.ruff.lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,11 +103,11 @@ build.targets.sdist.include = ["/src", "/tests", "/tox.ini"]
 version.source = "vcs"
 
 [tool.ruff]
-select = ["ALL"]
+lint.select = ["ALL"]
 line-length = 120
 target-version = "py38"
-isort = { known-first-party = ["tox", "tests"], required-imports = ["from __future__ import annotations"] }
-ignore = [
+lint.isort = { known-first-party = ["tox", "tests"], required-imports = ["from __future__ import annotations"] }
+lint.ignore = [
   "CPY",     # No copyright header
   "INP001",  # no implicit namespaces here
   "D",       # ignore documentation for now
@@ -132,7 +132,7 @@ ignore = [
 ]
 format.preview = true
 lint.preview = true
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
   "S101",    # asserts allowed in tests...
   "FBT",     # don"t care about booleans as positional arguments in tests


### PR DESCRIPTION
tool.ruff.{select,isort,ignore,per-file-ignores} will soon be deprecated in favour of putting these under tool.ruff.lint. (See reverted PR #3214 for the complaint that appears in a more recent version of ruff.) Change these now to avoid complaints later.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [n/a] ensured there are test(s) validating the fix
- [n/a] added news fragment in `docs/changelog` folder
- [n/a] updated/extended the documentation
