### PR TITLE
Fixup the spec string for sys.executable

### DIFF
--- a/docs/changelog/3327.bugfix.rst
+++ b/docs/changelog/3327.bugfix.rst
@@ -1,0 +1,2 @@
+Fix and test the string spec for the ``sys.executable`` interpreter (introduced in :pull:`3325`)
+- by :user:`hroncok`

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -158,6 +158,14 @@ class Python(ToxEnv, ABC):
         return None
 
     @classmethod
+    def python_spec_for_sys_executable(cls) -> PythonSpec:
+        implementation = sys.implementation.name
+        version = sys.version_info
+        bits = "64" if sys.maxsize > 2**32 else "32"
+        string_spec = f"{implementation}{version.major}{version.minor}-{bits}"
+        return PythonSpec.from_string_spec(string_spec)
+
+    @classmethod
     def _validate_base_python(
         cls,
         env_name: str,
@@ -172,8 +180,7 @@ class Python(ToxEnv, ABC):
                 if spec_base.path is not None:
                     path = Path(spec_base.path).absolute()
                     if str(spec_base.path) == sys.executable:
-                        ver, is_64 = sys.version_info, sys.maxsize != 2**32
-                        spec_base = PythonSpec.from_string_spec(f"{sys.implementation}{ver.major}{ver.minor}-{is_64}")
+                        spec_base = cls.python_spec_for_sys_executable()
                     else:
                         spec_base = cls.python_spec_for_path(path)
                 if any(

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -158,7 +158,7 @@ class Python(ToxEnv, ABC):
         return None
 
     @classmethod
-    def python_spec_for_sys_executable(cls) -> PythonSpec:
+    def _python_spec_for_sys_executable(cls) -> PythonSpec:
         implementation = sys.implementation.name
         version = sys.version_info
         bits = "64" if sys.maxsize > 2**32 else "32"
@@ -180,7 +180,7 @@ class Python(ToxEnv, ABC):
                 if spec_base.path is not None:
                     path = Path(spec_base.path).absolute()
                     if str(spec_base.path) == sys.executable:
-                        spec_base = cls.python_spec_for_sys_executable()
+                        spec_base = cls._python_spec_for_sys_executable()
                     else:
                         spec_base = cls.python_spec_for_path(path)
                 if any(

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -311,7 +311,7 @@ def test_python_spec_for_sys_executable(impl: str, major: int, minor: int, arch:
     mocker.patch.object(sys, "version_info", version_info)
     mocker.patch.object(sys, "implementation", implementation)
     mocker.patch.object(sys, "maxsize", 2**arch // 2 - 1)
-    spec = Python._python_spec_for_sys_executable()
+    spec = Python._python_spec_for_sys_executable()  # noqa: SLF001
     assert spec.implementation == impl
     assert spec.major == major
     assert spec.minor == minor

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -311,7 +311,7 @@ def test_python_spec_for_sys_executable(impl: str, major: int, minor: int, arch:
     mocker.patch.object(sys, "version_info", version_info)
     mocker.patch.object(sys, "implementation", implementation)
     mocker.patch.object(sys, "maxsize", 2**arch // 2 - 1)
-    spec = Python.python_spec_for_sys_executable()
+    spec = Python._python_spec_for_sys_executable()
     assert spec.implementation == impl
     assert spec.major == major
     assert spec.minor == minor


### PR DESCRIPTION
The previous spec string was:

    namespace(name='cpython', cache_tag='cpython-313', version=sys.version_info(major=3, minor=13, micro=0, releaselevel='candidate', serial=1), hexversion=51183809, _multiarch='x86_64-linux-gnu')313-True

When it was supposed to be:

    cpython313-64

Fixes https://github.com/tox-dev/tox/pull/3325/files#r1718230254
Fixes https://github.com/tox-dev/tox/pull/3325/files#r1718246292

Adds tests for a new method.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
