### PR TITLE
Fix code block format in docs/plugins.rst

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -30,9 +30,9 @@ For more information, refer to :ref:`the user guide <auto-provisioning>`.
 Plugins can be disabled via the ``TOX_DISABLED_EXTERNAL_PLUGINS`` environment variable. This variable can be set to a
 comma separated list of plugin names, e.g.:
 
-```bash
-env TOX_DISABLED_EXTERNAL_PLUGINS=tox-uv,tox-extra tox --version
-```
+.. code-block:: bash
+
+   env TOX_DISABLED_EXTERNAL_PLUGINS=tox-uv,tox-extra tox --version
 
 Developing your own plugin
 --------------------------


### PR DESCRIPTION
On [the current document](https://tox.wiki/en/latest/plugins.html), the bash command example for `TOX_DISABLED_EXTERNAL_PLUGINS` is rendered incorrectly.

This is because it uses Markdown-style code block (```bash) instead of reStructuredText syntax. This PR changes it to use the Sphinx `.. code-block:: bash` directive.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
