### PR TITLE
Fix #3318 - Suppress spinner in parallel runs in CI

### DIFF
--- a/docs/changelog/3318.feature.rst
+++ b/docs/changelog/3318.feature.rst
@@ -1,0 +1,1 @@
+Suppress spinner in parallel runs in CI - by :user:`ziima`.

--- a/src/tox/session/cmd/run/parallel.py
+++ b/src/tox/session/cmd/run/parallel.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from tox.plugin import impl
 from tox.session.env_select import CliEnv, register_env_select_flags
+from tox.util.ci import is_ci
 from tox.util.cpu import auto_detect_cpus
 
 from .common import env_run_create_flags, execute
@@ -28,7 +29,7 @@ def tox_add_option(parser: ToxParser) -> None:
     our = parser.add_command("run-parallel", ["p"], "run environments in parallel", run_parallel)
     register_env_select_flags(our, default=CliEnv())
     env_run_create_flags(our, mode="run-parallel")
-    parallel_flags(our, default_parallel=DEFAULT_PARALLEL)
+    parallel_flags(our, default_parallel=DEFAULT_PARALLEL, default_spinner=is_ci())
 
 
 def parse_num_processes(str_value: str) -> int | None:
@@ -51,6 +52,8 @@ def parallel_flags(
     our: ArgumentParser,
     default_parallel: int | str,
     no_args: bool = False,  # noqa: FBT001, FBT002
+    *,
+    default_spinner: bool = False,
 ) -> None:
     our.add_argument(
         "-p",
@@ -75,7 +78,11 @@ def parallel_flags(
         "--parallel-no-spinner",
         action="store_true",
         dest="parallel_no_spinner",
-        help="run tox environments in parallel, but don't show the spinner, implies --parallel",
+        default=default_spinner,
+        help=(
+            "run tox environments in parallel, but don't show the spinner, implies --parallel. "
+            "Disabled by default if CI is detected (not in legacy API)."
+        ),
     )
 
 

--- a/tests/session/cmd/test_legacy.py
+++ b/tests/session/cmd/test_legacy.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
-from unittest.mock import patch
 
 import pytest
 
@@ -123,12 +121,14 @@ def test_legacy_run_sequential(tox_project: ToxProjectCreator, mocker: MockerFix
     assert run_sequential.call_count == 1
 
 
-def test_legacy_run_sequential_ci(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+def test_legacy_run_sequential_ci(
+    tox_project: ToxProjectCreator, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test legacy run sequential in CI by default."""
     run_sequential = mocker.patch("tox.session.cmd.legacy.run_sequential")
+    monkeypatch.setenv("CI", "1")
 
-    with patch.dict(os.environ, {"CI": "1"}):
-        tox_project({"tox.ini": ""}).run("le", "-e", "py")
+    tox_project({"tox.ini": ""}).run("le", "-e", "py")
 
     assert run_sequential.call_count == 1
 

--- a/tests/session/cmd/test_legacy.py
+++ b/tests/session/cmd/test_legacy.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -117,6 +119,16 @@ def test_legacy_run_sequential(tox_project: ToxProjectCreator, mocker: MockerFix
     run_sequential = mocker.patch("tox.session.cmd.legacy.run_sequential")
 
     tox_project({"tox.ini": ""}).run("le", "-e", "py")
+
+    assert run_sequential.call_count == 1
+
+
+def test_legacy_run_sequential_ci(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+    """Test legacy run sequential in CI by default."""
+    run_sequential = mocker.patch("tox.session.cmd.legacy.run_sequential")
+
+    with patch.dict(os.environ, {"CI": "1"}):
+        tox_project({"tox.ini": ""}).run("le", "-e", "py")
 
     assert run_sequential.call_count == 1
 

--- a/tests/session/cmd/test_parallel.py
+++ b/tests/session/cmd/test_parallel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from argparse import ArgumentTypeError
 from signal import SIGINT
@@ -177,6 +178,19 @@ def test_parallel_no_spinner(tox_project: ToxProjectCreator) -> None:
     """Ensure passing `--parallel-no-spinner` implies `--parallel`."""
     with mock.patch.object(parallel, "execute") as mocked:
         tox_project({"tox.ini": ""}).run("p", "--parallel-no-spinner")
+
+    mocked.assert_called_once_with(
+        mock.ANY,
+        max_workers=None,
+        has_spinner=False,
+        live=False,
+    )
+
+
+def test_parallel_no_spinner_ci(tox_project: ToxProjectCreator) -> None:
+    """Ensure spinner is disabled by default in CI."""
+    with mock.patch.object(parallel, "execute") as mocked, mock.patch.dict(os.environ, {"CI": "1"}):
+        tox_project({"tox.ini": ""}).run("p")
 
     mocked.assert_called_once_with(
         mock.ANY,

--- a/tests/session/cmd/test_parallel.py
+++ b/tests/session/cmd/test_parallel.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sys
 from argparse import ArgumentTypeError
 from signal import SIGINT
@@ -187,10 +186,14 @@ def test_parallel_no_spinner(tox_project: ToxProjectCreator) -> None:
     )
 
 
-def test_parallel_no_spinner_ci(tox_project: ToxProjectCreator) -> None:
+def test_parallel_no_spinner_ci(
+    tox_project: ToxProjectCreator, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Ensure spinner is disabled by default in CI."""
-    with mock.patch.object(parallel, "execute") as mocked, mock.patch.dict(os.environ, {"CI": "1"}):
-        tox_project({"tox.ini": ""}).run("p")
+    mocked = mocker.patch.object(parallel, "execute")
+    monkeypatch.setenv("CI", "1")
+
+    tox_project({"tox.ini": ""}).run("p")
 
     mocked.assert_called_once_with(
         mock.ANY,


### PR DESCRIPTION
Suppress spinner in parallel run in CI (not legacy though).