### PR TITLE
📝 docs(plugins): document toxfile.py inline plugins

### DIFF
--- a/docs/changelog/828.doc.rst
+++ b/docs/changelog/828.doc.rst
@@ -1,0 +1,1 @@
+Document how to provide environments via ``toxfile.py`` inline plugins using ``tox_extend_envs`` and ``MemoryLoader`` - by :user:`gaborbernat`.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -53,14 +53,82 @@ Extensions points
 .. automodule:: tox.plugin.spec
    :members:
 
-A plugin can define its plugin module a:
+Inline plugins via ``toxfile.py``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can define plugins directly in your project by creating a ``toxfile.py`` file next to your tox configuration file.
+This avoids the need to package and install a separate plugin. All the same hooks are available.
+
+Adding a CLI flag
+"""""""""""""""""
+
+A ``toxfile.py`` that adds a ``--magic`` flag to the tox CLI:
 
 .. code-block:: python
 
+   from tox.config.cli.parser import ToxParser
+   from tox.plugin import impl
+
+
+   @impl
+   def tox_add_option(parser: ToxParser) -> None:
+       parser.add_argument("--magic", action="store_true", help="enable magic mode")
+
+Appending version info
+""""""""""""""""""""""
+
+A ``toxfile.py`` that appends text to the ``tox --version`` output:
+
+.. code-block:: python
+
+   from tox.plugin import impl
+
+
+   @impl
    def tox_append_version_info() -> str:
        return "magic"
 
-and this message will be appended to the output of the ``--version`` flag.
+Providing environments
+""""""""""""""""""""""
+
+Plugins can dynamically inject tox environments that don't need to be declared in ``tox.ini`` or ``pyproject.toml``.
+This uses two hooks together: :func:`tox_extend_envs <tox.plugin.spec.tox_extend_envs>` to declare the environment
+name, and :func:`tox_add_core_config <tox.plugin.spec.tox_add_core_config>` with
+:class:`~tox.config.loader.memory.MemoryLoader` to configure it.
+
+For example, a ``toxfile.py`` that adds a ``lint`` environment running `pre-commit <https://pre-commit.com>`_:
+
+.. code-block:: python
+
+   from collections.abc import Iterable
+
+   from tox.config.loader.memory import MemoryLoader
+   from tox.config.sets import ConfigSet
+   from tox.plugin import impl
+   from tox.session.state import State
+
+
+   @impl
+   def tox_extend_envs() -> Iterable[str]:
+       return ("lint",)
+
+
+   @impl
+   def tox_add_core_config(core_conf: ConfigSet, state: State) -> None:
+       state.conf.memory_seed_loaders["lint"].append(
+           MemoryLoader(
+               description="run pre-commit linters",
+               commands=[["pre-commit", "run", "--all-files"]],
+               deps=["pre-commit"],
+           ),
+       )
+
+With this ``toxfile.py`` in your project root, ``tox list`` shows the ``lint`` environment and ``tox run -e lint``
+executes it -- no configuration file entry needed.
+
+Any :ref:`configuration key <conf-testenv>` accepted by the environment can be passed as a keyword argument to
+``MemoryLoader``. Values from ``MemoryLoader`` act as defaults and can still be overridden by the configuration file
+or CLI ``--override``.
 
 Adoption of a plugin under tox-dev Github organization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -94,7 +162,7 @@ This section explains how the plugin interface changed between tox 3 and 4, and 
 on how to migrate.
 
 ``tox_get_python_executable``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""""
 
 With tox 4 the Python discovery is performed ``tox.tox_env.python.virtual_env.api._get_python`` that delegates the job
 to ``virtualenv``. Therefore first `define a new virtualenv discovery mechanism
@@ -102,11 +170,11 @@ to ``virtualenv``. Therefore first `define a new virtualenv discovery mechanism
 ``VIRTUALENV_DISCOVERY`` environment variable.
 
 ``tox_package``
-^^^^^^^^^^^^^^^
+"""""""""""""""
 
 Register new packager types via :func:`tox_register_tox_env <tox.plugin.spec.tox_register_tox_env>`.
 
 ``tox_addoption``
-^^^^^^^^^^^^^^^^^
+"""""""""""""""""
 
 Renamed to :func:`tox_add_option <tox.plugin.spec.tox_add_option>`.


### PR DESCRIPTION
The plugin documentation had only auto-generated API references and a single trivial example showing `tox_append_version_info`. Users wanting to provide environments from plugins (#828) had no practical guidance on how to use `toxfile.py` with `tox_extend_envs` and `MemoryLoader`.

This adds an "Inline plugins via `toxfile.py`" section with three progressively complex examples: adding a CLI flag via `tox_add_option`, appending version info, and dynamically providing environments using `tox_extend_envs` paired with `MemoryLoader`. 📝 The last example shows the exact use case from #828 -- a shared lint environment backed by pre-commit that doesn't require any `tox.ini` entry.

All examples are fully type-annotated and the RST heading levels in the Migration section were adjusted to stay consistent with the new sub-heading structure.

Closes #828