### PR TITLE
Fix none config file issue 3611

### DIFF
--- a/docs/changelog/3611.bugfix.rst
+++ b/docs/changelog/3611.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``None`` appearing as the config filename in error output
+when the user's default config file is corrupt. - by :user:`kurtmckee`

--- a/src/tox/config/cli/ini.py
+++ b/src/tox/config/cli/ini.py
@@ -39,7 +39,7 @@ class IniConfig:
                 if self.has_tox_section:
                     self.ini = IniLoader(CORE, parser, overrides=[], core_section=CORE)
             except Exception as exception:  # noqa: BLE001
-                logging.error("failed to read config file %s because %r", config_file, exception)  # noqa: TRY400
+                logging.error("failed to read config file %s because %r", self.config_file, exception)  # noqa: TRY400
                 self.has_config_file = None
 
     def get(self, key: str, of_type: type[Any]) -> Any:

--- a/tests/config/cli/test_cli_ini.py
+++ b/tests/config/cli/test_cli_ini.py
@@ -247,3 +247,21 @@ def test_ini_help(exhaustive_ini: Path, capfd: CaptureFixture) -> None:
     res = out.splitlines()[-1]
     msg = f"config file {str(exhaustive_ini)!r} active (changed via env var TOX_USER_CONFIG_FILE)"
     assert res == msg
+
+
+def test_ini_loader_corrupt_default_config_file(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    caplog: LogCaptureFixture,
+) -> None:
+    # Setup: Create a corrupt DEFAULT_CONFIG_FILE and point to it.
+    config_file = tmp_path / "config.ini"
+    config_file.write_text("[tox\n")
+    mocker.patch("tox.config.cli.ini.DEFAULT_CONFIG_FILE", config_file)
+
+    # Act
+    IniConfig()
+
+    # Verify
+    assert "failed to read config file None" not in caplog.messages[0]
+    assert f"failed to read config file {config_file}" in caplog.messages[0]


### PR DESCRIPTION
This change fixes an issue that manifests when a user's default config file (like `~/.config/tox/config.ini`) is corrupt: the phrase "failed to read config file None" appears in the output.

```
ERROR:root:failed to read config file None because File contains no section headers.
file: '/home/kurt/.config/tox/config.ini', line: 1
'[tox\n'
```

Fixes #3611 

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
