### PR TITLE
Gh issue 3456 update environment variable documentation

### DIFF
--- a/docs/changelog/3456.doc.rst
+++ b/docs/changelog/3456.doc.rst
@@ -1,0 +1,1 @@
+Updates the documentation for ``os.environ['KEY']`` when the variable does not exist - by :user:`jugmac00`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1635,7 +1635,8 @@ If you specify a substitution string like this::
 
     {env:KEY}
 
-then the value will be retrieved as ``os.environ['KEY']`` and raise an Error if the environment variable does not exist.
+then the value will be retrieved as ``os.environ['KEY']`` and replaced with an empty string if the environment variable
+does not exist.
 
 
 Environment variable substitutions with default values

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1645,14 +1645,14 @@ If you specify a substitution string like this::
 
     {env:KEY:DEFAULTVALUE}
 
-then the value will be retrieved as ``os.environ['KEY']`` and replace with DEFAULTVALUE if the environment variable does
+then the value will be retrieved as ``os.environ['KEY']`` and replaced with DEFAULTVALUE if the environment variable does
 not exist.
 
 If you specify a substitution string like this::
 
     {env:KEY:}
 
-then the value will be retrieved as ``os.environ['KEY']`` and replace with an empty string if the environment variable
+then the value will be retrieved as ``os.environ['KEY']`` and replaced with an empty string if the environment variable
 does not exist.
 
 Substitutions can also be nested. In that case they are expanded starting from the innermost expression::


### PR DESCRIPTION
Missing environment variables will be retrieved as an empty string, and do not raise an exception.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [-] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
