### PR TITLE
Allow users to disable use of pre-commit-uv

### DIFF
--- a/tox.toml
+++ b/tox.toml
@@ -51,7 +51,7 @@ commands = [
 description = "format the code base to adhere to our styles, and complain about what we cannot do automatically"
 skip_install = true
 dependency_groups = ["fix"]
-pass_env = [{ replace = "ref", of = ["env_run_base", "pass_env"], extend = true }, "PROGRAMDATA"]
+pass_env = [{ replace = "ref", of = ["env_run_base", "pass_env"], extend = true }, "PROGRAMDATA", "DISABLE_PRE_COMMIT_UV_PATCH"]
 commands = [["pre-commit", "run", "--all-files", "--show-diff-on-failure", { replace = "posargs", extend = true }]]
 
 [env.type]


### PR DESCRIPTION
This will allow the failsafe DISABLE_PRE_COMMIT_UV_PATCH=1 variable
to be used with `tox -e fix`.

Related:
- https://github.com/tox-dev/tox/issues/3428
- https://github.com/tox-dev/pre-commit-uv/issues/28

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
