### PR TITLE
🔒 ci(workflows): add explicit permissions to workflows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 8 * * *"
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
   push:
     tags: ["*"]
 
+permissions:
+  contents: read
+
 env:
   dists-artifact-name: python-package-distributions
   FORCE_COLOR: 1

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 8 * * 1"
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 


### PR DESCRIPTION
CodeQL flagged GitHub Actions workflows for missing explicit permission declarations. 🔒 Without these declarations, workflows inherit potentially broad default permissions, violating the principle of least privilege and increasing security risk if workflow files are compromised.

Added `permissions: contents: read` at the workflow level for `check.yaml`, `weekly.yaml`, and `release.yaml`. This grants only the minimal permission needed to checkout code and run CI checks. The `release` job already has its own `id-token: write` permission for PyPI publishing, which overrides the workflow-level setting for that specific job.

This change resolves all four CodeQL medium-severity alerts without affecting workflow functionality. The workflows continue to operate as before, now with proper security boundaries in place.