### PR TITLE
Support external tox.pytest usage via "test" extra

### DIFF
--- a/docs/changelog/3415.misc.rst
+++ b/docs/changelog/3415.misc.rst
@@ -1,0 +1,1 @@
+Provide ``test`` extra to support plugin authors using ``tox.pytest``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ dependencies = [
   "typing-extensions>=4.12.2; python_version<'3.11'",
   "virtualenv>=20.26.6",
 ]
+optional-dependencies.test = [
+  "devpi-process>=1.0.2",
+  "pytest>=8.3.3",
+  "pytest-mock>=3.14",
+]
 urls.Documentation = "https://tox.wiki"
 urls.Homepage = "http://tox.readthedocs.org"
 urls."Release Notes" = "https://tox.wiki/en/latest/changelog.html"


### PR DESCRIPTION
In order to allow plugin writers to easily pull in all dependencies needed to use the `tox.pytest` module, add a new `test` extra with a subset of the test dependency group. Though the pytest package should be present in the users' environment anyway, we still add it for consistency and to produce a conflict just in case the version has been constrained to an older version by the project.

Fixes #3415 

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

Not sure how to test this without splitting off the plugin tests into an extra test-suite, which seems like quite the invasive change.
Also did not find a good place to update this in the docs without starting a whole new section on testing plugins with pytest.