### PR TITLE
CLI Parser: Drop epilog message for Sphinx help

### DIFF
--- a/src/tox/config/cli/parse.py
+++ b/src/tox/config/cli/parse.py
@@ -91,7 +91,10 @@ def _get_parser_doc() -> ToxParser:
 
     MANAGER.load_plugins(Path.cwd())
 
-    return _get_parser()  # pragma: no cover
+    parser = _get_parser()  # pragma: no cover
+    # Remove epilog message from help when formatting website docs
+    parser.epilog = None
+    return parser
 
 
 __all__ = (


### PR DESCRIPTION
It was reported in #3585 that the online documentation page for the CLI is showing this message at the bottom of the page:

> config file ‘/home/docs/.config/tox/config.ini’ missing (change via env var TOX_USER_CONFIG_FILE)

That message is the `.epilog` property of the `IniConfig` class in `tox.config.cli.ini`.

TBH I don't really understand the point of the message. Most users will never need or have a Tox user config file, preferring that all of their configuration come from project-local configs. And that's fine, or at least it seems like it should be. But that message is always there at the end of the CLI help output. And it completely ignores the local configuration, focusing exclusively on the (wholly unnecessary) user config file.

(For example...)
```console
$ cd /path/to/tox-dev/tox/
$ tox list --help |tail -n2

config file '/home/ferd/.config/tox/config.ini' missing (change via env var TOX_USER_CONFIG_FILE)

$ tox config --assert-config > /tmp/config.ini
$ TOX_USER_CONFIG_FILE="/tmp/config.ini" \
  tox list --help |tail -n2

config file '/tmp/config.ini' active (changed via env var TOX_USER_CONFIG_FILE)

$ TOX_USER_CONFIG_FILE="/tmp/config.ini" \
  tox -c ./tox.toml list --help |tail -n2

config file '/tmp/config.ini' active (changed via env var TOX_USER_CONFIG_FILE)
```
Regardless, we definitely _don't_ want that message displayed when Sphinx is formatting the parser help for inclusion in the HTML documentation. So, just brute-force set it to `None` before returning it to Sphinx:

When calling `tox.config.cli.parse._get_parser_doc()` from the Sphinx documentation build, reset the `.epilog` property on the returned parser object. This ensures the help will be formatted without any messages about configuration files.

Fixes #3585

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
