### PR TITLE
Fix [dependency_groups] -> [dependency-groups] in pyproject.toml (PEP 735)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,10 @@ repos:
     rev: "2.3.0"
     hooks:
       - id: pyproject-fmt
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: "v0.21"
+    hooks:
+      - id: validate-pyproject
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.6.9"
     hooks:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -826,7 +826,7 @@ Python options
 Python run
 ~~~~~~~~~~
 .. conf::
-   :keys: dependency_groups
+   :keys: dependency-groups
    :default: <empty list>
    :version_added: 4.22
 
@@ -839,7 +839,7 @@ Python run
 
        .. code-block:: toml
 
-          [dependency_groups]
+          [dependency-groups]
           test = [
              "pytest>=8",
           ]


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [n/a] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

PR https://github.com/tox-dev/tox/pull/3409/files that added support for PEP 735 dependency groups used `[dependency_groups]` in the [docs](https://github.com/tox-dev/tox/pull/3409/files#diff-f0a5822170a0cb40ccc8b537d36cac7e27a986d9911b3a08c03feab8f9a47a13R837):

```toml
[dependency_groups]
test = [
   "pytest>=8",
]
```

But `[dependency-groups]` in [`pyproject.toml`](https://github.com/tox-dev/tox/pull/3409/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R196):

```toml
[dependency-groups]
dev = [
  { include-group = "docs" },
  { include-group = "test" },
  { include-group = "type" },
]
...
```


# Underscore

The underscore fails validation:

```console
❯ pre-commit run --all-files validate-pyproject
Validate pyproject.toml..................................................Failed
- hook id: validate-pyproject
- exit code: 1

Invalid file: pyproject.toml
[ERROR] `data` must not contain {'dependency_groups'} properties
```

And fails to run:
```pytb
❯ tox -e py313
py313: internal error
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/tox/session/cmd/run/single.py", line 47, in _evaluate
    tox_env.setup()
    ~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/tox/tox_env/api.py", line 250, in setup
    self._setup_env()
    ~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/tox/tox_env/python/runner.py", line 100, in _setup_env
    self._install_dependency_groups()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/tox/tox_env/python/runner.py", line 114, in _install_dependency_groups
    requirements = resolve(root, groups)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/tox/tox_env/python/dependency_groups.py", line 29, in resolve
    dependency_groups = pyproject["dependency-groups"]
                        ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
KeyError: 'dependency-groups'
  py313: FAIL code 2 (0.29 seconds)
  evaluation failed :( (0.42 seconds)
```

# Hyphen

The hyphen passes:
```console
❯ pre-commit run --all-files validate-pyproject
Validate pyproject.toml..................................................Passed
```
```console
❯ tox -e py313
py313: install_dependency-groups> python -I -m pip install 'build[virtualenv]>=1.2.2' 'covdefaults>=2.3' 'detect-test-pollution>=1.2' 'devpi-process>=1.0.2' 'diff-cover>=9.2' 'distlib>=0.3.8' 'flaky>=3.8.1' 'hatch-vcs>=0.4' 'hatchling>=1.25' 'psutil>=6' 'pytest-cov>=5' 'pytest-mock>=3.14' 'pytest-xdist>=3.6.1' 'pytest>=8.3.3' 're-assert>=1.1' 'setuptools>=75.1' 'time-machine>=2.15; implementation_name != "pypy"' 'wheel>=0.44'
.pkg: install_requires> python -I -m pip install 'hatch-vcs>=0.4' 'hatchling>=1.25'
.pkg: _optional_hooks> python /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: get_requires_for_build_wheel> python /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: get_requires_for_build_editable> python /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pyproject_api/_backend.py True hatchling.build
.pkg: install_requires_for_build_editable> python -I -m pip install 'editables~=0.3'
.pkg: build_wheel> python /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pyproject_api/_backend.py True hatchling.build
py313: install_package_deps> python -I -m pip install 'cachetools>=5.5' 'chardet>=5.2' 'colorama>=0.4.6' 'filelock>=3.16.1' 'packaging>=24.1' 'platformdirs>=4.3.6' 'pluggy>=1.5' 'pyproject-api>=1.8' 'tomli>=2.0.1; python_version < "3.11"' 'typing-extensions>=4.12.2; python_version < "3.11"' 'virtualenv>=20.26.6'
py313: install_package> python -I -m pip install --force-reinstall --no-deps /private/tmp/tox/.tox/.tmp/package/1/tox-4.23.1.dev3+g7e7bb004-py3-none-any.whl
py313: commands[0]> pytest --durations 15 -n auto --junitxml /private/tmp/tox/.tox/junit.py313.xml --no-cov-on-fail --cov /private/tmp/tox/.tox/py313/lib/python3.13/site-packages/tox --cov /private/tmp/tox/tests --cov-config /private/tmp/tox/pyproject.toml --cov-context test --cov-report term-missing:skip-covered --cov-report html:/private/tmp/tox/.tox/py313/tmp/htmlcov --cov-report xml:/private/tmp/tox/.tox/coverage.py313.xml tests --run-integration
============================================================ test session starts =============================================================
platform darwin -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0
cachedir: .tox/py313/.pytest_cache
rootdir: /private/tmp/tox
configfile: pyproject.toml
plugins: cov-5.0.0, flaky-3.8.1, time-machine-2.16.0, devpi-server-6.14.0, mock-3.14.0, anyio-4.6.2.post1, xdist-3.6.1
8 workers [1808 items]
...................................................................................................................................... [  7%]
...................................................................................................................................... [ 14%]
...................................................................................................................................... [ 22%]
...................................................................................................................................... [ 29%]
...................................................................................................................................... [ 37%]
...................................................................................................................................... [ 44%]
...................................................................................................................................... [ 51%]
...................................................................................................................................... [ 59%]
...................................................................................................................................... [ 66%]
...................................................................................................................................... [ 74%]
...................................................................................................................................... [ 81%]
...................................................................................................................................... [ 88%]
...................................................................................................................................... [ 96%]
..................................................................                                                                     [100%]
============================================================== warnings summary ==============================================================
tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py::test_tox_install_pkg_sdist
  /private/tmp/tox/.tox/py313/lib/python3.13/site-packages/tox/tox_env/python/virtual_env/package/cmd_builder.py:110: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    tar.extractall(path=str(work_dir))  # noqa: S202

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
----------------------------------------- generated xml file: /private/tmp/tox/.tox/junit.py313.xml ------------------------------------------

---------- coverage: platform darwin, python 3.13.0-final-0 ----------
Name                                                      Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------------------------------
src/tox/config/cli/parse.py                                  56      3      2      0    95%   54-55, 89
src/tox/config/cli/parser.py                                224      0     78      1    99%   106->exit
src/tox/config/loader/api.py                                 88      1     20      1    98%   156
src/tox/config/loader/ini/replace.py                         56      0     24      1    99%   73->75
src/tox/config/loader/toml/_replace.py                       98      5     46      5    93%   81, 112-113, 119-120
src/tox/config/source/api.py                                 50      0     12      1    98%   57->exit
src/tox/config/source/discover.py                            61      2     22      2    95%   42->49, 50-51
src/tox/execute/api.py                                      136      3      6      0    96%   257-259
src/tox/execute/local_sub_process/__init__.py               170      2     44      1    99%   306, 312, 317->321
src/tox/execute/pep517_backend.py                            68      1     10      1    97%   46
src/tox/pytest.py                                           316      1     50      1    99%   146
src/tox/session/cmd/depends.py                               35      2      8      0    95%   42-43
src/tox/session/cmd/legacy.py                                84      0     34      3    97%   131->133, 133->135, 135->129
src/tox/session/cmd/run/single.py                            85      1     14      1    98%   116
src/tox/session/env_select.py                               284      3    110      1    99%   191, 287-288
src/tox/tox_env/python/api.py                               182      4     48      1    97%   182-186
src/tox/tox_env/python/dependency_groups.py                  47      1     18      1    97%   26
src/tox/tox_env/python/pip/pip_install.py                   169      1     56      2    99%   168, 230->233
src/tox/tox_env/python/pip/req/util.py                       35      0     12      1    98%   41->36
src/tox/tox_env/python/pip/req_file.py                       91      1     30      1    98%   51
src/tox/tox_env/python/virtual_env/api.py                   106      3     10      1    97%   125->127, 183-184, 196
src/tox/tox_env/python/virtual_env/package/pyproject.py     293      2     72      1    99%   126, 336
src/tox/tox_env/python/virtual_env/package/util.py           51      0     22      1    99%   33->27
src/tox/util/file_view.py                                    28      3      4      2    84%   28->34, 32-33, 35
tests/config/cli/test_cli_ini.py                             86      0      2      1    99%   157->161
tests/config/loader/test_str_convert.py                      53      0      6      1    98%   61->75
tests/conftest.py                                            88      1      6      1    98%   42
tests/demo_pkg_inline/build.py                               39      5     12      2    78%   95-97, 114-119
tests/execute/local_subprocess/test_local_subprocess.py     271      2     18      0    99%   318-319
tests/session/cmd/test_legacy.py                             88      0      4      1    99%   158->157
tests/test_provision.py                                     159      1      8      1    99%   68
-----------------------------------------------------------------------------------------------------
TOTAL                                                     12100     48   1998     37    99%

186 files skipped due to complete coverage.
Coverage HTML written to dir /private/tmp/tox/.tox/py313/tmp/htmlcov
Coverage XML written to file /private/tmp/tox/.tox/coverage.py313.xml

Required test coverage of 88.0% reached. Total coverage: 99.34%
============================================================ slowest 15 durations ============================================================
59.22s setup    tests/session/cmd/test_sequential.py::test_platform_does_not_match_package_env
56.62s setup    tests/tox_env/python/pip/test_pip_install.py::test_constrain_package_deps[requirements_constraints_indirect-True-False]
55.42s setup    tests/tox_env/python/pip/test_pip_install.py::test_constrain_package_deps[explicit-False-True]
52.68s setup    tests/session/cmd/test_sequential.py::test_rerun_sequential_skip
50.27s setup    tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py::test_build_wheel_external
48.95s setup    tests/session/cmd/test_parallel.py::test_parallel_show_output_with_pkg
48.84s setup    tests/tox_env/python/pip/test_pip_install.py::test_constrain_package_deps[explicit+requirements-True-True]
11.16s call     tests/session/cmd/test_show_config.py::test_show_config_exception
7.32s setup    tests/test_provision.py::test_provision_requires_ok
3.65s call     tests/plugin/test_plugin.py::test_plugin_hooks_and_order
3.53s call     tests/plugin/test_plugin_custom_config_set.py::test_define_custom_config_factor_filter
3.51s call     tests/config/test_sets.py::test_define_custom_set
3.46s call     tests/session/cmd/run/test_common.py::test_empty_report
3.37s call     tests/session/cmd/test_sequential.py::test_run_ignore_cmd_exit_code[-]
2.85s call     tests/test_provision.py::test_provision_requires_ok
================================================= 1808 passed, 1 warning in 95.19s (0:01:35) =================================================
py313: commands[1]> diff-cover --compare-branch origin/main /private/tmp/tox/.tox/coverage.py313.xml
-------------
Diff Coverage
Diff: origin/main...HEAD, staged and unstaged changes
-------------
No lines with coverage information in this diff.
-------------

.pkg: _exit> python /Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/pyproject_api/_backend.py True hatchling.build
  py313: OK (111.77=setup[13.78]+cmd[97.52,0.47] seconds)
  congratulations :) (111.87 seconds)
```


