### PR TITLE
✨ feat(package): validate extras against package metadata

### DIFF
--- a/docs/changelog/1113.feature.rst
+++ b/docs/changelog/1113.feature.rst
@@ -1,0 +1,1 @@
+Validate that configured extras exist in package metadata, raising a clear error for unknown extras - by :user:`gaborbernat`


### PR DESCRIPTION
tox silently ignored invalid extras names, leading to missing dependencies with no error. When a user configures `extras = typo-extra` but the package only provides `testing`, `docs`, `format`, the dependency filtering finds nothing and the environment appears to work — but required packages are missing, causing confusing test failures that waste debugging time.

Validation now happens at dependency resolution time using the metadata already available at each code path: static PEP-621 `optional-dependencies` keys, built distribution `Provides-Extra` headers, and wheel/sdist metadata. Invalid extras raise a `Fail` with a clear message listing both the unknown and available extras, e.g. `extras not found for package demo: typo (available: alpha, beta)`.

Closes #1113