### PR TITLE
Docs: environment variables contain strings

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -575,7 +575,7 @@ Base options
        .. code-block:: toml
 
           [tool.tox.env_run_base]
-          set_env = { file = "conf{/}local.env", TEST_TIMEOUT = 30 }
+          set_env = { file = "conf{/}local.env", TEST_TIMEOUT = "30" }
 
     .. tab:: INI
 


### PR DESCRIPTION
Or else I got: TypeError: {'TEST_TIMEOUT': 30}

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

I made my contribution via the GitHub web interface. Hopefully the CI will fix any lint issues.