### PR TITLE
fix: ensure log folder is created before writing the execution logs

### DIFF
--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -487,6 +487,8 @@ class ToxEnv(ABC):
 
     @staticmethod
     def _write_execute_log(env_name: str, log_file: Path, request: ExecuteRequest, status: ExecuteStatus) -> None:
+        if not log_file.parent.exists():
+            log_file.parent.mkdir(parents=True, exist_ok=True)
         with log_file.open("wt", encoding="utf-8") as file:
             file.write(f"name: {env_name}\n")
             file.write(f"run_id: {request.run_id}\n")


### PR DESCRIPTION
Fixes: #3632
