### PR TITLE
Add colour to GitHub Actions CI logs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 8 * * *"
 
+env:
+  FORCE_COLOR: 1
+
 concurrency:
   group: check-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
 
 env:
   dists-artifact-name: python-package-distributions
+  FORCE_COLOR: 1
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

This adds colour to the GitHub Actions CI logs, makes it easier to find where things are failing.

Before: https://github.com/tox-dev/tox/actions/runs/14953881206/job/42006920411

After: https://github.com/tox-dev/tox/actions/runs/14955298530/job/42010125057?pr=3525

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [n/a] ensured there are test(s) validating the fix
- [n/a] added news fragment in `docs/changelog` folder
- [n/a] updated/extended the documentation
