### PR TITLE
Allow `ConfigSet.add_config` to receive parameterized generics for `of_type`.

### DIFF
--- a/docs/changelog/3288.bugfix.rst
+++ b/docs/changelog/3288.bugfix.rst
@@ -1,0 +1,1 @@
+Allow ``ConfigSet.add_config`` to receive parameterized generics for ``of_type``.

--- a/src/tox/config/loader/convert.py
+++ b/src/tox/config/loader/convert.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from pathlib import Path
@@ -39,6 +40,10 @@ class Convert(ABC, Generic[T]):
             return self.to_env_list(raw)  # type: ignore[return-value]
         if issubclass(of_type, str):
             return self.to_str(raw)  # type: ignore[return-value]
+        # python does not allow use of parametrized generics with isinstance,
+        # so we need to check for them.
+        if hasattr(typing, "GenericAlias") and isinstance(of_type, typing.GenericAlias):
+            return list(self.to_list(raw, of_type=of_type))  # type: ignore[return-value]
         if isinstance(raw, of_type):  # already target type no need to transform it
             # do it this late to allow normalization - e.g. string strip
             return raw

--- a/tests/config/loader/test_str_convert.py
+++ b/tests/config/loader/test_str_convert.py
@@ -57,6 +57,19 @@ def test_str_convert_ok(raw: str, value: Any, of_type: type[Any]) -> None:
     assert result == value
 
 
+# Tests that can work only with py39 or newer due to type not being subscriptible before
+if sys.version_info >= (3, 9):
+    @pytest.mark.parametrize(
+        ("raw", "value", "of_type"),
+        [
+            ("", None, Optional[list[str]]),
+            ("1,2", ["1", "2"], Optional[list[str]]),
+        ],
+    )
+    def test_str_convert_ok_py39(raw: str, value: Any, of_type: type[Any]) -> None:
+        result = StrConvert().to(raw, of_type, None)
+        assert result == value
+
 @pytest.mark.parametrize(
     ("raw", "of_type", "exc_type", "msg"),
     [

--- a/tests/config/loader/test_str_convert.py
+++ b/tests/config/loader/test_str_convert.py
@@ -59,6 +59,7 @@ def test_str_convert_ok(raw: str, value: Any, of_type: type[Any]) -> None:
 
 # Tests that can work only with py39 or newer due to type not being subscriptible before
 if sys.version_info >= (3, 9):
+
     @pytest.mark.parametrize(
         ("raw", "value", "of_type"),
         [
@@ -69,6 +70,7 @@ if sys.version_info >= (3, 9):
     def test_str_convert_ok_py39(raw: str, value: Any, of_type: type[Any]) -> None:
         result = StrConvert().to(raw, of_type, None)
         assert result == value
+
 
 @pytest.mark.parametrize(
     ("raw", "of_type", "exc_type", "msg"),


### PR DESCRIPTION
Allow `ConfigSet.add_config` to receive parameterized generics for `of_type`.

Fixes: #3287

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
