### PR TITLE
Use ubuntu-24.04 during build

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -27,7 +27,7 @@ jobs:
           - "3.9"
           - "3.8"
         os:
-          - ubuntu-latest
+          - ubuntu-24.04
           - windows-latest
           - macos-latest
     steps:
@@ -67,7 +67,7 @@ jobs:
           - docs
           - pkg_meta
         os:
-          - ubuntu-latest
+          - ubuntu-24.04
           - windows-latest
         exclude:
           - { os: windows-latest, tox_env: docs }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,7 +30,7 @@ jobs:
   release:
     needs:
       - build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: release
       url: https://pypi.org/project/tox/${{ github.ref_name }}


### PR DESCRIPTION
This change will ensure that we are in control of the ubuntu version
using build and avoid surprises from GitHub as the date when they
make the switch is not predictable.

This needs to change only once every two years, so not really a
problem. Also sorts the noise we currently get due to the upcoming
switch:

ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
