### PR TITLE
✨ feat(cli): add shell completion via argcomplete

### DIFF
--- a/docs/changelog/918.feature.rst
+++ b/docs/changelog/918.feature.rst
@@ -1,0 +1,1 @@
+Add shell completion support for bash, zsh, and fish via :pypi:`argcomplete` - by :user:`gaborbernat`

--- a/docs/cli_interface.rst
+++ b/docs/cli_interface.rst
@@ -1,5 +1,49 @@
 .. _cli:
 
+Shell completion
+----------------
+
+tox supports shell completion for commands, flags, and environment names via :pypi:`argcomplete`. Install tox with the
+``completion`` extra:
+
+.. code-block:: bash
+
+   uv tool install 'tox[completion]'
+
+Then configure your shell:
+
+.. tab:: bash
+
+   Add to ``~/.bashrc``:
+
+   .. code-block:: bash
+
+      eval "$(register-python-argcomplete tox)"
+
+.. tab:: zsh
+
+   Add to ``~/.zshrc``:
+
+   .. code-block:: zsh
+
+      autoload -U bashcompinit
+      bashcompinit
+      eval "$(register-python-argcomplete tox)"
+
+.. tab:: fish
+
+   Add to ``~/.config/fish/config.fish``:
+
+   .. code-block:: fish
+
+      register-python-argcomplete --shell fish tox | source
+
+Once configured, pressing ``<TAB>`` completes subcommands (``tox r`` → ``tox run``), flags (``tox run --``), and
+environment names (``tox run -e`` lists environments from your tox configuration).
+
+CLI interface
+-------------
+
 .. sphinx_argparse_cli::
   :module: tox.config.cli.parse
   :func: _get_parser_doc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ dependencies = [
   "typing-extensions>=4.15; python_version<'3.11'",
   "virtualenv>=20.36.1",
 ]
+optional-dependencies.completion = [
+  "argcomplete>=3.6.3",
+]
 urls.Documentation = "https://tox.wiki"
 urls.Homepage = "http://tox.readthedocs.org"
 urls."Release Notes" = "https://tox.wiki/en/latest/changelog.html"

--- a/src/tox/config/cli/parse.py
+++ b/src/tox/config/cli/parse.py
@@ -70,6 +70,12 @@ def _get_base(args: Sequence[str]) -> tuple[int, ToxHandler, Source]:
 def _get_all(args: Sequence[str]) -> tuple[Parsed, dict[str, Callable[[State], int]]]:
     """Parse all the options."""
     tox_parser = _get_parser()
+    try:
+        import argcomplete  # noqa: PLC0415
+
+        argcomplete.autocomplete(tox_parser)
+    except ImportError:
+        pass
     parsed = cast("Parsed", tox_parser.parse_args(args))
     handlers = {k: p for k, (_, p) in tox_parser.handlers.items()}
     return parsed, handlers

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -5,10 +5,14 @@ import re
 from collections import Counter
 from dataclasses import dataclass
 from difflib import get_close_matches
+from importlib.util import find_spec
 from itertools import chain
 from typing import TYPE_CHECKING, cast
 
+from tox.config.cli.parser import Parsed
 from tox.config.loader.str_convert import StrConvert
+from tox.config.main import Config
+from tox.config.source.discover import discover_source
 from tox.config.types import EnvList
 from tox.report import HandledError
 from tox.tox_env.api import ToxEnvCreateArgs
@@ -18,7 +22,7 @@ from tox.tox_env.register import REGISTER
 from tox.tox_env.runner import RunToxEnv
 
 if TYPE_CHECKING:
-    from argparse import ArgumentParser
+    from argparse import Action, ArgumentParser, Namespace
     from collections.abc import Iterable, Iterator
 
     from tox.session.state import State
