### PR TITLE
TOML set_env file support

### DIFF
--- a/docs/changelog/3474.bugfix.rst
+++ b/docs/changelog/3474.bugfix.rst
@@ -1,0 +1,1 @@
+TOML config did not accept set_env=file|<path> terminology, despite suggesting equal support as for INI.

--- a/docs/changelog/3474.bugfix.rst
+++ b/docs/changelog/3474.bugfix.rst
@@ -1,1 +1,1 @@
-TOML config did not accept set_env=file|<path> terminology, despite suggesting equal support as for INI.
+Support ``set_env = { file = "conf{/}local.env"}`` for TOML format - by :user:`juditnovak`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -551,8 +551,26 @@ Base options
 .. conf::
    :keys: set_env, setenv
 
-   A dictionary of environment variables to set when running commands in the tox environment. Lines starting with a
-   ``file|`` prefix define the location of environment file.
+   A dictionary of environment variables to set when running commands in the tox environment.
+
+   In addition, there is an option to include an existing environment file. See the different syntax for TOML and INI below.
+
+    .. tab:: TOML
+
+       .. code-block:: toml
+
+          [tool.tox.env_run_base]
+          set_env = { file = "conf{/}local.env", TEST_TIMEOUT = 30 }
+
+    .. tab:: INI
+
+
+       .. code-block:: ini
+
+          [testenv]
+          set_env = file|conf{/}local.env
+               TEST_TIMEOUT = 30
+
 
     .. note::
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -564,12 +564,29 @@ Base options
 
     .. tab:: INI
 
-
        .. code-block:: ini
 
           [testenv]
           set_env = file|conf{/}local.env
                TEST_TIMEOUT = 30
+
+
+    The env file path may include previously defined tox variables:
+
+
+    .. tab:: TOML
+
+       .. code-block:: toml
+
+          [tool.tox.env_run_base]
+          set_env = { file = "{env:variable}" }
+
+    .. tab:: INI
+
+       .. code-block:: ini
+
+          [testenv]
+          set_env = file|{env:variable}
 
 
     .. note::

--- a/src/tox/config/loader/toml/__init__.py
+++ b/src/tox/config/loader/toml/__init__.py
@@ -68,17 +68,14 @@ class TomlLoader(Loader[TomlTypes]):
         delay_replace = inspect.isclass(of_type) and issubclass(of_type, SetEnv)
 
         def replacer(raw_: str, args_: ConfigLoadArgs) -> str:
-            if conf is None:
-                replaced = raw_  # no replacement supported in the core section
-            else:
-                reference_replacer = Unroll(conf, self, args)
-                try:
-                    replaced = str(reference_replacer(raw_))  # do replacements
-                except Exception as exception:
-                    if isinstance(exception, HandledError):
-                        raise
-                    msg = f"replace failed in {args_.env_name}.{key} with {exception!r}"
-                    raise HandledError(msg) from exception
+            reference_replacer = Unroll(conf, self, args)
+            try:
+                replaced = str(reference_replacer(raw_))  # do replacements
+            except Exception as exception:
+                if isinstance(exception, HandledError):
+                    raise
+                msg = f"replace failed in {args_.env_name}.{key} with {exception!r}"
+                raise HandledError(msg) from exception
             return replaced
 
         exploded = Unroll(conf=conf, loader=self, args=args)(raw)

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -24,22 +24,17 @@ class SetEnv:
         from .loader.replacer import MatchExpression, find_replace_expr  # noqa: PLC0415
 
         if isinstance(raw, dict):
-            # TOML 'file' attribute is to be handled separately later
-            self._raw = dict(raw)
-            if "file" in raw:
+            self._raw = raw
+            if "file" in raw:  # environment files to be handled later
                 self._env_files.append(raw["file"])
                 self._raw.pop("file")
-
             return
-
         if isinstance(raw, list):
             self._raw = reduce(lambda a, b: {**a, **b}, raw)
             return
-
         for line in raw.splitlines():  # noqa: PLR1702
             if line.strip():
