### PR TITLE
Add `windir` to the default list of `pass_env` variables on Windows

### DIFF
--- a/docs/changelog/3302.bugfix.rst
+++ b/docs/changelog/3302.bugfix.rst
@@ -1,0 +1,1 @@
+- Add ``windir`` to the default list of Windows ``pass_env`` environment variables. - by :user:`kurtmckee`

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -231,6 +231,7 @@ class ToxEnv(ABC):
                     "USERPROFILE",  # needed for `os.path.expanduser()`
                     "PATHEXT",  # needed for discovering executables
                     "MSYSTEM",  # controls paths printed format
+                    "WINDIR",  # base path to system executables and DLLs
                 ],
             )
         else:  # pragma: win32 no cover

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -137,7 +137,9 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
         + (["SYSTEMDRIVE", "SYSTEMROOT", "TEMP"] if is_win else [])
         + (["TERM"] if stdout_is_atty else [])
         + (["TMP", "USERPROFILE"] if is_win else ["TMPDIR"])
-        + ["VIRTUALENV_*", "http_proxy", "https_proxy", "no_proxy"]
+        + ["VIRTUALENV_*"]
+        + (["WINDIR"] if is_win else [])
+        + ["http_proxy", "https_proxy", "no_proxy"]
     )
     assert pass_env == expected
 


### PR DESCRIPTION
This PR adds `windir` to the default list of Windows `pass_env` environment variables.

`windir` is a system environment variable that has existed since Windows 95. Like `TMP` and `USERPROFILE`, it is assumed to exist and no software documents that it should be set. It is often difficult to figure out that crashes and errors are caused by a missing `windir` environment variable.

This change allows Windows software that relies on `windir` to work out-of-the-box.

> [!NOTE]
>
> The canonical spelling of `windir` is lowercase. This PR uses an uppercase variant based on PR feedback.

Fixes #3302

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
