### PR TITLE
Log environment variables sorted by key while redacting values of unsafe ones

### DIFF
--- a/docs/changelog/3542.bugfix.rst
+++ b/docs/changelog/3542.bugfix.rst
@@ -1,0 +1,2 @@
+Improves logging of environment variables by sorting them by key and redacting
+the values for the ones that are likely to contain secrets.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -441,6 +441,15 @@ CLI
   have a stale Python environment; e.g. ``tox run -e py310 -r`` would clean the run environment and recreate it from
   scratch.
 
+Logging
+~~~~~~~
+
+Tox logs its activity inside ``.tox/<env_name>/log`` which can prove to be a good source of information when debugging
+its behavior. It should be noted that some of the environment variables with names containing one of the words
+``access``, ``api``, ``auth``, ``client``, ``cred``, ``key``, ``passwd``, ``password``, ``private``, ``pwd``,
+``secret`` and ``token`` will be logged with their values redacted with ``*`` to prevent accidental secret leaking when
+tox is used in CI/CD environments (as log collection is common).
+
 Config files
 ~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dev = [
 test = [
   "build[virtualenv]>=1.2.2.post1",
   "covdefaults>=2.3",
+  "coverage>=7.9.1",
   "detect-test-pollution>=1.2",
   "devpi-process>=1.0.2",
   "diff-cover>=9.2",


### PR DESCRIPTION
Improves logging of environment variables by sorting them by key and redacting the values for the ones that are likely to contain secrets.

Fixes: #3542

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