-                # INI 'file|' attribute is to be handled separately later
-                if line.startswith("file|"):
+                if line.startswith("file|"):  # environment files to be handled later
                     self._env_files.append(line[len("file|") :])
                 else:
                     try:

--- a/tests/config/test_set_env.py
+++ b/tests/config/test_set_env.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from unittest.mock import ANY
 
 import pytest
@@ -51,10 +51,14 @@ def test_set_env_bad_line() -> None:
         SetEnv("A", "py", "py", Path())
 
 
+_ConfType = Literal["ini", "toml"]
+
+
 class EvalSetEnv(Protocol):
     def __call__(
         self,
-        tox_ini: str,
+        config: str,
+        conf_type: _ConfType = "ini",
         extra_files: dict[str, Any] | None = ...,
         from_cwd: Path | None = ...,
     ) -> SetEnv: ...
@@ -62,8 +66,16 @@ class EvalSetEnv(Protocol):
 
 @pytest.fixture
 def eval_set_env(tox_project: ToxProjectCreator) -> EvalSetEnv:
-    def func(tox_ini: str, extra_files: dict[str, Any] | None = None, from_cwd: Path | None = None) -> SetEnv:
-        prj = tox_project({"tox.ini": tox_ini, **(extra_files or {})})
+    def func(
+        config: str,
+        conf_type: _ConfType = "ini",
+        extra_files: dict[str, Any] | None = None,
+        from_cwd: Path | None = None,
+    ) -> SetEnv:
+        if conf_type == "ini":
+            prj = tox_project({"tox.ini": config, **(extra_files or {})})
+        else:
+            prj = tox_project({"tox.toml": config, **(extra_files or {})})
         result = prj.run("c", "-k", "set_env", "-e", "py", from_cwd=None if from_cwd is None else prj.path / from_cwd)
         result.assert_success()
         set_env: SetEnv = result.env_conf("py")["set_env"]
@@ -149,7 +161,19 @@ def test_set_env_honor_override(eval_set_env: EvalSetEnv) -> None:
     assert set_env.load("PIP_DISABLE_PIP_VERSION_CHECK") == "0"
 
 
-def test_set_env_environment_file(eval_set_env: EvalSetEnv) -> None:
+@pytest.mark.parametrize(
+    ("conf_type", "config"),
+    [
+        ("ini", "[testenv]\npackage=skip\nset_env=file|A{/}a.txt\nchange_dir=C"),
+        ("toml", '[env_run_base]\npackage="skip"\nset_env="file|A{/}a.txt"\nchange_dir="C"'),
+        # Using monkeypatched env setting as a reference
+        ("ini", "[testenv]\npackage=skip\nset_env=file|{env:myenvfile}\nchange_dir=C"),
+        ("toml", '[env_run_base]\npackage="skip"\nset_env="file|{env:myenvfile}"\nchange_dir="C"'),
+    ],
+)
+def test_set_env_environment_file(
+    conf_type: _ConfType, config: str, eval_set_env: EvalSetEnv, monkeypatch: MonkeyPatch
+) -> None:
     env_file = """
     A=1
     B= 2
@@ -158,9 +182,11 @@ def test_set_env_environment_file(eval_set_env: EvalSetEnv) -> None:
     E = "1"
     F =
     """
+    # Monkeypatch only used for some of the parameters
+    monkeypatch.setenv("myenvfile", "A{/}a.txt")
+
     extra = {"A": {"a.txt": env_file}, "B": None, "C": None}
-    ini = "[testenv]\npackage=skip\nset_env=file|A{/}a.txt\nchange_dir=C"
-    set_env = eval_set_env(ini, extra_files=extra, from_cwd=Path("B"))
+    set_env = eval_set_env(config, conf_type=conf_type, extra_files=extra, from_cwd=Path("B"))
     content = {k: set_env.load(k) for k in set_env}
     assert content == {
         "PIP_DISABLE_PIP_VERSION_CHECK": "1",


### PR DESCRIPTION
This code change is addressing https://github.com/tox-dev/tox/issues/3474, making sure that TOML config has the same support to apply `set_env` from file, as INI configuration does.


Resolves https://github.com/tox-dev/tox/issues/3474