### PR TITLE
Add pypy-major.minor environment name support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,34 +31,27 @@ jobs:
           - windows-latest
           - macos-latest
     steps:
-      - name: Setup python for tox
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install self-tox
-        run: python -m pip install .
-      - name: Setup python for test ${{ matrix.py }}
-        uses: actions/setup-python@v5
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v3
         with:
-          python-version: ${{ matrix.py }}
-          allow-prereleases: true
-      - name: Pick environment to run
-        run: |
-          import os; import platform; import sys; from pathlib import Path
-          env = f'TOXENV=py{"" if platform.python_implementation() == "CPython" else "py"}3{sys.version_info.minor}'
-          print(f"Picked: {env} for {sys.version} based of {sys.executable}")
-          with Path(os.environ["GITHUB_ENV"]).open("ta") as file_handler:
-              file_handler.write(env)
-        shell: python
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add .local/bin to Windows PATH
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "$USERPROFILE/.local/bin" >> $GITHUB_PATH
+      - name: Install tox@self
+        run: uv tool install --python-preference only-managed --python ${{ matrix.py }} tox@.
       - name: Setup test suite
-        run: tox r -vv --notest --skip-missing-interpreters false
+        run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.py }}
       - name: Run test suite
-        run: tox r --skip-pkg-install
+        run: tox run --skip-pkg-install -e ${{ matrix.py }}
         env:
-          CI_RUN: "yes"
+          PYTEST_ADDOPTS: "-vv --durations=20"
           DIFF_AGAINST: HEAD
           PYTEST_XDIST_AUTO_NUM_WORKERS: 0
 
@@ -77,19 +70,24 @@ jobs:
           - ubuntu-latest
           - windows-latest
         exclude:
-          - { os: windows-latest, tox_env: pkg_meta }
           - { os: windows-latest, tox_env: docs }
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Python 3.12
-        uses: actions/setup-python@v5
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v3
         with:
-          python-version: "3.12"
-      - name: Install self-tox
-        run: python -m pip install .
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add .local/bin to Windows PATH
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "$USERPROFILE/.local/bin" >> $GITHUB_PATH
+      - name: Install tox@self
+        run: uv tool install --python-preference only-managed --python 3.13 tox@.
       - name: Setup check suite
-        run: tox r -vv --notest --skip-missing-interpreters false -e  ${{ matrix.tox_env }}
+        run: tox r -vv --notest --skip-missing-interpreters false -e ${{ matrix.tox_env }}
       - name: Run check for ${{ matrix.tox_env }}
         run: tox r --skip-pkg-install -e ${{ matrix.tox_env }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup python to build package
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install build
-        run: python -m pip install build[uv]
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build package
-        run: pyproject-build --installer uv
+        run: uv build --python 3.13 --python-preference only-managed --sdist --wheel . --out-dir dist
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
@@ -44,3 +44,5 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.10.1
+        with:
+          attestations: true

--- a/docs/changelog/3346.feature.rst
+++ b/docs/changelog/3346.feature.rst
@@ -1,0 +1,1 @@
+Support ``pypy-<major>.<minor>`` environment names for PyPy environments - by :user:`gaborbernat`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,12 +114,11 @@ def setup(app: Sphinx) -> None:
         ) -> Element:
             # fixup some wrongly resolved mappings
             mapping = {
-                "_io.TextIOWrapper": "io.TextIOWrapper",
                 "tox.config.of_type.T": "typing.TypeVar",  # used by Sphinx bases
                 "tox.config.loader.api.T": "typing.TypeVar",  # used by Sphinx bases
                 "tox.config.loader.convert.T": "typing.TypeVar",  # used by Sphinx bases
                 "tox.tox_env.installer.T": "typing.TypeVar",  # used by Sphinx bases
-                "concurrent.futures._base.Future": "concurrent.futures.Future",
+                "pathlib._local.Path": "pathlib.Path",
             }
             if target in mapping:
                 target = node["reftarget"] = mapping[target]

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -55,7 +55,7 @@ PY_FACTORS_RE = re.compile(
     """,
     re.VERBOSE,
 )
-PY_FACTORS_RE_EXPLICIT_VERSION = re.compile(r"^(?P<version>[2-9]\.[0-9]+)$")
+PY_FACTORS_RE_EXPLICIT_VERSION = re.compile(r"^((?P<impl>cpython|pypy)-)?(?P<version>[2-9]\.[0-9]+)$")
 
 
 class Python(ToxEnv, ABC):
@@ -144,7 +144,8 @@ class Python(ToxEnv, ABC):
         candidates: list[str] = []
         match = PY_FACTORS_RE_EXPLICIT_VERSION.match(env_name)
         if match:
-            candidates.append(env_name)
+            found = match.groupdict()
+            candidates.append(f'{"pypy" if found["impl"] == "pypy" else ""}{found["version"]}')
         else:
             for factor in env_name.split("-"):
                 match = PY_FACTORS_RE.match(factor)

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -104,6 +104,7 @@ def test_diff_msg_no_diff() -> None:
         ("3.10", "3.10"),
         ("3.9", "3.9"),
         ("2.7", "2.7"),
+        ("pypy-3.10", "pypy3.10"),
     ],
     ids=lambda a: "|".join(a) if isinstance(a, list) else str(a),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -72,11 +72,11 @@ commands =
 description = check that the long description is valid
 skip_install = true
 deps =
-    build[uv]>=1.2.2
     check-wheel-contents>=0.6
     twine>=5.1.1
+    uv>=0.4.10
 commands =
-    python -m build --installer uv -o {envtmpdir} -s -w .
+    uv build --sdist --wheel --out-dir {envtmpdir} .
     twine check {envtmpdir}{/}*
     check-wheel-contents --no-config {envtmpdir}
 


### PR DESCRIPTION
This allows simplified GitHub Actions configuration, as the GitHub py versions can be passed through as environment names.

Also use uv in CI.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
