### PR TITLE
Add `[testenv] constraints` option

### DIFF
--- a/docs/changelog/3350.feature.rst
+++ b/docs/changelog/3350.feature.rst
@@ -1,0 +1,1 @@
+Added ``constraints`` to allow specifying constraints files for all dependencies.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -942,15 +942,15 @@ Python run
    :keys: deps
    :default: <empty list>
 
-   Name of the Python dependencies. Installed into the environment prior to project after environment creation, but
+   Python dependencies. Installed into the environment prior to project after environment creation, but
    before package installation. All installer commands are executed using the :ref:`tox_root` as the current working
    directory. Each value must be one of:
 
    - a Python dependency as specified by :pep:`440`,
    - a `requirement file <https://pip.pypa.io/en/stable/user_guide/#requirements-files>`_ when the value starts with
-     ``-r`` (followed by a file path),
+     ``-r`` (followed by a file path or URL),
    - a `constraint file <https://pip.pypa.io/en/stable/user_guide/#constraints-files>`_ when the value starts with
-     ``-c`` (followed by a file path).
+     ``-c`` (followed by a file path or URL).
 
    If you are only defining :pep:`508` requirements (aka no pip requirement files), you should use
    :ref:`dependency_groups` instead.
@@ -976,6 +976,21 @@ Python run
             pytest>=7,<8
             -r requirements.txt
             -c constraints.txt
+
+   .. note::
+
+      :ref:`constraints` is the preferred way to specify constraints files since they will apply to package dependencies
+      also.
+
+.. conf::
+   :keys: constraints
+   :default: <empty list>
+   :version_added: 4.28.0
+
+   `Constraints files <https://pip.pypa.io/en/stable/user_guide/#constraints-files>`_ to use during package and
+   dependency installation. Provided constraints files will be used when installing package dependencies and any
+   additional dependencies specified in :ref:`deps`, but will not be used when installing the package itself.
+   Each value must be a file path or URL.
 
 .. conf::
    :keys: use_develop, usedevelop
@@ -1210,7 +1225,6 @@ Pip installer
    This command will be executed only if executing on Continuous Integrations is detected (for example set environment
    variable ``CI=1``) or if journal is active.
 
-
 .. conf::
    :keys: pip_pre
    :default: false
@@ -1227,7 +1241,7 @@ Pip installer
 
    If ``constrain_package_deps`` is true, then tox will create and use ``{env_dir}{/}constraints.txt`` when installing
    package dependencies during ``install_package_deps`` stage. When this value is set to false, any conflicting package
