### PR TITLE
Add bang to invert exit code

### DIFF
--- a/docs/changelog/3271.feature.rst
+++ b/docs/changelog/3271.feature.rst
@@ -1,1 +1,1 @@
-Add support for inverting exit code success critera using bang (!)
+Add support for inverting exit code success criteria using bang (!)

--- a/docs/changelog/3271.feature.rst
+++ b/docs/changelog/3271.feature.rst
@@ -1,0 +1,1 @@
+Add support for inverting exit code success critera using bang (!)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -187,11 +187,21 @@ a given command add a ``-`` prefix to that line (similar syntax to how the GNU `
 
 .. code-block:: ini
 
-
    [testenv]
    commands =
      - python -c 'import sys; sys.exit(1)'
      python --version
+
+You can also choose to provide a ``!`` prefix instead to purposely invert the exit code, making the line fail if the
+command returned exit code 0. Any other exit code is considered a success.
+
+.. code-block:: ini
+
+   [testenv]
+   commands =
+     ! python -c 'import sys; sys.exit(1)'
+     python --version
+
 
 Customizing virtual environment creation
 ----------------------------------------

--- a/src/tox/config/types.py
+++ b/src/tox/config/types.py
@@ -16,15 +16,20 @@ class Command:  # noqa: PLW1641
         :param args: the command line arguments (first value can be ``-`` to indicate ignore the exit code)
         """
         self.ignore_exit_code: bool = args[0] == "-"  #: a flag indicating if the exit code should be ignored
-        self.args: list[str] = args[1:] if self.ignore_exit_code else args  #: the command line arguments
+        self.invert_exit_code: bool = args[0] == "!"  #: a flag for flipped exit code (non-zero = success, 0 = error)
+        self.args: list[str] = (
+            args[1:] if self.ignore_exit_code or self.invert_exit_code else args
+        )  #: the command line arguments
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(args={(['-'] if self.ignore_exit_code else []) + self.args!r})"
+        args = (["-"] if self.ignore_exit_code else ["!"] if self.invert_exit_code else []) + self.args
+        return f"{type(self).__name__}(args={args!r})"
 
     def __eq__(self, other: object) -> bool:
-        return type(self) == type(other) and (self.args, self.ignore_exit_code) == (
+        return type(self) == type(other) and (self.args, self.ignore_exit_code, self.invert_exit_code) == (
             other.args,  # type: ignore[attr-defined]
             other.ignore_exit_code,  # type: ignore[attr-defined]
+            other.invert_exit_code,  # type: ignore[attr-defined]
         )
 
     def __ne__(self, other: object) -> bool:

--- a/src/tox/execute/api.py
+++ b/src/tox/execute/api.py
@@ -252,6 +252,12 @@ class Outcome:
             self._assert_fail()
         self.log_run_done(logging.INFO)
 
+    def assert_failure(self) -> None:
+        """Assert that the execution failed."""
+        if self.exit_code is not None and self.exit_code == self.OK:
+            self._assert_fail()
+        self.log_run_done(logging.INFO)
+
     def _assert_fail(self) -> NoReturn:
         if self.show_on_standard is False:
             if self.out:

--- a/src/tox/session/cmd/run/single.py
+++ b/src/tox/session/cmd/run/single.py
@@ -112,7 +112,10 @@ def run_command_set(
         )
         outcomes.append(current_outcome)
         try:
-            current_outcome.assert_success()
+            if cmd.invert_exit_code:
+                current_outcome.assert_failure()
+            else:
+                current_outcome.assert_success()
         except SystemExit as exception:
             if cmd.ignore_exit_code:
                 logging.warning("command failed but is marked ignore outcome so handling it as success")

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -6,13 +6,22 @@ from tox.config.types import Command, EnvList
 def tests_command_repr() -> None:
     cmd = Command(["python", "-m", "pip", "list"])
     assert repr(cmd) == "Command(args=['python', '-m', 'pip', 'list'])"
+    assert cmd.invert_exit_code is False
     assert cmd.ignore_exit_code is False
 
 
 def tests_command_repr_ignore() -> None:
     cmd = Command(["-", "python", "-m", "pip", "list"])
     assert repr(cmd) == "Command(args=['-', 'python', '-m', 'pip', 'list'])"
+    assert cmd.invert_exit_code is False
     assert cmd.ignore_exit_code is True
+
+
+def tests_command_repr_invert() -> None:
+    cmd = Command(["!", "python", "-m", "pip", "list"])
+    assert repr(cmd) == "Command(args=['!', 'python', '-m', 'pip', 'list'])"
+    assert cmd.invert_exit_code is True
+    assert cmd.ignore_exit_code is False
 
 
 def tests_command_eq() -> None:
@@ -24,7 +33,8 @@ def tests_command_eq() -> None:
 def tests_command_ne() -> None:
     cmd_1 = Command(["python", "-m", "pip", "list"])
     cmd_2 = Command(["-", "python", "-m", "pip", "list"])
-    assert cmd_1 != cmd_2
+    cmd_3 = Command(["!", "python", "-m", "pip", "list"])
+    assert cmd_1 != cmd_2 != cmd_3
 
 
 def tests_env_list_repr() -> None:


### PR DESCRIPTION
This makes it so that you can provide a "!" before the command line to invert the success/failure of a command. Just like with regular POSIX shell. This is useful if you expect that the command should crash / return an error.

Currently, to achieve this behavior, you'd have to do wrap it in a shell command: `sh -c "! python3 -m foo"` and that won't necessarily use the correct virtualenv.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
