### PR TITLE
Add GraalPy and test both GraalPy and Jython env identifiers

### DIFF
--- a/docs/changelog/3312.feature.rst
+++ b/docs/changelog/3312.feature.rst
@@ -1,0 +1,1 @@
+Add "graalpy" prefix as a supported base python

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -116,6 +116,7 @@ implementations of Python and provide default values for ``base_python``:
 - ``cpythonNM``: configures ``basepython = cpythonN.M``
 - ``ironpythonNM``: configures ``basepython = ironpythonN.M``
 - ``rustpythonNM``: configures ``basepython = rustpythonN.M``
+- ``graalpyNM``: configures ``basepython = graalpyN.M``
 
 You can also specify these factors with a period between the major and minor versions (e.g. ``pyN.M``), without a minor
 version (e.g. ``pyN``), or without any version information whatsoever (e.g. ``py``)

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -51,7 +51,7 @@ class PythonInfo(NamedTuple):
 PY_FACTORS_RE = re.compile(
     r"""
     ^(?!py$)                                               # don't match 'py' as it doesn't provide any info
-    (?P<impl>py|pypy|cpython|jython|rustpython|ironpython) # the interpreter; most users will simply use 'py'
+    (?P<impl>py|pypy|cpython|jython|graalpy|rustpython|ironpython) # the interpreter; most users will simply use 'py'
     (?P<version>[2-9]\.?[0-9]?[0-9]?)?$                    # the version; one of: MAJORMINOR, MAJOR.MINOR
     """,
     re.VERBOSE,

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -84,6 +84,8 @@ def test_diff_msg_no_diff() -> None:
         ("py3.12", "py3.12"),
         ("pypy2", "pypy2"),
         ("rustpython3", "rustpython3"),
+        ("graalpy", "graalpy"),
+        ("jython", "jython"),
         ("cpython3.8", "cpython3.8"),
         ("ironpython2.7", "ironpython2.7"),
         ("functional-py310", "py310"),


### PR DESCRIPTION
tox "supports" Jython, IronPython, RustPython in the sense that they can specified for an env, and they are matched and passed on to virtualenv. Not supporting GraalPy at least to this same minimal extent means we cannot run tests against virtualenv. GraalPy is included with manylinux and supported by uv, but our patch to add support to the virtualenv project cannot pass their CI unless tox at least matches the `graalpy` env string and passes that on via `VIRTUALENV_PYTHON`.

So this PR adds that minimum of support, including a parameter to a test. I couldn't find a single test checking the match for Jython, so I added that parameter as well. Afaict this puts GraalPy and Jython on the same level as RustPython and IronPython.

(relates to #3148)