### PR TITLE
Docs: Add caution about ranges like `py{39-314}`

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1688,6 +1688,13 @@ will create the following envs:
 
 Negative ranges will also be expanded (``{3-1}`` -> ``{3,2,1}``), however, open ranges such as ``{1-}``, ``{-2}``, ``{a-}``, and ``{-b}`` will not be expanded.
 
+.. caution::
+
+  Be conscious of the number of significant digits in your range endpoints.
+  A range like ``py{39-314}`` will not do what you may expect.
+  (It expands to 275 environment names,
+  ``py39``, ``py40``, ``py41`` … ``py314``.)
+  Instead, use ``py3{9-14}``.
 
 
 Generative section names


### PR DESCRIPTION
A very minor documentation addition.

Tox's ultra-concise environment naming creates some challenges when using features like range expansions. If the user tries to define a range like `py{39-314}`, they'll get a lot more than they bargained for. Add a "Caution" box to the documentation about the range feature, reminding users to consider what their ranges mean _numerically_, rather than semantically.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