@@ -109,7 +113,9 @@ def register_env_select_flags(
             help_msg = "enumerate (ALL -> all environments, not set -> use <env_list> from config)"
         else:
             help_msg = "environment to run"
-        add_to.add_argument("-e", dest="env", help=help_msg, default=default, type=CliEnv)
+        action = add_to.add_argument("-e", dest="env", help=help_msg, default=default, type=CliEnv)
+        if find_spec("argcomplete"):
+            action.completer = _env_completer  # type: ignore[attr-defined]
     if multiple:
         help_msg = "labels to evaluate"
         add_to.add_argument("-m", dest="labels", metavar="label", help=help_msg, default=[], type=str, nargs="+")
@@ -129,6 +135,28 @@ def register_env_select_flags(
     help_msg = "exclude all environments selected that match this regular expression"
     add_to.add_argument("--skip-env", dest="skip_env", metavar="re", help=help_msg, default="", type=str)
     return add_to
+
+
+def _env_completer(
+    prefix: str,  # noqa: ARG001
+    action: Action,  # noqa: ARG001
+    parser: ArgumentParser,  # noqa: ARG001
+    parsed_args: Namespace,  # noqa: ARG001
+) -> list[str]:
+    from tox.plugin.manager import MANAGER  # noqa: PLC0415  # circular import
+
+    try:
+        source = discover_source(None, None)
+        conf = Config.make(
+            Parsed(override=[], root_dir=None, work_dir=None),
+            None,
+            source,
+            chain.from_iterable(MANAGER.tox_extend_envs()),
+        )
+    except HandledError:
+        return []
+    else:
+        return ["ALL", *conf]
 
 
 @dataclass

--- a/tests/config/cli/test_argcomplete.py
+++ b/tests/config/cli/test_argcomplete.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import argcomplete
+
+from tox.config.cli.parse import get_options
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def test_argcomplete_autocomplete_called(mocker: MockerFixture) -> None:
+    mock_autocomplete = mocker.patch.object(argcomplete, "autocomplete")
+    get_options("r")
+    mock_autocomplete.assert_called_once()
+
+
+def test_argcomplete_missing_does_not_break(mocker: MockerFixture) -> None:
+    mocker.patch.dict("sys.modules", {"argcomplete": None})
+    result = get_options("r")
+    assert result.parsed is not None

--- a/tests/session/test_env_completer.py
+++ b/tests/session/test_env_completer.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from argparse import Action, ArgumentParser, Namespace
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from tox.report import HandledError
+from tox.session.env_select import _env_completer, register_env_select_flags  # noqa: PLC2701
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def completer_args() -> dict[str, Action | ArgumentParser | Namespace | str]:
+    return {
+        "prefix": "",
+        "action": MagicMock(spec=Action),
+        "parser": MagicMock(spec=ArgumentParser),
+        "parsed_args": MagicMock(spec=Namespace),
+    }
+
+
+def test_env_completer_ini(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, completer_args: dict[str, object]) -> None:
+    config = tmp_path / "tox.ini"
+    config.write_text("[tox]\nenv_list = py311,lint\n[testenv:docs]\n")
+    monkeypatch.chdir(tmp_path)
+    result = _env_completer(**completer_args)  # type: ignore[arg-type]
+    assert "ALL" in result
+    assert "py311" in result
+    assert "lint" in result
+    assert "docs" in result
+
+
+def test_env_completer_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, completer_args: dict[str, object]) -> None:
+    config = tmp_path / "tox.toml"
+    config.write_text('[env.lint]\ncommands = [["ruff", "check"]]\n')
+    monkeypatch.chdir(tmp_path)
+    result = _env_completer(**completer_args)  # type: ignore[arg-type]
+    assert "ALL" in result
+    assert "lint" in result
+
+
+def test_env_completer_no_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, completer_args: dict[str, object]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = _env_completer(**completer_args)  # type: ignore[arg-type]
+    assert result == ["ALL"]
+
+
+def test_env_completer_handled_error(mocker: MockerFixture, completer_args: dict[str, object]) -> None:
+    mocker.patch("tox.session.env_select.discover_source", side_effect=HandledError("bad config"))
+    result = _env_completer(**completer_args)  # type: ignore[arg-type]
+    assert result == []
+
+
+def test_env_completer_includes_plugin_envs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture, completer_args: dict[str, object]
+) -> None:
+    config = tmp_path / "tox.ini"
+    config.write_text("[tox]\nenv_list = py311\n")
+    monkeypatch.chdir(tmp_path)
+    mocker.patch("tox.plugin.manager.Plugin.tox_extend_envs", return_value=[["plugin-env"]])
+    result = _env_completer(**completer_args)  # type: ignore[arg-type]
+    assert "ALL" in result
+    assert "py311" in result
+    assert "plugin-env" in result
+
+
+def test_register_env_select_attaches_completer() -> None:
+    parser = ArgumentParser()
+    register_env_select_flags(parser, default=None, multiple=False)
+    action = next(a for a in parser._actions if a.dest == "env")  # noqa: SLF001
+    assert hasattr(action, "completer")
+    assert action.completer is _env_completer

--- a/tox.toml
+++ b/tox.toml
@@ -6,6 +6,7 @@ skip_missing_interpreters = true
 description = "run the tests with pytest under {env_name}"
 package = "wheel"
 wheel_build_env = ".pkg"
+extras = [ "completion" ]
 dependency_groups = [ "test" ]
 pass_env = [ "PYTEST_*", "SSL_CERT_FILE" ]
 set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{work_dir}{/}.coverage.{env_name}" }
@@ -132,6 +133,7 @@ commands = [ [ "python", "{tox_root}/tasks/release.py", "--version", "{posargs}"
 [env.dev]
 description = "dev environment with all deps at {envdir}"
 package = "editable"
+extras = [ "completion" ]
 dependency_groups = [ "dev" ]
 commands = [ [ "python", "-m", "pip", "list", "--format=columns" ], [ "python", "-c", 'print(r"{env_python}")' ] ]
 uv_seed = true


### PR DESCRIPTION
This is a long-standing request (issue #918, opened 10+ years ago) for shell tab-completion support. Users currently have no way to discover subcommands, flags, or environment names without consulting the docs or running `tox list`.

✨ Integrating `argcomplete` as an optional dependency (via `tox[completion]`) keeps the core lightweight — users who don't need completion pay no cost. When installed, pressing `<TAB>` completes subcommands (`tox r` → `tox run`), flags (`tox run --`), and crucially environment names (`tox run -e` lists envs from the project's tox configuration). The `-e` completer reads environment names directly from the config source without running full tox setup, keeping completion fast. Bash, zsh, and fish are all supported.

No behavioral changes for existing users. The `argcomplete.autocomplete()` call is a no-op unless the shell sets the `_ARGCOMPLETE` env var, and the entire integration is skipped when argcomplete is not installed.

Closes #918