### PR TITLE
Address a type-conversion noted during doc builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,8 @@ if TYPE_CHECKING:
 company, name = "tox-dev", "tox"
 release, version = __version__, ".".join(__version__.split(".")[:2])
 copyright = f"{company}"  # noqa: A001
-master_doc, source_suffix = "index", ".rst"
+master_doc = "index"
+source_suffix = {".rst": "restructuredtext"}
 
 html_theme = "furo"
 html_title, html_last_updated_fmt = "tox", "%Y-%m-%dT%H:%M:%S"


### PR DESCRIPTION
Doc builds show the following output:

```
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
```

This is addressed by upgrading `source_suffix` to a dict in `conf.py`.

> [!NOTE]
>
> As reported in #3622, the scheduled doc builds are currently failing in `main`. I expect the doc builds to fail here, as well, but it is not related. This PR is simply a minor update based on output I observed while investigating #3622.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
