### PR TITLE
fix(docs): correct path for built documentation

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -28,7 +28,7 @@ section. This section contains only highlights; it's not a substitute for readin
     you are missing dependencies, but those tests will still be run by GitHub Actions.
   - ``tox -e type`` to typecheck changes. (All new code should have complete type annotations.)
   - ``tox -e docs`` to build documentation changes and update the changelog, followed by viewing (with a browser) the
-    generated HTML files under :file:`.tox/docs_out/`. The required changelog entry can be viewed at the "Release
+    generated HTML files under :file:`.tox/docs_out/html/`. The required changelog entry can be viewed at the "Release
     History" link at the left.
   - ``tox -e fix`` to lint code, documentation and any other changes to the repo. This will also fix the code and
     write out the changed files; you can update your commit with `git commit --amend`.
@@ -149,8 +149,8 @@ locally, run:
 
     tox -e docs
 
-The built documentation can be found in the ``.tox/docs_out`` folder and may be viewed by opening ``index.html`` within
-that folder.
+The built documentation can be found in the ``.tox/docs_out/html`` folder and may be viewed by opening ``index.html``
+within that folder.
 
 
 Contributing


### PR DESCRIPTION
The documentation references `.tox/docs_out` as the location of built docs, but the actual HTML output is in `.tox/docs_out/html/`.

This updates both references in `docs/development.rst` to point to the correct path.

Fixes #3674