### PR TITLE
Support multiple override appends

### DIFF
--- a/docs/changelog/3261.feature.rst
+++ b/docs/changelog/3261.feature.rst
@@ -1,0 +1,1 @@
+Add support for multiple appending override options (-x, --override) on command line - by :user:`amitschang`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1037,13 +1037,26 @@ You could add additional dependencies by running:
 
 .. code-block:: bash
 
-   tox --override testenv.deps+=pytest-xdist,pytest-cov
+   tox --override testenv.deps+=pytest-xdist
 
 You could set additional environment variables by running:
 
 .. code-block:: bash
 
    tox --override testenv.setenv+=baz=quux
+
+You can specify overrides multiple times on the command line to append multiple items:
+
+.. code-block:: bash
+
+   tox -x testenv.seteenv+=foo=bar -x testenv.setenv+=baz=quux
+   tox -x testenv.deps+=pytest-xdist -x testenv.deps+=pytest-cov
+
+Or reset override and append to that (note the first override is ``=`` and not ``+=``):
+
+.. code-block:: bash
+
+   tox -x testenv.deps=pytest-xdist -x testenv.deps+=pytest-cov
 
 Set CLI flags via environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/config/loader/ini/test_ini_loader.py
+++ b/tests/config/loader/ini/test_ini_loader.py
@@ -21,7 +21,7 @@ def test_ini_loader_keys(mk_ini_conf: Callable[[str], ConfigParser]) -> None:
 def test_ini_loader_repr(mk_ini_conf: Callable[[str], ConfigParser]) -> None:
     core = IniSection(None, "tox")
     loader = IniLoader(core, mk_ini_conf("\n[tox]\n\na=b\nc=d\n\n"), [Override("tox.a=1")], core_section=core)
-    assert repr(loader) == "IniLoader(section=tox, overrides={'a': Override('tox.a=1')})"
+    assert repr(loader) == "IniLoader(section=tox, overrides={'a': [Override('tox.a=1')]})"
 
 
 def test_ini_loader_has_section(mk_ini_conf: Callable[[str], ConfigParser]) -> None:

--- a/tests/config/loader/test_loader.py
+++ b/tests/config/loader/test_loader.py
@@ -42,6 +42,12 @@ def test_override_append(flag: str) -> None:
     assert value.append is True
 
 
+@pytest.mark.parametrize("flag", ["-x", "--override"])
+def test_override_multiple(flag: str) -> None:
+    parsed, _, __, ___, ____ = get_options(flag, "magic+=1", flag, "magic+=2")
+    assert len(parsed.override) == 2
+
+
 def test_override_equals() -> None:
     assert Override("a=b") == Override("a=b")
 

--- a/tests/config/loader/test_memory_loader.py
+++ b/tests/config/loader/test_memory_loader.py
@@ -18,7 +18,7 @@ def test_memory_loader_repr() -> None:
 
 def test_memory_loader_override() -> None:
     loader = MemoryLoader(a=1)
-    loader.overrides["a"] = Override("a=2")
+    loader.overrides["a"] = [Override("a=2")]
     args = ConfigLoadArgs([], "name", None)
     loaded = loader.load("a", of_type=int, conf=None, factory=None, args=args)
     assert loaded == 2


### PR DESCRIPTION
Currently only the last override supplied is considered, in conflict with now supported append overrides ("+="). This now enables appending multiple times via the command line.

The docs are also misleading for dependencies, where seems to imply a comma-separated list of dependencies can be given in the override, but there is no handling of this (and there probably shouldn't be, since `,` is a possible character in version spec).

With this change, something like

```sh
tox -e env -x testenv.deps+=debugpy -x testenv.deps+=pytest
```

 would be possible.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
