### PR TITLE
Fix using deprecated virtualenv option `--wheel`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
   "pyproject-api>=1.8",
   "tomli>=2.2.1; python_version<'3.11'",
   "typing-extensions>=4.12.2; python_version<'3.11'",
-  "virtualenv>=20.29.1",
+  "virtualenv>=20.31",
 ]
 optional-dependencies.test = [
   "devpi-process>=1.0.2",

--- a/src/tox/pytest.py
+++ b/src/tox/pytest.py
@@ -281,7 +281,8 @@ class ToxProject:
                 m.setenv("VIRTUALENV_SYMLINK_APP_DATA", "1")
                 m.setenv("VIRTUALENV_SYMLINKS", "1")
                 m.setenv("VIRTUALENV_PIP", "embed")
-                m.setenv("VIRTUALENV_WHEEL", "embed")
+                if sys.version_info[:2] < (3, 9):
+                    m.setenv("VIRTUALENV_WHEEL", "embed")
                 m.setenv("VIRTUALENV_SETUPTOOLS", "embed")
                 try:
                     tox_run(args)

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -114,7 +114,9 @@ def test_result_json_sequential(
     py_test = get_cmd_exit_run_id(log_report, "py", "test")
     assert py_test == [(1, "commands[0]"), (0, "commands[1]")]
     packaging_installed = log_report["testenvs"]["py"].pop("installed_packages")
-    expected_pkg = {"pip", "setuptools", "wheel", "a"}
+    expected_pkg = {"pip", "setuptools", "a"}
+    if sys.version_info[0:2] == (3, 8):
+        expected_pkg.add("wheel")
     assert {i[: i.find("==")] if "@" not in i else "a" for i in packaging_installed} == expected_pkg
     install_package = log_report["testenvs"]["py"].pop("installpkg")
     assert re.match(r"^[a-fA-F0-9]{64}$", install_package.pop("sha256"))


### PR DESCRIPTION
The CI started failing when virtualenv deprecated the `--wheel` and `--no-wheel` options (in [20.31.0](https://virtualenv.pypa.io/en/latest/changelog.html#features-20-31-0)). This PR makes it so that tox doesn't run into this deprecation which caused the tests to fail that checked for some expected stdout which were then unexpectedly containing the deprecation message.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
       (Existing test were failing, so if this improves the situation, I consider this box ticked :wink:) 
- [ ] ~~added news fragment in `docs/changelog` folder~~ not user-facing, or it it?
- [ ] ~~updated/extended the documentation~~ API/CLI didn't change
