### PR TITLE
fix: wheel corruption when running parallel tox processes

### DIFF
--- a/docs/changelog/3667.bugfix.rst
+++ b/docs/changelog/3667.bugfix.rst
@@ -1,0 +1,1 @@
+Fix wheel corruption errors when the build backend updates the file in place - by :user:`gaborbernat`.

--- a/src/tox/util/file_view.py
+++ b/src/tox/util/file_view.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import shutil
 from itertools import chain
 from os.path import commonpath
@@ -24,16 +23,8 @@ def create_session_view(package: Path, temp_path: Path) -> Path:
     session_dir.mkdir()
     session_package = session_dir / package.name
 
-    links = False  # if we can do hard links do that, otherwise just copy
-    if hasattr(os, "link"):
-        try:
-            os.link(package, session_package)
-            links = True
-        except (OSError, NotImplementedError):
-            pass
-    if not links:
-        shutil.copyfile(package, session_package)
-    operation = "links" if links else "copied"
+    shutil.copyfile(package, session_package)
+    operation = "copied"
     common = commonpath((session_package, package))
     rel_session, rel_package = session_package.relative_to(common), package.relative_to(common)
     logging.debug("package %s %s to %s (%s)", rel_session, operation, rel_package, common)

--- a/tests/tox_env/python/test_python_runner.py
+++ b/tests/tox_env/python/test_python_runner.py
@@ -112,7 +112,7 @@ def test_package_temp_dir_view(tox_project: ToxProjectCreator, demo_pkg_inline: 
     result.assert_success()
     wheel_name = "demo_pkg_inline-1.0.0-py3-none-any.whl"
     session_path = Path(".tmp") / "package" / "1" / wheel_name
-    msg = f" D package {session_path} links to {Path('.pkg') / 'dist' / wheel_name} ({project.path / '.tox'}) "
+    msg = f" D package {session_path} copied to {Path('.pkg') / 'dist' / wheel_name} ({project.path / '.tox'}) "
     assert msg in result.out
     assert f" D delete package {project.path / '.tox' / session_path}" in result.out
 


### PR DESCRIPTION
When running multiple tox processes in parallel (e.g., `tox -p auto` or multiple CI jobs), users encounter wheel corruption errors:

```
Failed to read dist/my_package-1.0.0-py3-none-any.whl
Invalid zip file 'dist/my_package-1.0.0-py3-none-any.whl': Could not find EOCD
```

## Root Cause

The session view mechanism used hard links (`os.link()`) to create per-session copies of built wheels. Hard links share the same underlying file data (inode).

**Example of the problem:**

1. Process A builds wheel → `.tox/.tmp/package/1/pkg-1.0.whl` (hard link to original)
2. Process B starts reading from its session view
3. Process A rebuilds the wheel (overwrites original file data)
4. Process B's read fails - the file it's reading was corrupted mid-read

Even though numbered directories (`.tmp/package/1/`, `.tmp/package/2/`) prevent path collisions, all hard links point to the same inode, so modifying the original corrupts all views.

## Solution

Replace `os.link()` with `shutil.copyfile()`, which creates an independent copy. On modern copy-on-write filesystems (APFS, Btrfs, XFS with reflink), this automatically uses reflink, making it nearly as fast as hard linking while maintaining data independence.