### PR TITLE
Feat: include free_threaded flag in result-json

### DIFF
--- a/docs/changelog/3534.feature.rst
+++ b/docs/changelog/3534.feature.rst
@@ -1,0 +1,1 @@
+Add ``free_threaded`` flag to to ``"python"`` entries in json output of ``--result-json``.

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -312,6 +312,7 @@ class Python(ToxEnv, ABC):
             "is_64": self.base_python.is_64,
             "sysplatform": self.base_python.platform,
             "extra_version_info": None,
+            "free_threaded": self.base_python.free_threaded,
         }
 
     @abstractmethod

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -89,6 +89,7 @@ def test_result_json_sequential(
         "sysplatform": py_info.platform,
         "version": py_info.version,
         "version_info": list(py_info.version_info),
+        "free_threaded": py_info.free_threaded,
     }
     packaging_setup = get_cmd_exit_run_id(log_report, ".pkg", "setup")
     assert "result" not in log_report["testenvs"][".pkg"]


### PR DESCRIPTION
Continuing https://github.com/tox-dev/tox/pull/3526

Adding the free_threaded flag also in the json output of `tox ... --result-json ...`.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] ~~updated/extended the documentation~~ I don't think the result json format is documented anywhere. If so, I didn't find it.
