### PR TITLE
Fix broad build privileges @ GHA release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,12 @@ on:
   push:
     tags: ["*"]
 
+env:
+  dists-artifact-name: python-package-distributions
+
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: release
-      url: https://pypi.org/project/tox/${{ github.ref_name }}
-    permissions:
-      id-token: write
     steps:
       - name: Setup python to build package
         uses: actions/setup-python@v5
@@ -23,5 +21,26 @@ jobs:
           fetch-depth: 0
       - name: Build package
         run: pyproject-build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.dists-artifact-name }}
+          path: dist/*
+
+  release:
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/project/tox/${{ github.ref_name }}
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.dists-artifact-name }}
+          path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
-      url: https://pypi.org/p/tox
+      url: https://pypi.org/project/tox/${{ github.ref_name }}
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build package
-        run: pyproject-build -s -w . -o dist
+        run: pyproject-build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.14


### PR DESCRIPTION
This makes sure the GHA workflow follows the principle of the least privilege, preventing possible future privilege escalation attacks through poisoning the build dependencies. While the level of privilege compromise suggested already means the compromise of PyPI, the attack surface here is any other services that make use of OIDC and may be connected separately to the repository without considering this workflow, at some point.
So this patch follows the suggestions outlined in https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ to separate privileges through standalone jobs with individual privileges.
It also makes the URLs rendered in the UI more accurate. And while on it, I simplified the build command into the form that is closer to what pip does — making pypa/build create an sdist from Git but wheel from that sdist. Previously, both were made from Git.