### PR TITLE
Update installation.rst

### DIFF
--- a/docs/changelog/3257.bugfix.rst
+++ b/docs/changelog/3257.bugfix.rst
@@ -1,0 +1,1 @@
+Fix non-existing branch ``rewrite`` in the documentation to ``main``.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -57,7 +57,7 @@ a pip version of at least ``18.0.0`` and use the following command:
 
 .. code-block:: bash
 
-    pip install git+https://github.com/tox-dev/tox.git@rewrite
+    pip install git+https://github.com/tox-dev/tox.git@main
 
 .. _compatibility-requirements:
 


### PR DESCRIPTION

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation


I'm following [the installation doc](https://tox.wiki/en/4.14.2/installation.html#latest-unreleased) to try tox and noticed the command to install the latest unreleased tox seems incorrect. so I changed the non-existing branch from  ``rewrite``  to ``main``.
