### PR TITLE
✨ feat(depends): add glob pattern support for depends option

### DIFF
--- a/docs/changelog/1152.feature.rst
+++ b/docs/changelog/1152.feature.rst
@@ -1,0 +1,1 @@
+Add glob pattern support in ``depends`` (e.g. ``depends = py3*``) to match environments by wildcard instead of listing them explicitly - by :user:`gaborbernat`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -814,7 +814,32 @@ Run
    :keys: depends
    :default: <empty list>
 
-   tox environments that this environment depends on (must be run after those).
+   tox environments that this environment depends on (must be run after those). Supports glob patterns using
+   :py:mod:`fnmatch` syntax to match environment names dynamically:
+
+   - ``*`` matches everything (e.g. ``3.*`` matches ``3.12``, ``3.13``, ``3.14``)
+   - ``?`` matches any single character (e.g. ``py?`` matches ``py3`` but not ``py314``)
+   - ``[seq]`` matches any character in *seq* (e.g. ``lint-[ab]`` matches ``lint-a`` and ``lint-b``)
+   - ``[!seq]`` matches any character not in *seq*
+
+   .. tab:: TOML
+
+      .. code-block:: toml
+
+         [env.coverage]
+         depends = ["3.*"]
+
+   .. tab:: INI
+
+      .. code-block:: ini
+
+         [testenv:coverage]
+         depends = 3.*
+
+   This matches all environments whose name starts with ``3.`` (e.g. ``3.12``, ``3.13``, ``3.14``). Glob patterns are
+   resolved at runtime against the set of environments being run, so adding a new environment to ``env_list``
+   automatically includes it in the dependency without updating ``depends``. Self-matches are excluded, so
+   ``depends = *`` will depend on all other environments without creating a cycle.
 
    .. warning::
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -503,6 +503,9 @@ Parallel mode
   environment list to be run to satisfy these dependencies, also for sequential runs. Furthermore, in parallel mode,
   tox will only schedule a tox environment to run once all of its dependencies have finished (independent of their outcome).
 
+  ``depends`` supports glob patterns (``*``, ``?``, ``[seq]``), so instead of listing each environment explicitly you
+  can write ``depends = 3.*`` to match all environments starting with ``3.``.
+
   .. warning::
 
     ``depends`` does not pull in dependencies into the run target, for example if you select ``py310,py39,coverage``

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -7,6 +7,7 @@ import os
 import time
 from argparse import Action, ArgumentError, ArgumentParser, Namespace
 from concurrent.futures import CancelledError, Future, ThreadPoolExecutor, as_completed
+from fnmatch import fnmatchcase
 from pathlib import Path
 from signal import SIGINT, Handlers, signal
 from threading import Event, Thread
@@ -391,6 +392,6 @@ def run_order(state: State, to_run: list[str]) -> tuple[list[str], dict[str, set
     for env in to_run:
         run_env = cast("RunToxEnv", state.envs[env])
         depends = set(cast("EnvList", run_env.conf["depends"]).envs)
-        todo[env] = to_run_set & depends
+        todo[env] = {name for dep in depends for name in to_run_set if fnmatchcase(name, dep)} - {env}
     order = stable_topological_sort(todo)
     return order, todo

--- a/tests/session/cmd/test_depends.py
+++ b/tests/session/cmd/test_depends.py
@@ -96,6 +96,125 @@ def test_depends_sdist(tox_project: ToxProjectCreator, patch_prev_py: Callable[[
     assert outcome.out == dedent(expected).lstrip()
 
 
+def test_depends_glob_star(tox_project: ToxProjectCreator) -> None:
+    toml = """
+    env_list = ["3.12", "3.13", "3.14", "lint", "cov"]
+    [env_run_base]
+    package = "skip"
+    [env.cov]
+    depends = ["3.*"]
+    """
+    project = tox_project({"tox.toml": toml})
+    outcome = project.run("de")
+    outcome.assert_success()
+    expected = dedent("""\
+    Execution order: 3.12, 3.13, 3.14, lint, cov
+    ALL
+       3.12
+       3.13
+       3.14
+       lint
+       cov
+          3.12
+          3.13
+          3.14
+    """)
+    assert outcome.out == expected
+
+
+def test_depends_glob_question_mark(tox_project: ToxProjectCreator) -> None:
+    toml = """
+    env_list = ["a1", "a2", "ab", "cov"]
+    [env_run_base]
+    package = "skip"
+    [env.cov]
+    depends = ["a?"]
+    """
+    project = tox_project({"tox.toml": toml})
+    outcome = project.run("de")
+    outcome.assert_success()
+    expected = dedent("""\
+    Execution order: a1, a2, ab, cov
+    ALL
+       a1
+       a2
+       ab
+       cov
+          a1
+          a2
+          ab
+    """)
+    assert outcome.out == expected
+
+
+def test_depends_glob_no_match(tox_project: ToxProjectCreator) -> None:
+    toml = """
+    env_list = ["lint", "cov"]
+    [env_run_base]
+    package = "skip"
+    [env.cov]
+    depends = ["py*"]
+    """
+    project = tox_project({"tox.toml": toml})
+    outcome = project.run("de")
+    outcome.assert_success()
+    expected = dedent("""\
+    Execution order: lint, cov
+    ALL
+       lint
+       cov
+    """)
+    assert outcome.out == expected
+
+
+def test_depends_glob_mixed(tox_project: ToxProjectCreator) -> None:
+    toml = """
+    env_list = ["3.13", "3.14", "lint", "cov"]
+    [env_run_base]
+    package = "skip"
+    [env.cov]
+    depends = ["lint", "3.*"]
+    """
+    project = tox_project({"tox.toml": toml})
+    outcome = project.run("de")
+    outcome.assert_success()
+    expected = dedent("""\
+    Execution order: 3.13, 3.14, lint, cov
+    ALL
+       3.13
+       3.14
+       lint
+       cov
+          3.13
+          3.14
+          lint
+    """)
+    assert outcome.out == expected
+
+
+def test_depends_glob_excludes_self(tox_project: ToxProjectCreator) -> None:
+    toml = """
+    env_list = ["a", "b", "cov"]
+    [env_run_base]
+    package = "skip"
+    [env.cov]
+    depends = ["*"]
+    """
+    project = tox_project({"tox.toml": toml})
+    outcome = project.run("de")
+    outcome.assert_success()
+    expected = dedent("""\
+    Execution order: a, b, cov
+    ALL
+       a
+       b
+       cov
+          a
+          b
+    """)
+    assert outcome.out == expected
+
+
 def test_depends_help(tox_project: ToxProjectCreator) -> None:
     outcome = tox_project({"tox.ini": ""}).run("de", "-h")
     outcome.assert_success()


### PR DESCRIPTION
Users had to enumerate every dependency environment explicitly in `depends`, which was error-prone — adding a new Python version to `env_list` without updating `depends` could cause race conditions in parallel runs. 🔧 This became especially painful for projects testing across many Python versions or platform factors.

Glob patterns like `depends = py3*` now match against all environments in the current run, using `fnmatch` semantics (`*`, `?`, `[...]`). Non-glob entries pass through unchanged, so existing configurations keep working. Self-matches are automatically excluded to prevent dependency cycles (e.g. `depends = *` won't create a self-dependency).

Factor syntax (`{py39,py310}-test`) continues to work as before since glob resolution happens after factor expansion at runtime in `run_order()`, where the full set of environments is known.

Closes #1152