### PR TITLE
Fix dropped leading characters `c` from constraints' packages

### DIFF
--- a/docs/changelog/3247.bugfix.rst
+++ b/docs/changelog/3247.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue that the leading character ``c`` was dropped from packages in constraints files - by :user:`jugmac00`.

--- a/tests/tox_env/python/pip/test_pip_install.py
+++ b/tests/tox_env/python/pip/test_pip_install.py
@@ -309,8 +309,8 @@ def constrained_mock_project(
         "build.py": (demo_pkg_inline / "build.py").read_text(),
     }
     exp_constraints: list[str] = []
-    requirement = "foo==1.2.3"
-    constraint = "foo<2"
+    requirement = "coo==1.2.3"
+    constraint = "coo<2"
     if request.param == "explicit":
         deps = requirement
         exp_constraints.append(requirement)


### PR DESCRIPTION
`lstrip` takes a set, not a string, so `.lstrip("-c ")` did not work as intended.

Until we only support Python 3.9 or higher, we need to use a custom function to remove a prefix. With Python 3.9+ we can use the builtin `.removeprefix`.

This fixes #3247.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
