### PR TITLE
Pass LOCALAPPDATA by default on Windows (#3639)

### DIFF
--- a/docs/changelog/3639.bugfix.rst
+++ b/docs/changelog/3639.bugfix.rst
@@ -1,0 +1,1 @@
+Added 'LocalAppData' to the default passed environment variables on Windows.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -504,6 +504,10 @@ Base options
             - ❌
             - ❌
             - ✅
+        *   - LOCALAPPDATA
+            - ❌
+            - ❌
+            - ✅
         *   - PROGRAMDATA
             - ❌
             - ❌

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -131,6 +131,7 @@ class Python(ToxEnv, ABC):
             env.extend(
                 [
                     "APPDATA",  # Needed for PIP platformsdirs.windows
+                    "LOCALAPPDATA",  # Needed for pymanager
                     "PROGRAMDATA",  # needed for discovering the VS compiler
                     "PROGRAMFILES(x86)",  # needed for discovering the VS compiler
                     "PROGRAMFILES",  # needed for discovering the VS compiler

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -126,6 +126,7 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
         + (["COMSPEC"] if is_win else [])
         + ["CPPFLAGS", "CURL_CA_BUNDLE", "CXX", "FORCE_COLOR", "HOME", "LANG"]
         + ["LANGUAGE", "LDFLAGS", "LD_LIBRARY_PATH"]
+        + (["LOCALAPPDATA"] if is_win else [])
         + (["MSYSTEM"] if is_win else [])
         + ["NETRC"]
         + (["NIX_LD", "NIX_LD_LIBRARY_PATH"] if not is_win else [])


### PR DESCRIPTION
In Python 3.14 the recommended installer for Python on Windows is to use [pymanager](https://docs.python.org/3/using/windows.html#python-install-manager). `pymanager` uses the `LOCALAPPDATA` setting to help located the installed runtimes. Without passing the environment variable, subprocess calls to `pymanager` or `py.exe` from within a tox command can fail.

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
