### PR TITLE
Update sdist rules to include `tox.toml` (#3389)

### DIFF
--- a/docs/changelog/3389.bugfix.rst
+++ b/docs/changelog/3389.bugfix.rst
@@ -1,0 +1,2 @@
+Include ``tox.toml`` in sdist archives to fix test failures resulting from its lack.
+- by :user:`mgorny`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ build.hooks.vcs.version-file = "src/tox/version.py"
 build.targets.sdist.include = [
   "/src",
   "/tests",
-  "/tox.ini",
+  "/tox.toml",
 ]
 version.source = "vcs"
 


### PR DESCRIPTION
Update sdist rules to include `tox.toml`, rather than `tox.ini` that no longer exists.  This fixes test failures due to missing tox configuration.

Fixes #3389

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
