### PR TITLE
Follow recommendations for `FORCE_COLOR`

### DIFF
--- a/docs/changelog/3579.bugfix.rst
+++ b/docs/changelog/3579.bugfix.rst
@@ -1,0 +1,2 @@
+When the ``FORCE_COLOR`` variable is present and not an empty string, it forces ANSI color to be set.
+Previously, only ``yes``, ``true`` or ``0`` were valid values. - by :user:`jugmac00`

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, 
 
 from colorama import Fore
 
-from tox.config.loader.str_convert import StrConvert
 from tox.plugin import NAME
 from tox.util.ci import is_ci
 
@@ -357,10 +356,9 @@ def add_verbosity_flags(parser: ArgumentParser) -> None:
 
 
 def add_color_flags(parser: ArgumentParser) -> None:
-    converter = StrConvert()
     if os.environ.get("NO_COLOR", ""):
         color = "no"
-    elif converter.to_bool(os.environ.get("FORCE_COLOR", "")):
+    elif os.environ.get("FORCE_COLOR", ""):
         color = "yes"
     elif os.environ.get("TERM", "") == "dumb":
         color = "no"

--- a/tests/config/cli/test_parser.py
+++ b/tests/config/cli/test_parser.py
@@ -33,10 +33,10 @@ def test_parser_const_with_default_none(monkeypatch: MonkeyPatch) -> None:
 
 @pytest.mark.parametrize("is_atty", [True, False])
 @pytest.mark.parametrize("no_color", [None, "0", "1", "", "\t", " ", "false", "true"])
-@pytest.mark.parametrize("force_color", [None, "0", "1"])
+@pytest.mark.parametrize("force_color", [None, "", "0", "1", "string"])
 @pytest.mark.parametrize("tox_color", [None, "bad", "no", "yes"])
 @pytest.mark.parametrize("term", [None, "xterm", "dumb"])
-def test_parser_color(  # noqa: PLR0913
+def test_color(  # noqa: PLR0913
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
     no_color: str | None,
@@ -62,7 +62,7 @@ def test_parser_color(  # noqa: PLR0913
         expected = tox_color == "yes"
     elif bool(no_color):
         expected = False
-    elif force_color == "1":
+    elif force_color in {"0", "1", "string"}:
         expected = True
     elif term == "dumb":
         expected = False


### PR DESCRIPTION
When the `FORCE_COLOR` variable is present and not an empty string, it forces ANSI color to be set. Previously, only `yes`, `true` or `0` were valid values.

See https://force-color.org/.

Fixes #3579

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
