### PR TITLE
Properly document the `tox_env_teardown` hook

### DIFF
--- a/docs/changelog/3305.doc.rst
+++ b/docs/changelog/3305.doc.rst
@@ -1,1 +1,1 @@
-Changes the `tox_env_teardown` docstring to explain the hook is called after a tox env was teared down.
+Changes the ``tox_env_teardown`` docstring to explain the hook is called after a tox env was teared down.

--- a/docs/changelog/3305.doc.rst
+++ b/docs/changelog/3305.doc.rst
@@ -1,0 +1,1 @@
+Changes the `tox_env_teardown` docstring to explain the hook is called after a tox env was teared down.

--- a/src/tox/plugin/spec.py
+++ b/src/tox/plugin/spec.py
@@ -94,7 +94,7 @@ def tox_on_install(tox_env: ToxEnv, arguments: Any, section: str, of_type: str) 
 @_spec
 def tox_env_teardown(tox_env: ToxEnv) -> None:  # noqa: ARG001
     """
-    Called before executing an installation command.
+    Called after a tox environment has been teared down.
 
     :param tox_env: the tox environment
     """


### PR DESCRIPTION
Previously the description from the `tox_on_install` hook was accidentally copied over to the `tox_env_teardown` hook.

 Fixes #3305.
