### PR TITLE
Separate list dependencies to a separate installer class

### DIFF
--- a/docs/changelog/3347.feature.rst
+++ b/docs/changelog/3347.feature.rst
@@ -1,0 +1,2 @@
+Separate the list dependencies functionality to a separate abstract class allowing code reuse in plugins (such as
+``tox-uv``) - by :gaborbernat`.


### PR DESCRIPTION
This allows other installers (such as uv) to reuse this code.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
