### PR TITLE
Drop setup.py mentions from the installation page

### DIFF
--- a/docs/changelog/3588.doc.rst
+++ b/docs/changelog/3588.doc.rst
@@ -1,0 +1,1 @@
+Drop ``setup.py`` mentions from the installation page — by :user:`rahuldevikar`.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,13 +55,6 @@ When installing via a source distribution you need an installer that handles the
 need to ensure that the build requirements from :gh:`pyproject.toml <tox-dev/tox/blob/main/pyproject.toml>` are
 satisfied before triggering the installation.
 
-via ``setup.py``
-----------------
-
-We don't recommend and officially support this method. You should prefer using an installer that supports :pep:`517`
-interface, such as pip ``19.0.0`` or later. That being said you might be able to still install a package via this method
-if you satisfy build dependencies before calling the installation command (as described under :ref:`sdist`).
-
 latest unreleased
 -----------------
 


### PR DESCRIPTION
Fixes: #3588 

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
