### PR TITLE
TST: add weekly compatibility checks for CPython 3.15

### DIFF
--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -1,0 +1,56 @@
+name: weekly checks
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    tags-ignore: ["**"]
+  pull_request:
+    paths:
+      - .github/workflows/weekly.yaml
+  schedule:
+    - cron: "0 8 * * 1"
+
+env:
+  FORCE_COLOR: 1
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test ${{ matrix.py }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        py:
+          - "3.15"
+        os:
+          - ubuntu-24.04
+          - windows-2025
+          - macos-15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add .local/bin to Windows PATH
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "$USERPROFILE/.local/bin" >> $GITHUB_PATH
+      - name: Install tox@self
+        run: uv tool install --python-preference only-managed --python ${{ matrix.py }} tox@.
+      - name: Setup test suite
+        run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.py }}
+      - name: Run test suite
+        run: tox run --skip-pkg-install -e ${{ matrix.py }}
+        env:
+          PYTEST_ADDOPTS: "-vv --durations=20"
+          DIFF_AGAINST: HEAD
+          PYTEST_XDIST_AUTO_NUM_WORKERS: 0

--- a/docs/changelog/3629.misc.rst
+++ b/docs/changelog/3629.misc.rst
@@ -1,0 +1,1 @@
+Added weekly compatibility checks for Python 3.15 (alpha).

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,5 @@
 requires = [ "tox>=4.27" ]
-env_list = [ "fix", "3.14t", "3.14", "3.13", "3.12", "3.11", "3.10", "cov", "type", "docs", "pkg_meta" ]
+env_list = [ "fix", "3.15t", "3.15", "3.14t", "3.14", "3.13", "3.12", "3.11", "3.10", "cov", "type", "docs", "pkg_meta" ]
 skip_missing_interpreters = true
 
 [env_run_base]


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->


Python 3.15 is still early in its development and I don't know that there's a precedent for adding "support" quite this early in the cycle, but given there are 0 failing tests at the moment, I figure it would might still be useful so:
- later breaking changes are detected soon-ish
- this would help any downstream package tested with tox knowing they can try out 3.15 pre-releases safely (or at least that issues might already be known here).

Anyway, I think this is worth a shot. Let me know if this is too early.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [N/A] updated/extended the documentation
