### PR TITLE
Add missing bracket in config example

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1366,7 +1366,7 @@ You can reference other configurations via the ``ref`` replacement. This can eit
         [env.src]
         extras = ["A", "{env_name}"]
         [env.dest]
-        extras = [{ replace = "ref", env = "src", key = "extras", extend = true }, "B"
+        extras = [{ replace = "ref", env = "src", key = "extras", extend = true }, "B"]
 
   In this case ``dest`` environments ``extras`` will be ``A``, ``src``, ``B``.
 


### PR DESCRIPTION
The first config example at https://tox.wiki/en/4.24.1/config.html#configuration-reference seems to be missing a closing bracket.
