### PR TITLE
Remove duplicated and misleading configuration section

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -519,15 +519,6 @@ Run
 
    tox package type used to package.
 
-Packaging
-~~~~~~~~~
-.. conf::
-   :keys: package_root, setupdir
-   :default: {package_root}
-   :ref_suffix: env
-
-   Indicates where the packaging root file exists (historically setup.py file or pyproject.toml now).
-
 .. _python-options:
 
 Python options


### PR DESCRIPTION
The removed section described `package_root` in a way which could be interpreted that it is a configuration option for a testenv, whereas it is a configuration option for the tox section, which is already properly documented.
