### PR TITLE
Display exception name when subprocesses raise them

### DIFF
--- a/docs/changelog/3450.bugfix.rst
+++ b/docs/changelog/3450.bugfix.rst
@@ -1,0 +1,3 @@
+Log exception name when subprocess execution produces one.
+
+- by :user:`ssbarnea`

--- a/src/tox/execute/local_sub_process/__init__.py
+++ b/src/tox/execute/local_sub_process/__init__.py
@@ -214,6 +214,9 @@ class LocalSubProcessExecuteInstance(ExecuteInstance):
                 env=self.request.env,
             )
         except OSError as exception:
+            # We log a nice error message to avout returning opaque error codes,
+            # like exit code 2 (filenotfound).
+            logging.error("Exception running subprocess %s", str(exception))  # noqa: TRY400
             return LocalSubprocessExecuteFailedStatus(self.options, self._out, self._err, exception.errno)
 
         status = LocalSubprocessExecuteStatus(self.options, self._out, self._err, process)

--- a/tests/execute/local_subprocess/test_local_subprocess.py
+++ b/tests/execute/local_subprocess/test_local_subprocess.py
@@ -4,6 +4,7 @@ import json
 import locale
 import logging
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -264,7 +265,11 @@ def test_command_does_not_exist(caplog: LogCaptureFixture, os_env: dict[str, str
     assert outcome.exit_code != Outcome.OK
     assert not outcome.out
     assert not outcome.err
-    assert not caplog.records
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "ERROR"
+    assert re.match(
+        r".*(No such file or directory|The system cannot find the file specified).*", caplog.records[0].message
+    )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="You need a conhost shell for keyboard interrupt")


### PR DESCRIPTION
This change provides more context information for cases like when a command is not found as previous behavior only returned the exist code of the exception, without any other information. Same exit codes could have being produced by commands that did run.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
