### PR TITLE
Docs: adjusting EOL Python version testing remarks

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -359,6 +359,8 @@ Just make sure you switch the user to ``root`` when needed and switch back to ``
     USER tox
 
 
+.. _eol-version-support:
+
 Testing end-of-life Python versions
 -----------------------------------
 
@@ -376,6 +378,9 @@ If you need to test against e.g. Python 2.7, 3.5 or 3.6, you need to add the fol
 
 In case you need to do this for many repositories, we recommend to use
 `all-repos <https://github.com/asottile/all-repos>`_.
+
+Support for Python 3.7 was dropped in `virtualenv 20.27.0 <https://virtualenv.pypa.io/en/latest/changelog.html#v20-27-0-2024-10-17>`_.
+In order to test against Python 3.7, you can limit the version with ``requires = virtualenv<20.27.0`` instead.
 
 
 Testing with Pytest

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -361,7 +361,8 @@ Main features
 
 * ``plugin system`` to modify tox execution with simple hooks.
 * uses :pypi:`pip` and :pypi:`virtualenv` by default. Support for plugins replacing it with their own.
-* **cross-Python compatible**: tox requires CPython 3.7 and higher, but it can create environments 2.7 or later
+* **cross-Python compatible**: tox requires CPython 3.7 and higher, but it can create environments 2.7 or later.
+  Special configuration might be required: :ref:`eol-version-support`.
 * **cross-platform**: Windows, macOS and Unix style environments
 * **full interoperability with devpi**: is integrated with and is used for testing in the :pypi:`devpi` system, a
   versatile PyPI index server and release managing tool

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -361,7 +361,7 @@ Main features
 
 * ``plugin system`` to modify tox execution with simple hooks.
 * uses :pypi:`pip` and :pypi:`virtualenv` by default. Support for plugins replacing it with their own.
-* **cross-Python compatible**: tox requires CPython 3.7 and higher, but it can create environments 2.7 or later.
+* **cross-Python compatible**: tox requires CPython 3.9 and higher, but it can create environments 2.7 or later.
   Special configuration might be required: :ref:`eol-version-support`.
 * **cross-platform**: Windows, macOS and Unix style environments
 * **full interoperability with devpi**: is integrated with and is used for testing in the :pypi:`devpi` system, a


### PR DESCRIPTION
 * `virtualenv` just dropped support for Python 3.7 (with their version 20.27.0)
 * Feature special configuration required for legacy testing more prominently

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ~~ensured there are test(s) validating the fix~~ not applicable
- [ ] ~~added news fragment in `docs/changelog` folder~~ unsure? do you want this tiny change to have an entry?
- [x] updated/extended the documentation

See also: https://github.com/tox-dev/tox/issues/3416