### PR TITLE
Fix custom HelpFormatter for Python 3.14

### DIFF
--- a/docs/changelog/3523.bugfix.rst
+++ b/docs/changelog/3523.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``TypeError`` for ``HelpFormatter`` with Python 3.14

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -95,8 +95,8 @@ class ArgumentParserWithEnvAndConfig(ArgumentParser):
 class HelpFormatter(ArgumentDefaultsHelpFormatter):
     """A help formatter that provides the default value and the source it comes from."""
 
-    def __init__(self, prog: str) -> None:
-        super().__init__(prog, max_help_position=30, width=240)
+    def __init__(self, prog: str, **kwargs: Any) -> None:
+        super().__init__(prog, max_help_position=30, width=240, **kwargs)
 
     def _get_help_string(self, action: Action) -> str | None:
         text: str = super()._get_help_string(action) or ""


### PR DESCRIPTION
https://github.com/python/cpython/pull/132323 passes prefix_chars= (and other arguments) to the formatter_class, but the custom HelpFormatter only accepted prog=.

Accept any keyword arguments and pass them on to the parent class.

Fixes #3523

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
