### PR TITLE
Adds ability to configure stderr output color

### DIFF
--- a/docs/changelog/3426.misc.rst
+++ b/docs/changelog/3426.misc.rst
@@ -1,0 +1,2 @@
+Adds ability to configure the stderr color for output received from external
+commands.

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -11,6 +11,8 @@ from argparse import SUPPRESS, Action, ArgumentDefaultsHelpFormatter, ArgumentEr
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Type, TypeVar, cast
 
+from colorama import Fore
+
 from tox.config.loader.str_convert import StrConvert
 from tox.plugin import NAME
 from tox.util.ci import is_ci
@@ -365,6 +367,12 @@ def add_color_flags(parser: ArgumentParser) -> None:
         default=color,
         choices=["yes", "no"],
         help="should output be enriched with colors, default is yes unless TERM=dumb or NO_COLOR is defined.",
+    )
+    parser.add_argument(
+        "--stderr-color",
+        default="RED",
+        choices=[*Fore.__dict__.keys()],
+        help="color for stderr output, use RESET for terminal defaults.",
     )
 
 

--- a/src/tox/execute/api.py
+++ b/src/tox/execute/api.py
@@ -122,18 +122,19 @@ class Execute(ABC):
         env: ToxEnv,
     ) -> Iterator[ExecuteStatus]:
         start = time.monotonic()
+        stderr_color = None
+        if self._colored:
+            try:
+                cfg_color = env.conf._conf.options.stderr_color  # noqa: SLF001
+                stderr_color = getattr(Fore, cfg_color)
+            except (AttributeError, KeyError, TypeError):  # many tests have a mocked 'env'
+                stderr_color = Fore.RED
         try:
             # collector is what forwards the content from the file streams to the standard streams
             out, err = out_err[0].buffer, out_err[1].buffer
-            out_sync = SyncWrite(
-                out.name,
-                out if show else None,  # type: ignore[arg-type]
-            )
-            err_sync = SyncWrite(
-                err.name,
-                err if show else None,  # type: ignore[arg-type]
-                Fore.RED if self._colored else None,
-            )
+            out_sync = SyncWrite(out.name, out if show else None)  # type: ignore[arg-type]
+            err_sync = SyncWrite(err.name, err if show else None, stderr_color)  # type: ignore[arg-type]
+
             with out_sync, err_sync:
                 instance = self.build_instance(request, self._option_class(env), out_sync, err_sync)
                 with instance as status:

--- a/tests/config/cli/test_cli_env_var.py
+++ b/tests/config/cli/test_cli_env_var.py
@@ -31,6 +31,7 @@ def test_verbose_no_test() -> None:
         "verbose": 4,
         "quiet": 0,
         "colored": "no",
+        "stderr_color": "RED",
         "work_dir": None,
         "root_dir": None,
         "config_file": None,
@@ -90,6 +91,7 @@ def test_env_var_exhaustive_parallel_values(
     assert vars(options.parsed) == {
         "always_copy": False,
         "colored": "no",
+        "stderr_color": "RED",
         "command": "legacy",
         "default_runner": "virtualenv",
         "develop": False,

--- a/tests/config/cli/test_cli_ini.py
+++ b/tests/config/cli/test_cli_ini.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 def default_options() -> dict[str, Any]:
     return {
         "colored": "no",
+        "stderr_color": "RED",
         "command": "r",
         "default_runner": "virtualenv",
         "develop": False,
@@ -200,6 +201,7 @@ def test_ini_exhaustive_parallel_values(core_handlers: dict[str, Callable[[State
     options = get_options("p")
     assert vars(options.parsed) == {
         "colored": "yes",
+        "stderr_color": "RED",
         "command": "p",
         "default_runner": "virtualenv",
         "develop": False,

--- a/tests/execute/local_subprocess/test_local_subprocess.py
+++ b/tests/execute/local_subprocess/test_local_subprocess.py
@@ -87,7 +87,7 @@ def test_local_execute_basic_pass(  # noqa: PLR0913
     out_got, err_got = out_err.read_out_err()
     if show:
         assert out_got == out
-        expected = f"{Fore.__dict__[stderr_color]}{err}{Fore.RESET}" if color and err else err
+        expected = f"{getattr(Fore, stderr_color)}{err}{Fore.RESET}" if color and err else err
         assert err_got == expected
     else:
         assert not out_got


### PR DESCRIPTION
This feature will allow users to control the coloring of stderr with tox, including ability to avoiding adding colors to it, while still using colors as many tools are already producing colored output.

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
