### PR TITLE
docs: fix misleading ENVDIR reference in devenv description

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -33,7 +33,7 @@ Here is a non-exhaustive list of these.
         run-parallel (p)          run environments in parallel
         depends (de)              visualize tox environment dependencies
         list (l)                  list environments
-        devenv (d)                sets up a development environment at ENVDIR based on the tox configuration specified
+        devenv (d)                sets up a development environment at path based on the tox configuration specified
         config (c)                show tox configuration
         quickstart (q)            Command line script to quickly create a tox config file for a Python project
         exec (e)                  execute an arbitrary command within a tox environment


### PR DESCRIPTION
Replace ENVDIR with path in the devenv command description to match the actual CLI usage. The devenv command uses [path] not ENVDIR. Closes #3398