-   dependencies will override explicit dependencies and constraints passed to ``deps``.
+   dependencies will override explicit dependencies and constraints passed to :ref:`deps`.
 
 .. conf::
    :keys: use_frozen_constraints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,8 +97,7 @@ test = [
   "pytest-mock>=3.14",
   "pytest-xdist>=3.6.1",
   "re-assert>=1.1",
-  "setuptools>=75.3; python_version<='3.8'",
-  "setuptools>=75.8; python_version>'3.8'",
+  "setuptools>=75.8",
   "time-machine>=2.15; implementation_name!='pypy'",
   "wheel>=0.45.1",
 ]

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -289,7 +289,14 @@
         },
         "deps": {
           "type": "string",
-          "description": "Name of the python dependencies as specified by PEP-440"
+          "description": "python dependencies with optional version specifiers, as specified by PEP-440"
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "constraints to apply to installed python dependencies"
         },
         "dependency_groups": {
           "type": "array",

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -4,8 +4,9 @@ import logging
 import operator
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
 
 from packaging.requirements import Requirement
 
@@ -15,7 +16,7 @@ from tox.tox_env.errors import Fail, Recreate
 from tox.tox_env.installer import Installer
 from tox.tox_env.python.api import Python
 from tox.tox_env.python.package import EditableLegacyPackage, EditablePackage, SdistPackage, WheelPackage
-from tox.tox_env.python.pip.req_file import PythonDeps
+from tox.tox_env.python.pip.req_file import PythonConstraints, PythonDeps
 
 if TYPE_CHECKING:
     from tox.config.main import Config
@@ -52,6 +53,7 @@ class Pip(PythonInstallerListDependencies):
 
     def _register_config(self) -> None:
         super()._register_config()
+        root = self._env.core["toxinidir"]
         self._env.conf.add_config(
             keys=["pip_pre"],
             of_type=bool,
@@ -64,6 +66,13 @@ class Pip(PythonInstallerListDependencies):
             default=self.default_install_command,
             post_process=self.post_process_install_command,
             desc="command used to install packages",
+        )
+        self._env.conf.add_config(
+            keys=["constraints"],
+            of_type=PythonConstraints,
+            factory=partial(PythonConstraints.factory, root),
+            default=PythonConstraints("", root),
+            desc="constraints to apply to installed python dependencies",
         )
         self._env.conf.add_config(
             keys=["constrain_package_deps"],
@@ -110,6 +119,10 @@ class Pip(PythonInstallerListDependencies):
             logging.warning("pip cannot install %r", arguments)
             raise SystemExit(1)
 
+    @property
+    def constraints(self) -> PythonConstraints:
+        return cast("PythonConstraints", self._env.conf["constraints"])
+
     def constraints_file(self) -> Path:
         return Path(self._env.env_dir) / "constraints.txt"
 
@@ -122,15 +135,24 @@ class Pip(PythonInstallerListDependencies):
         return bool(self._env.conf["use_frozen_constraints"])
 
     def _install_requirement_file(self, arguments: PythonDeps, section: str, of_type: str) -> None:
+        new_requirements: list[str] = []
+        new_constraints: list[str] = []
+
         try:
             new_options, new_reqs = arguments.unroll()
         except ValueError as exception:
             msg = f"{exception} for tox env py within deps"
             raise Fail(msg) from exception
-        new_requirements: list[str] = []
-        new_constraints: list[str] = []
         for req in new_reqs:
             (new_constraints if req.startswith("-c ") else new_requirements).append(req)
+
+        try:
+            _, new_reqs = self.constraints.unroll()
+        except ValueError as exception:
+            msg = f"{exception} for tox env py within constraints"
+            raise Fail(msg) from exception
+        new_constraints.extend(new_reqs)
+
         constraint_options = {
             "constrain_package_deps": self.constrain_package_deps,
             "use_frozen_constraints": self.use_frozen_constraints,
@@ -159,6 +181,7 @@ class Pip(PythonInstallerListDependencies):
                         raise Recreate(msg)
                 args = arguments.as_root_args
                 if args:  # pragma: no branch
+                    args.extend(self.constraints.as_root_args)
                     self._execute_installer(args, of_type)
                     if self.constrain_package_deps and not self.use_frozen_constraints:
                         combined_constraints = new_requirements + [c.removeprefix("-c ") for c in new_constraints]
@@ -207,13 +230,18 @@ class Pip(PythonInstallerListDependencies):
                     raise Recreate(msg)  # pragma: no branch
                 new_deps = sorted(set(groups["req"]) - set(old or []))
                 if new_deps:  # pragma: no branch
+                    new_deps.extend(self.constraints.as_root_args)
                     self._execute_installer(new_deps, req_of_type)
         install_args = ["--force-reinstall", "--no-deps"]
         if groups["pkg"]:
+            # we intentionally ignore constraints when installing the package itself
+            # https://github.com/tox-dev/tox/issues/3550
             self._execute_installer(install_args + groups["pkg"], of_type)
         if groups["dev_pkg"]:
             for entry in groups["dev_pkg"]:
                 install_args.extend(("-e", str(entry)))
+            # we intentionally ignore constraints when installing the package itself
+            # https://github.com/tox-dev/tox/issues/3550
             self._execute_installer(install_args, of_type)
 
     def _execute_installer(self, deps: Sequence[Any], of_type: str) -> None:

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -121,7 +121,7 @@ class Pip(PythonInstallerListDependencies):
     def use_frozen_constraints(self) -> bool:
         return bool(self._env.conf["use_frozen_constraints"])
 
-    def _install_requirement_file(self, arguments: PythonDeps, section: str, of_type: str) -> None:  # noqa: C901
+    def _install_requirement_file(self, arguments: PythonDeps, section: str, of_type: str) -> None:
         try:
             new_options, new_reqs = arguments.unroll()
         except ValueError as exception:
@@ -161,15 +161,7 @@ class Pip(PythonInstallerListDependencies):
                 if args:  # pragma: no branch
                     self._execute_installer(args, of_type)
                     if self.constrain_package_deps and not self.use_frozen_constraints:
-                        # when we drop Python 3.8 we can use the builtin `.removeprefix`
-                        def remove_prefix(text: str, prefix: str) -> str:
-                            if text.startswith(prefix):
-                                return text[len(prefix) :]
-                            return text
-
-                        combined_constraints = new_requirements + [
-                            remove_prefix(text=c, prefix="-c ") for c in new_constraints
-                        ]
+                        combined_constraints = new_requirements + [c.removeprefix("-c ") for c in new_constraints]
                         self.constraints_file().write_text("\n".join(combined_constraints))
 
     @staticmethod

--- a/src/tox/tox_env/python/runner.py
+++ b/src/tox/tox_env/python/runner.py
@@ -34,11 +34,11 @@ class PythonRun(Python, RunToxEnv, ABC):
         super().register_config()
         root = self.core["toxinidir"]
         self.conf.add_config(
-            keys="deps",
+            keys=["deps"],
             of_type=PythonDeps,
             factory=partial(PythonDeps.factory, root),
             default=PythonDeps("", root),
-            desc="Name of the python dependencies as specified by PEP-440",
+            desc="python dependencies with optional version specifiers, as specified by PEP-440",
         )
         self.conf.add_config(
             keys=["dependency_groups"],

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -89,28 +89,29 @@ class RunToxEnv(ToxEnv, ABC):
         self._call_pkg_envs("interrupt")
 
     def get_package_env_types(self) -> tuple[str, str] | None:
-        if self._register_package_conf():
-            has_external_pkg = self.conf["package"] == "external"
-            self.core.add_config(
-                keys=["package_env", "isolated_build_env"],
-                of_type=str,
-                default=self._default_package_env,
-                desc="tox environment used to package",
-            )
-            self.conf.add_config(
-                keys=["package_env"],
-                of_type=str,
-                default=f"{self.core['package_env']}{'_external' if has_external_pkg else ''}",
-                desc="tox environment used to package",
-            )
-            is_external = self.conf["package"] == "external"
-            self.conf.add_constant(
-                keys=["package_tox_env_type"],
-                desc="tox package type used to generate the package",
-                value=self._external_pkg_tox_env_type if is_external else self._package_tox_env_type,
-            )
-            return self.conf["package_env"], self.conf["package_tox_env_type"]
-        return None
+        if not self._register_package_conf():
+            return None
+
+        has_external_pkg = self.conf["package"] == "external"
+        self.core.add_config(
+            keys=["package_env", "isolated_build_env"],
+            of_type=str,
+            default=self._default_package_env,
+            desc="tox environment used to package",
+        )
+        self.conf.add_config(
+            keys=["package_env"],
+            of_type=str,
+            default=f"{self.core['package_env']}{'_external' if has_external_pkg else ''}",
+            desc="tox environment used to package",
+        )
+        is_external = self.conf["package"] == "external"
+        self.conf.add_constant(
+            keys=["package_tox_env_type"],
+            desc="tox package type used to generate the package",
+            value=self._external_pkg_tox_env_type if is_external else self._package_tox_env_type,
+        )
+        return self.conf["package_env"], self.conf["package_tox_env_type"]
 
     def _call_pkg_envs(self, method_name: str, *args: Any) -> None:
         for package_env in self.package_envs:


### PR DESCRIPTION
~Pushing as draft to ensure this is a sane direction. I still need to add tests. I also think I should subclass `PythonConstraints` from `RequirementsFile` rather than `PythonDeps` since we don't need a lot of the logic in the latter.~

I've done both of these now.

---

Add a new option allowing us to specify constraints file(s) that will be applied when installing all dependencies *except* the package under test. For example, given the following `tox.ini`:

```ini
[testenv]
deps =
  requests
extras =
  test
constraints =
  upper-constraints.txt
command =
  pytest {posargs}
```

The all requirements in `deps`, all requirements in the `test` extra, and all dependencies of the package itself will be installed with `-c upper-constraints.txt`. The package itself will not.

Closes #3550

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
