### PR TITLE
Fix broken log message (in that branch it did not match the arguments).

### DIFF
--- a/src/tox/execute/local_sub_process/__init__.py
+++ b/src/tox/execute/local_sub_process/__init__.py
@@ -85,6 +85,7 @@ class LocalSubprocessExecuteStatus(ExecuteStatus):
                     self._process.send_signal(SIG_INTERRUPT)
                 if self.wait(self.options.interrupt_timeout) is None:  # still alive -> TERM # pragma: no branch
                     terminate_output = self.options.terminate_timeout
+                    msg = "send signal %s to %d from %d with timeout %.2f"
                     logging.warning(msg, f"SIGTERM({SIGTERM})", to_pid, host_pid, terminate_output)
                     self._process.terminate()
                     # Windows terminate is UNIX kill


### PR DESCRIPTION
Should fix this bug:
```
TypeError: %d format: a real number is required, not str
Call stack:
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "c:\users\ionel\.local\bin\tox.exe\__main__.py", line 10, in <module>
    sys.exit(run())
  File "C:\Users\ionel\AppData\Roaming\uv\data\tools\tox\Lib\site-packages\tox\run.py", line 23, in run
    result = main(sys.argv[1:] if args is None else args)
  File "C:\Users\ionel\AppData\Roaming\uv\data\tools\tox\Lib\site-packages\tox\run.py", line 49, in main
    return handler(state)
  File "C:\Users\ionel\AppData\Roaming\uv\data\tools\tox\Lib\site-packages\tox\session\cmd\legacy.py", line 115, in legacy
    return run_sequential(state)
  File "C:\Users\ionel\AppData\Roaming\uv\data\tools\tox\Lib\site-packages\tox\session\cmd\run\sequential.py", line 25, in run_sequential
    return execute(state, max_workers=1, has_spinner=False, live=True)
  File "C:\Users\ionel\AppData\Roaming\uv\data\tools\tox\Lib\site-packages\tox\session\cmd\run\common.py", line 194, in execute
    tox_env.interrupt()
  File "C:\Users\ionel\AppData\Roaming\uv\data\tools\tox\Lib\site-packages\tox\tox_env\runner.py", line 90, in interrupt
    super().interrupt()
  File "C:\Users\ionel\AppData\Roaming\uv\data\tools\tox\Lib\site-packages\tox\tox_env\api.py", line 438, in interrupt
    status.interrupt()
  File "C:\Users\ionel\AppData\Roaming\uv\data\tools\tox\Lib\site-packages\tox\execute\local_sub_process\__init__.py", line 88, in interrupt
    logging.warning(msg, f"SIGTERM({SIGTERM})", to_pid, host_pid, terminate_output)
Message: 'requested interrupt of %d from %d, activate in %.2f'
Arguments: ('SIGTERM(15)', 30604, 30880, 0.2)
```
