### PR TITLE
Add a "version added" note for `tox_extend_envs`

### DIFF
--- a/src/tox/plugin/spec.py
+++ b/src/tox/plugin/spec.py
@@ -33,6 +33,8 @@ def tox_register_tox_env(register: ToxEnvRegister) -> None:
 def tox_extend_envs() -> Iterable[str]:
     """Declare additional environment names.
 
+    .. versionadded:: 4.29.0
+
     This hook is called without any arguments early in the lifecycle. It
     is expected to return an iterable of strings with environment names
     for tox to consider. It can be used to facilitate dynamic creation of


### PR DESCRIPTION
This is a follow-up for #3591 that makes it prominent in the docs when the hook was first added.

*Preview:* https://tox--3595.org.readthedocs.build/en/3595/plugins.html#tox.plugin.spec.tox_extend_envs