### PR TITLE
Expose a new `tox_extend_envs` hook in plugins API

### DIFF
--- a/docs/changelog/3510.feature.rst
+++ b/docs/changelog/3510.feature.rst
@@ -1,0 +1,1 @@
+3591.feature.rst

--- a/docs/changelog/3591.feature.rst
+++ b/docs/changelog/3591.feature.rst
@@ -1,0 +1,10 @@
+A new tox life cycle event is now exposed for use via :doc:`Plugins
+API </plugins>` -- by :user:`webknjaz`.
+
+The corresponding hook point is :func:`tox_extend_envs
+<tox.plugin.spec.tox_extend_envs>`. It allows plugin authors to
+declare ephemeral environments that they can then populate through
+the in-memory configuration loader interface.
+
+This patch was made possible thanks to pair programming with
+:user:`gaborbernat` at PyCon US 2025.

--- a/src/tox/plugin/manager.py
+++ b/src/tox/plugin/manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterable
 
 import pluggy
 
@@ -79,6 +79,12 @@ class Plugin:
         for name in os.environ.get("TOX_DISABLED_EXTERNAL_PLUGINS", "").split(","):
             self.manager.set_blocked(name)
         self.manager.load_setuptools_entrypoints(NAME)
+
+    def tox_extend_envs(self) -> list[Iterable[str]]:
+        additional_env_names_hook_value = self.manager.hook.tox_extend_envs()
+        # NOTE: S101 is suppressed below to allow for type narrowing in MyPy
+        assert isinstance(additional_env_names_hook_value, list)  # noqa: S101
+        return additional_env_names_hook_value
 
     def tox_add_option(self, parser: ToxParser) -> None:
         self.manager.hook.tox_add_option(parser=parser)

--- a/src/tox/plugin/spec.py
+++ b/src/tox/plugin/spec.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterable
 
 import pluggy
 
