### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Reporting Vulnerabilities
+
+**⚠️ Please do not file public GitHub issues for security vulnerabilities as they are open for everyone to see! ⚠️**
+
+We encourage responsible disclosure practices for security vulnerabilities.
+
+## Reporting a Vulnerability
+
+If you believe you've found a security-related bug, fill out a new
+vulnerability report via GitHub directly. To do so, follow these instructions:
+
+1. Click on the `Security` tab in the project repository.
+2. Click the green `Report a vulnerability` button at the top right corner.
+3. Fill in the form as accurately as you can, including as many details as possible.
+4. Click the green `Submit report` button at the bottom.
+
+## Don't have a GitHub account?
+
+Alternatively, to report a security vulnerability, please use the
+[Tidelift security contact](https://tidelift.com/security). Tidelift will coordinate the fix and disclosure.
+
+It is currently set up to forward every incoming report to Bernát Gábor. We will try to assess the problem in timely
+manner and disclose it in a responsible way.


### PR DESCRIPTION
Please note:

- Before we merge this PR, we need to enable "Private vulnerability reporting" on GitHub.
- After we merge this PR, we need to go to Tidelift and add the URL to this file to fulfill their requirements.

@gaborbernat please let me know whether you are OK with this approach, I am happy to perform the above mentioned steps.