### PR TITLE
✨ feat(env): add disallow_pass_env to exclude env vars

### DIFF
--- a/docs/changelog/1387.feature.rst
+++ b/docs/changelog/1387.feature.rst
@@ -1,0 +1,2 @@
+Add ``disallow_pass_env`` configuration option to exclude specific environment variables after ``pass_env`` glob
+expansion - by :user:`gaborbernat`

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -580,6 +580,32 @@ Base options
    More environment variable-related information can be found in :ref:`environment variable substitutions`.
 
 .. conf::
+   :keys: disallow_pass_env
+   :default: <empty list>
+
+   Environment variable patterns to exclude after :ref:`pass_env` glob expansion. Uses the same
+   :py:mod:`fnmatch` wildcard syntax as ``pass_env``. Applied after ``pass_env`` patterns are resolved against the
+   host environment and before ``set_env`` values are applied:
+
+   .. tab:: TOML
+
+      .. code-block:: toml
+
+         [env_run_base]
+         pass_env = ["FOO_*"]
+         disallow_pass_env = ["FOO_SECRET"]
+
+   .. tab:: INI
+
+      .. code-block:: ini
+
+         [testenv]
+         pass_env = FOO_*
+         disallow_pass_env = FOO_SECRET
+
+   In this example, all environment variables matching ``FOO_*`` are passed through except ``FOO_SECRET``.
+
+.. conf::
    :keys: set_env, setenv
 
    A dictionary of environment variables to set when running commands in the tox environment.

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -187,6 +187,13 @@
         "passenv": {
           "$ref": "#/properties/env_run_base/properties/pass_env"
         },
+        "disallow_pass_env": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/subs"
+          },
+          "description": "environment variable patterns to exclude after pass_env glob expansion"
+        },
         "parallel_show_output": {
           "type": "boolean",
           "description": "if set to True the content of the output will always be shown  when running in parallel mode"


### PR DESCRIPTION
When using `pass_env` with wildcards like `FOO_*`, there was no way to exclude specific variables from the matched set. Tools where `unset` and empty-string have different semantics were impossible to configure correctly.

The new `disallow_pass_env` option accepts the same `fnmatch` glob patterns as `pass_env` and filters out matching variables after `pass_env` expansion, before `set_env` is applied. This keeps the configuration model simple — a separate key rather than overloaded syntax like `!FOO` in `pass_env`.

```toml
[env_run_base]
pass_env = ["FOO_*"]
disallow_pass_env = ["FOO_SECRET"]
```

Closes #1387