### PR TITLE
Expose type checking dependencies into an extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,11 @@ optional-dependencies.testing = [
   "time-machine>=2.15; implementation_name!='pypy'",
   "wheel>=0.44",
 ]
+optional-dependencies.type = [
+  "mypy==1.11.2",
+  "types-cachetools>=5.5.0.20240820",
+  "types-chardet>=5.0.4.6",
+]
 urls.Documentation = "https://tox.wiki"
 urls.Homepage = "http://tox.readthedocs.org"
 urls."Release Notes" = "https://tox.wiki/en/latest/changelog.html"

--- a/tox.toml
+++ b/tox.toml
@@ -56,7 +56,7 @@ commands = [["pre-commit", "run", "--all-files", "--show-diff-on-failure", { rep
 
 [env.type]
 description = "run type check on code base"
-deps = ["mypy==1.11.2", "types-cachetools>=5.5.0.20240820", "types-chardet>=5.0.4.6"]
+extras = ["testing", "type"]
 commands = [["mypy", "src{/}tox"], ["mypy", "tests"]]
 
 [env.docs]


### PR DESCRIPTION
This will allow to add tox to [mypy_primer](https://github.com/hauntsaninja/mypy_primer) so new versions of mypy will be tested against it (used directly from their [GHA pipelines](https://github.com/python/mypy/blob/master/.github/workflows/mypy_primer.yml)). It should also make it easier to do type checking for plugin developers.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
