### PR TITLE
Pass ssh-agent variables by default

### DIFF
--- a/docs/changelog/3572.feature.rst
+++ b/docs/changelog/3572.feature.rst
@@ -1,0 +1,2 @@
+Pass ssh-agent variables ``SSH_AGENT_PID`` and ``SSH_AUTH_SOCK`` in ``pass_env`` by default.
+- by :user:`daniilgankov`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -552,6 +552,14 @@ Base options
             - ✅
             - ✅
             - ✅
+        *   - SSH_AGENT_PID
+            - ✅
+            - ✅
+            - ❌
+        *   - SSH_AUTH_SOCK
+            - ✅
+            - ✅
+            - ❌
 
    More environment variable-related information can be found in :ref:`environment variable substitutions`.
 

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -267,6 +267,8 @@ class ToxEnv(ABC):
                     "TMPDIR",  # temporary file location
                     "NIX_LD",  # nix-ld loader
                     "NIX_LD_LIBRARY_PATH",  # nix-ld library path
+                    "SSH_AGENT_PID",  # ssh-agent process ID
+                    "SSH_AUTH_SOCK",  # ssh-agent socket path
                 ],
             )
         return env

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -135,7 +135,9 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
         + (["PROGRAMDATA"] if is_win else [])
         + (["PROGRAMFILES"] if is_win else [])
         + (["PROGRAMFILES(x86)"] if is_win else [])
-        + ["PYTHON_GIL", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"]
+        + ["PYTHON_GIL", "REQUESTS_CA_BUNDLE"]
+        + (["SSH_AGENT_PID", "SSH_AUTH_SOCK"] if not is_win else [])
+        + ["SSL_CERT_FILE"]
         + (["SYSTEMDRIVE", "SYSTEMROOT", "TEMP"] if is_win else [])
         + (["TERM"] if stdout_is_atty else [])
         + (["TMP", "USERPROFILE"] if is_win else ["TMPDIR"])


### PR DESCRIPTION
A tox environment may have `git+ssh` dependencies or even direct `ssh` command calls. In non-interactive shell sessions (such as in CI tasks) the identity is often available only through ssh-agent to keep the private key in secret or because there is no way to enter the passphrase. SSH client is communicating with ssh-agent session through the socket opened on ``SSH_AUTH_SOCK``. This variable must be passed in the tox environment to SSH client could work with the agent session from there. If there is an active agent in a shell session, it most likely implies that it will be used for every SSH client connection even in tox environments.

ssh-agent evaluation exports not only ``SSH_AUTH_SOCK`` but also ``SSH_AGENT_PID`` with agent's process identifier. This variable is necessary to control the agent which also may be done from within a tox environment.

I do not know if either ssh-agent is available on Windows or it works the same way as it does on Linux/MacOS, so I do not pass the variables.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
