### PR TITLE
Add NETRC to the default_pass_env list

### DIFF
--- a/docs/changelog/3410.feature.rst
+++ b/docs/changelog/3410.feature.rst
@@ -1,0 +1,1 @@
+Add `NETRC` to the list of environment variables always passed through.

--- a/docs/changelog/3410.feature.rst
+++ b/docs/changelog/3410.feature.rst
@@ -1,1 +1,1 @@
-Add `NETRC` to the list of environment variables always passed through.
+Add ``NETRC`` to the list of environment variables always passed through.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -534,7 +534,7 @@ Base options
             - ✅
             - ✅
             - ✅
-    
+
 
 
    More environment variable-related information

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -530,6 +530,11 @@ Base options
             - ✅
             - ✅
             - ✅
+        *   - NETRC
+            - ✅
+            - ✅
+            - ✅
+    
 
 
    More environment variable-related information

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -220,7 +220,7 @@ class ToxEnv(ABC):
             "HOME",  # needed for `os.path.expanduser()` on non-Windows systems
             "FORCE_COLOR",  # force color output
             "NO_COLOR",  # disable color output
-            "NETRC", # used by pip and netrc modules
+            "NETRC",  # used by pip and netrc modules
         ]
         if sys.stdout.isatty():  # if we're on a interactive shell pass on the TERM
             env.append("TERM")

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -220,6 +220,7 @@ class ToxEnv(ABC):
             "HOME",  # needed for `os.path.expanduser()` on non-Windows systems
             "FORCE_COLOR",  # force color output
             "NO_COLOR",  # disable color output
+            "NETRC", # used by pip and netrc modules
         ]
         if sys.stdout.isatty():  # if we're on a interactive shell pass on the TERM
             env.append("TERM")

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -124,7 +124,7 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
         + ["CC", "CCSHARED", "CFLAGS"]
         + (["COMSPEC"] if is_win else [])
         + ["CPPFLAGS", "CURL_CA_BUNDLE", "CXX", "FORCE_COLOR", "HOME", "LANG"]
-        + ["LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH"]
+        + ["LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH", "NETRC"]
         + (["MSYSTEM"] if is_win else [])
         + ["NO_COLOR"]
         + (["NUMBER_OF_PROCESSORS", "PATHEXT"] if is_win else [])

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -124,9 +124,9 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
         + ["CC", "CCSHARED", "CFLAGS"]
         + (["COMSPEC"] if is_win else [])
         + ["CPPFLAGS", "CURL_CA_BUNDLE", "CXX", "FORCE_COLOR", "HOME", "LANG"]
-        + ["LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH", "NETRC"]
+        + ["LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH"]
         + (["MSYSTEM"] if is_win else [])
-        + ["NO_COLOR"]
+        + ["NETRC", "NO_COLOR"]
         + (["NUMBER_OF_PROCESSORS", "PATHEXT"] if is_win else [])
         + ["PIP_*", "PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_SYSROOT_DIR"]
         + (["PROCESSOR_ARCHITECTURE"] if is_win else [])


### PR DESCRIPTION
Add NETRC to the list of default_pass_env.
This is used by pip when downloading package from an index needing authentication.

My usecase is a CI process needing to obtain authentication tokens and pass them to pip for it to be able to use the index. Installing the credentials in `~/.netrc` would work but isn't always possible when using temporary tokens, or running CI jobs in parallel on the same host. The other supported way is to write a temporary `netrc` file, and point `pip` to it using `NETRC` environment variable. After the CI run is done, this `netrc` can be removed.


- [] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
