### PR TITLE
Allow appending to deps with the command line

### DIFF
--- a/docs/changelog/3256.bugfix.rst
+++ b/docs/changelog/3256.bugfix.rst
@@ -1,0 +1,1 @@
+Allow appending to ``deps`` with ``--override testenv.deps+=foo`` - by :user:`stefanor`.

--- a/src/tox/config/loader/api.py
+++ b/src/tox/config/loader/api.py
@@ -5,6 +5,7 @@ from argparse import ArgumentTypeError
 from typing import TYPE_CHECKING, Any, List, Mapping, TypeVar
 
 from tox.plugin import impl
+from tox.tox_env.python.pip.req_file import PythonDeps
 
 from .convert import Convert, Factory
 from .str_convert import StrConvert
@@ -148,6 +149,8 @@ class Loader(Convert[T]):
                 converted.update(converted_override)
             elif isinstance(converted, SetEnv) and isinstance(converted_override, SetEnv):
                 converted.update(converted_override, override=True)
+            elif isinstance(converted, PythonDeps) and isinstance(converted_override, PythonDeps):
+                converted += converted_override
             else:
                 msg = "Only able to append to lists and dicts"
                 raise ValueError(msg)

--- a/src/tox/tox_env/python/pip/req_file.py
+++ b/src/tox/tox_env/python/pip/req_file.py
@@ -118,6 +118,10 @@ class PythonDeps(RequirementsFile):
             self._unroll = result_opts, result_req
         return self._unroll
 
+    def __iadd__(self, other: PythonDeps) -> PythonDeps:  # noqa: PYI034
+        self._raw += "\n" + other._raw
+        return self
+
     @classmethod
     def factory(cls, root: Path, raw: object) -> PythonDeps:
         if not isinstance(raw, str):

--- a/tests/tox_env/python/pip/test_req_file.py
+++ b/tests/tox_env/python/pip/test_req_file.py
@@ -67,3 +67,10 @@ def test_opt_only_req_file(tmp_path: Path) -> None:
     python_deps = PythonDeps(raw="-rr.txt", root=tmp_path)
     assert not python_deps.requirements
     assert python_deps.options == Namespace(features_enabled=["fast-deps"])
+
+
+def test_req_iadd(tmp_path: Path) -> None:
+    a = PythonDeps(raw="foo", root=tmp_path)
+    b = PythonDeps(raw="bar", root=tmp_path)
+    a += b
+    assert a.lines() == ["foo", "bar"]


### PR DESCRIPTION
Allow appending to deps with `-x testenv.deps+=foo`

Fixes: #3256

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
