### PR TITLE
trivial: Prefer '[testenv] pip_pre'

### DIFF
--- a/src/tox/session/cmd/legacy.py
+++ b/src/tox/session/cmd/legacy.py
@@ -62,7 +62,7 @@ def tox_add_option(parser: ToxParser) -> None:
     our.add_argument(
         "--pre",
         action="store_true",
-        help="deprecated use PIP_PRE in set_env instead - install pre-releases and development versions of"
+        help="deprecated use pip_pre=true in a testenv instead - install pre-releases and development versions of"
         "dependencies; this will set PIP_PRE=1 environment variable",
     )
     our.add_argument(


### PR DESCRIPTION
We have an option specifically for this use case. Tell people about it.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
