### PR TITLE
fix(docs): update expected code

### DIFF
--- a/docs/changelog/3480.bugfix.rst
+++ b/docs/changelog/3480.bugfix.rst
@@ -1,0 +1,1 @@
+fix example on the docs

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1586,10 +1586,8 @@ create your virtual env for the developers.
     py          -> [no description]
 
     additional environments:
-    py310-black -> [no description]
-    py310-lint  -> [no description]
-    py311-black -> [no description]
-    py311-lint  -> [no description]
+    py311-x86-venv -> [no description]
+    py311-x64-venv -> [no description]
 
 .. _substitution:
 


### PR DESCRIPTION
The example on `Generative section names` was not the one would expect.

Probably some leftover from a previous refactoring? 🤔 

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
