### PR TITLE
Pass nix-ld related variables by default in pass_env (fixes #3425)

### DIFF
--- a/docs/changelog/3425.doc.rst
+++ b/docs/changelog/3425.doc.rst
@@ -1,0 +1,3 @@
+Pass ``NIX_LD`` and ``NIX_LD_LIBRARY_PATH`` variables by default in ``pass_env`` to make generic binaries work under Nix/NixOS.
+
+- by :user:`albertodonato`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -534,6 +534,14 @@ Base options
             - ✅
             - ✅
             - ✅
+        *   - NIX_LD*
+            - ✅
+            - ✅
+            - ❌
+        *   - NIX_LD_LIBRARY_PATH
+            - ✅
+            - ✅
+            - ❌
 
 
 

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -236,7 +236,13 @@ class ToxEnv(ABC):
                 ],
             )
         else:  # pragma: win32 no cover
-            env.append("TMPDIR")  # temporary file location
+            env.extend(
+                [
+                    "TMPDIR",  # temporary file location
+                    "NIX_LD",  # nix-ld loader
+                    "NIX_LD_LIBRARY_PATH",  # nix-ld library path
+                ],
+            )
         return env
 
     def setup(self) -> None:

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -126,7 +126,9 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
         + ["CPPFLAGS", "CURL_CA_BUNDLE", "CXX", "FORCE_COLOR", "HOME", "LANG"]
         + ["LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH"]
         + (["MSYSTEM"] if is_win else [])
-        + ["NETRC", "NO_COLOR"]
+        + ["NETRC"]
+        + (["NIX_LD", "NIX_LD_LIBRARY_PATH"] if not is_win else [])
+        + ["NO_COLOR"]
         + (["NUMBER_OF_PROCESSORS", "PATHEXT"] if is_win else [])
         + ["PIP_*", "PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_SYSROOT_DIR"]
         + (["PROCESSOR_ARCHITECTURE"] if is_win else [])


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
