### PR TITLE
Fix section substitution with setenv

### DIFF
--- a/docs/changelog/3262.bugfix.rst
+++ b/docs/changelog/3262.bugfix.rst
@@ -1,0 +1,1 @@
+Fix section substitution with setenv.

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -93,6 +93,7 @@ class SetEnv:
             expanded_line = self._replacer(line, ConfigLoadArgs([], self._name, self._env_name))
             sub_raw = dict(self._extract_key_value(sub_line) for sub_line in expanded_line.splitlines() if sub_line)
             self._raw.update(sub_raw)
+            self.changed = True  # loading while iterating can cause these values to be missed
             yield from sub_raw.keys()
 
     def update(self, param: Mapping[str, str] | SetEnv, *, override: bool = True) -> None:

--- a/tests/tox_env/test_api.py
+++ b/tests/tox_env/test_api.py
@@ -21,3 +21,14 @@ def test_dont_cleanup_temp_dir(tox_project: ToxProjectCreator, tmp_path: Path) -
     result = project.run()
     result.assert_success()
     assert (tmp_path / "foo" / "bar").exists()
+
+
+def test_setenv_section_substitution(tox_project: ToxProjectCreator) -> None:
+    ini = """[variables]
+    var = VAR = val
+    [testenv]
+    setenv = {[variables]var}
+    commands = python -c 'import os; os.environ["VAR"]'"""
+    project = tox_project({"tox.ini": ini})
+    result = project.run()
+    result.assert_success()


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

Fixes https://github.com/tox-dev/tox/issues/3262, resolving the environment variable name now causes the previous cache to be invalidated.
