### PR TITLE
Removed unneeded line

### DIFF
--- a/docs/changelog/3241.doc
+++ b/docs/changelog/3241.doc
@@ -1,0 +1,2 @@
+Removed unused line from the 'fresh_subprocess' documentation.
+  

--- a/docs/changelog/3241.doc
+++ b/docs/changelog/3241.doc
@@ -1,2 +1,2 @@
 Removed unused line from the 'fresh_subprocess' documentation.
-  
+

--- a/docs/changelog/3241.doc.rst
+++ b/docs/changelog/3241.doc.rst
@@ -1,2 +1,1 @@
 Removed unused line from the 'fresh_subprocess' documentation.
-

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -802,7 +802,6 @@ Python virtual environment packaging
    A flag controlling if each call to the build backend should be done in a fresh subprocess or not (especially older
    build backends such as ``setuptools`` might require this to discover newly provisioned dependencies).
 
-   Directory where to put the project metadata files.
 
 Pip installer
 ~~~~~~~~~~~~~


### PR DESCRIPTION
I guess it's a copy/paste left-over from `meta_dir` when creating the documentation for the new `fresh_subprocess`?

~(I assume there's no need for a changelog entry for this change? I can add one if desired.)~