@@ -27,6 +27,24 @@ def tox_register_tox_env(register: ToxEnvRegister) -> None:
 
     :param register: a object that can be used to register new tox environment types
     """
+
+
+@_spec
+def tox_extend_envs() -> Iterable[str]:
+    """Declare additional environment names.
+
+    This hook is called without any arguments early in the lifecycle. It
+    is expected to return an iterable of strings with environment names
+    for tox to consider. It can be used to facilitate dynamic creation of
+    additional environments from within tox plugins.
+
+    This is ideal to pair with :func:`tox_add_core_config
+    <tox.plugin.spec.tox_add_core_config>` that has access to
+    ``state.conf.memory_seed_loaders`` allowing to extend it with instances of
+    :class:`tox.config.loader.memory.MemoryLoader` early enough before tox
+    starts caching configuration values sourced elsewhere.
+    """
+    return ()  # <- Please MyPy
 
 
 @_spec
@@ -108,6 +126,7 @@ __all__ = [
     "tox_after_run_commands",
     "tox_before_run_commands",
     "tox_env_teardown",
+    "tox_extend_envs",
     "tox_on_install",
     "tox_register_tox_env",
 ]

--- a/src/tox/session/state.py
+++ b/src/tox/session/state.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import sys
+from itertools import chain
 from typing import TYPE_CHECKING, Sequence
 
 from tox.config.main import Config
 from tox.journal import Journal
 from tox.plugin import impl
+from tox.plugin.manager import MANAGER
 
 from .env_select import EnvSelector
 
@@ -18,7 +20,8 @@ class State:
     """Runtime state holder."""
 
     def __init__(self, options: Options, args: Sequence[str]) -> None:
-        self.conf = Config.make(options.parsed, options.pos_args, options.source)
+        extended_envs = chain.from_iterable(MANAGER.tox_extend_envs())
+        self.conf = Config.make(options.parsed, options.pos_args, options.source, extended_envs)
         self.conf.core.add_constant(
             keys=["on_platform"],
             desc="platform we are running on",

--- a/tests/config/cli/test_cli_ini.py
+++ b/tests/config/cli/test_cli_ini.py
@@ -166,6 +166,7 @@ def test_conf_arg(tmp_path: Path, conf_arg: str, filename: str, content: str) ->
         Parsed(work_dir=dest, override=[], config_file=config_file, root_dir=None),
         pos_args=[],
         source=source,
+        extra_envs=(),
     )
 
 

--- a/tests/config/loader/conftest.py
+++ b/tests/config/loader/conftest.py
@@ -32,6 +32,7 @@ def replace_one(tmp_path: Path) -> ReplaceOne:
             root=tmp_path,
             pos_args=pos_args,
             work_dir=tmp_path,
+            extra_envs=(),
         )
         loader = config.get_env("py").loaders[0]
         args = ConfigLoadArgs(chain=[], name="a", env_name="a")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def tox_ini_conf(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ToxIniCreat
             Parsed(work_dir=dest, override=override or [], config_file=config_file, root_dir=None),
             pos_args=[],
             source=source,
+            extra_envs=(),
         )
 
     return func

--- a/tests/plugin/test_inline.py
+++ b/tests/plugin/test_inline.py
@@ -28,6 +28,7 @@ def test_inline_tox_py(tox_project: ToxProjectCreator) -> None:
 
 def test_toxfile_py_w_ephemeral_envs(tox_project: ToxProjectCreator) -> None:
     """Ensure additional ephemeral tox envs can be plugin-injected."""
+
     def plugin() -> None:  # pragma: no cover # the code is copied to a python file
         from tox.config.loader.memory import MemoryLoader  # noqa: PLC0415
         from tox.plugin import impl  # noqa: PLC0415

--- a/tests/plugin/test_inline.py
+++ b/tests/plugin/test_inline.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from tox.config.cli.parser import ToxParser
+    from tox.config.sets import ConfigSet
     from tox.pytest import ToxProjectCreator
+    from tox.session.state import State
 
 
 def test_inline_tox_py(tox_project: ToxProjectCreator) -> None:
@@ -22,3 +24,37 @@ def test_inline_tox_py(tox_project: ToxProjectCreator) -> None:
     result = project.run("-h")
     result.assert_success()
     assert "--magic" in result.out
+
+
+def test_toxfile_py_w_ephemeral_envs(tox_project: ToxProjectCreator) -> None:
+    """Ensure additional ephemeral tox envs can be plugin-injected."""
+    def plugin() -> None:  # pragma: no cover # the code is copied to a python file
+        from tox.config.loader.memory import MemoryLoader  # noqa: PLC0415
+        from tox.plugin import impl  # noqa: PLC0415
+
+        env_name = "sentinel-env-name"
+
+        @impl
+        def tox_extend_envs() -> tuple[str]:
+            return (env_name,)
+
+        @impl
+        def tox_add_core_config(core_conf: ConfigSet, state: State) -> None:  # noqa: ARG001
+            in_memory_config_loader = MemoryLoader(
+                base=["sentinel-base"],
+                description="sentinel-description",
+            )
+            state.conf.memory_seed_loaders[env_name].append(
+                in_memory_config_loader,  # src/tox/provision.py:provision()
+            )
+
+    project = tox_project({"toxfile.py": plugin})
+
+    tox_list_result = project.run("list", "-qq")
+    tox_list_result.assert_success()
+    expected_additional_env_txt = "\n\nadditional environments:\nsentinel-env-name -> sentinel-description"
+    assert expected_additional_env_txt in tox_list_result.out
+
+    tox_config_result = project.run("config", "-e", "sentinel-env-name", "-qq")
+    tox_config_result.assert_success()
+    assert "base = sentinel-base" in tox_config_result.out


### PR DESCRIPTION
This patch adds a new hook point in the tox lifecycle that lets plugin authors declare additional environment names dynamically. This can be used to provide extra tox environments shipped as installable plugins.

Resolves #3510.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation: https://tox--3591.org.readthedocs.build/en/3591/plugins.html#tox.plugin.spec.tox_extend_envs
