### PR TITLE
✨ feat(config): add extra_setup_commands for --notest phase

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,21 +6,27 @@
 
 .. towncrier release notes start
 
-*********************
+**********************
  v4.36.1 (2026-02-17)
-*********************
+**********************
 
 Bugfixes - 4.36.1
 =================
-- Report TOML parse errors during config discovery instead of silently ignoring them - by :user:`rahuldevikar`. (:issue:`3030`)
-- Adopt CPython's subprocess stream handling to fix deadlocks and improve performance when reading subprocess output (:issue:`3715`)
+
+- Report TOML parse errors during config discovery instead of silently ignoring them - by :user:`rahuldevikar`.
+  (:issue:`3030`)
+- Adopt CPython's subprocess stream handling to fix deadlocks and improve performance when reading subprocess output
+  (:issue:`3715`)
 
 Documentation - 4.36.1
 ======================
-- Add Unix man page generation and installation support using sphinx-argparse-cli - by :user:`gaborbernat`. (:issue:`1409`)
-- Document use of Python :mod:`logging` for plugin authors in the how-to guides, covering verbosity levels, coloring, and
-  best practices — by :user:`rahuldevikar`. (:issue:`3449`)
-- Add architecture documentation for new contributors under the development section - by :user:`rahuldevikar` (:issue:`3707`)
+
+- Add Unix man page generation and installation support using sphinx-argparse-cli - by :user:`gaborbernat`.
+  (:issue:`1409`)
+- Document use of Python :mod:`logging` for plugin authors in the how-to guides, covering verbosity levels, coloring,
+  and best practices — by :user:`rahuldevikar`. (:issue:`3449`)
+- Add architecture documentation for new contributors under the development section - by :user:`rahuldevikar`
+  (:issue:`3707`)
 
 **********************
  v4.36.0 (2026-02-15)

--- a/docs/changelog/1504.feature.rst
+++ b/docs/changelog/1504.feature.rst
@@ -1,0 +1,2 @@
+Add ``extra_setup_commands`` configuration option to run commands after dependency and package installation but before
+test commands, useful with ``--notest`` for separating setup from execution - by :user:`gaborbernat`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -965,6 +965,46 @@ Run
        set.
 
 .. conf::
+    :keys: extra_setup_commands
+    :default: <empty list>
+    :version_added: 4.37
+
+    Commands to execute after the setup phase (dependencies and package installation) but before test commands.
+    These commands run during the ``--notest`` phase, making them useful for separating environment setup from
+    test execution. All evaluation and configuration logic applies from :ref:`commands`.
+
+    This is particularly useful when you want to use ``tox run --notest`` to set up the environment and install
+    additional tools or perform setup tasks, while keeping the actual test execution separate.
+
+    For example, to install pre-commit hooks during the setup phase:
+
+    .. tab:: TOML
+
+       .. code-block:: toml
+
+          [tool.tox.env_run_base]
+          deps = ["pre-commit"]
+          extra_setup_commands = [
+            ["pre-commit", "install-hooks"],
+          ]
+          commands = [
+            ["pre-commit", "run", "--all-files"],
+          ]
+
+    .. tab:: INI
+
+       .. code-block:: ini
+
+          [testenv]
+          deps = pre-commit
+          extra_setup_commands = pre-commit install-hooks
+          commands = pre-commit run --all-files
+
+    When running ``tox run --notest``, the environment will be created, dependencies installed, and
+    ``extra_setup_commands`` executed, but ``commands`` will be skipped. When running ``tox run`` without
+    ``--notest``, all commands including ``extra_setup_commands`` will execute.
+
+.. conf::
     :keys: commands_pre
     :default: <empty list>
     :version_added: 3.4

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -116,25 +116,26 @@ This traces ``tox run -e py311`` from start to finish, showing the six main phas
             L[Create virtualenv]
             M[Install dependencies]
             N[Build & install package]
+            O[Run extra_setup_commands]
             K -->|No| L --> M
             K -->|Yes| M
-            M --> N
+            M --> N --> O
         end
 
         subgraph EXEC["5️⃣ EXECUTION"]
             direction TB
-            O[Run commands_pre]
-            P[Run commands]
-            Q[Run commands_post]
-            O --> P --> Q
+            P[Run commands_pre]
+            Q[Run commands]
+            R[Run commands_post]
+            P --> Q --> R
         end
 
         subgraph RESULT["6️⃣ RESULTS"]
             direction TB
-            R[Collect outcomes]
-            S[Write journal]
-            T[Report summary]
-            R --> S --> T
+            S[Collect outcomes]
+            T[Write journal]
+            U[Report summary]
+            S --> T --> U
         end
 
         ENTRY --> PROV
@@ -165,12 +166,13 @@ This traces ``tox run -e py311`` from start to finish, showing the six main phas
         style L fill:#9B59B6,stroke:#6D3F8C,color:#fff
         style M fill:#9B59B6,stroke:#6D3F8C,color:#fff
         style N fill:#9B59B6,stroke:#6D3F8C,color:#fff
-        style O fill:#3498DB,stroke:#2574A9,color:#fff
+        style O fill:#9B59B6,stroke:#6D3F8C,color:#fff
         style P fill:#3498DB,stroke:#2574A9,color:#fff
         style Q fill:#3498DB,stroke:#2574A9,color:#fff
-        style R fill:#E74C3C,stroke:#B23A2F,color:#fff
+        style R fill:#3498DB,stroke:#2574A9,color:#fff
         style S fill:#E74C3C,stroke:#B23A2F,color:#fff
         style T fill:#E74C3C,stroke:#B23A2F,color:#fff
+        style U fill:#E74C3C,stroke:#B23A2F,color:#fff
 
 High-level architecture
 =======================
@@ -405,7 +407,7 @@ Environment lifecycle
 .. mermaid::
 
     flowchart TD
-        A["1. SETUP<br/>• Platform check (skip if no match)<br/>• Recreate check → clean()<br/>• Create virtualenv<br/>• Install deps<br/>• Install package (build + install)"]
+        A["1. SETUP<br/>• Platform check (skip if no match)<br/>• Recreate check → clean()<br/>• Create virtualenv<br/>• Install deps<br/>• Install package (build + install)<br/>• extra_setup_commands"]
         B["2. EXECUTE<br/>• commands_pre<br/>• commands<br/>• commands_post (always runs)"]
         C["3. TEARDOWN<br/>• Detach from package envs<br/>• Close PEP-517 backend<br/>• Delete built packages"]
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -37,8 +37,9 @@ Below is a graphical representation of the tox lifecycle:
             create --> deps[Install dependencies]
             deps --> pkg{package project?}
             pkg -- yes --> build[Build and install package]
-            pkg -- no --> cmds
-            build --> cmds
+            pkg -- no --> extra
+            build --> extra[Run extra_setup_commands]
+            extra --> cmds
             cmds[Run commands]
         end
 
@@ -48,6 +49,7 @@ Below is a graphical representation of the tox lifecycle:
         classDef configStyle fill:#dbeafe,stroke:#3b82f6,stroke-width:2px,color:#1e3a5f
         classDef envStyle fill:#dcfce7,stroke:#22c55e,stroke-width:2px,color:#14532d
         classDef pkgStyle fill:#ffedd5,stroke:#f97316,stroke-width:2px,color:#7c2d12
+        classDef setupStyle fill:#fde68a,stroke:#fbbf24,stroke-width:2px,color:#78350f
         classDef cmdStyle fill:#ede9fe,stroke:#8b5cf6,stroke-width:2px,color:#3b0764
         classDef reportStyle fill:#ccfbf1,stroke:#14b8a6,stroke-width:2px,color:#134e4a
         classDef decisionStyle fill:#fef9c3,stroke:#eab308,stroke-width:2px,color:#713f12
@@ -55,6 +57,7 @@ Below is a graphical representation of the tox lifecycle:
         class config configStyle
         class create,deps envStyle
         class build pkgStyle
+        class extra setupStyle
         class cmds cmdStyle
         class report reportStyle
         class pkg decisionStyle
@@ -77,7 +80,9 @@ The primary tox states are:
       configuration section, and then the earlier packaged source distribution. By default ``pip`` is used to install
       packages, however one can customize this via ``install_command``.
    3. **Packaging** (optional): create a distribution of the current project (see :ref:`packaging` below).
-   4. **Commands**: run the specified commands in the specified order. Whenever the exit code of any of them is not
+   4. **Extra setup commands** (optional): run the :ref:`extra_setup_commands` specified. These execute after all
+      installations complete but before test commands, and run during the ``--notest`` phase.
+   5. **Commands**: run the specified commands in the specified order. Whenever the exit code of any of them is not
       zero, stop and mark the environment failed. When you start a command with a dash character, the exit code will be
       ignored.
 

--- a/tests/tox_env/python/test_extra_setup_commands.py
+++ b/tests/tox_env/python/test_extra_setup_commands.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tox.pytest import ToxProjectCreator
+
+
+def test_extra_setup_commands_runs_with_notest(tox_project: ToxProjectCreator) -> None:
+    ini = """
+        [testenv]
+        package = skip
+        deps = pip
+        extra_setup_commands = python -c 'print("extra setup")'
+        commands = python -c 'print("main command")'
+    """
+    proj = tox_project({"tox.ini": ini})
+    result = proj.run("r", "--notest")
+    result.assert_success()
+    assert "extra setup" in result.out
+    assert "main command" not in result.out
+
+
+def test_extra_setup_commands_runs_without_notest(tox_project: ToxProjectCreator) -> None:
+    ini = """
+        [testenv]
+        package = skip
+        deps = pip
+        extra_setup_commands = python -c 'print("extra setup")'
+        commands = python -c 'print("main command")'
+    """
+    proj = tox_project({"tox.ini": ini})
+    result = proj.run("r")
+    result.assert_success()
+    assert "extra setup" in result.out
+    assert "main command" in result.out
+
+
+def test_extra_setup_commands_with_package_skip(tox_project: ToxProjectCreator) -> None:
+    ini = """
+        [testenv]
+        package = skip
+        extra_setup_commands = python -c 'import sys; sys.exit(0)'
+    """
+    proj = tox_project({"tox.ini": ini})
+    result = proj.run("r", "--notest")
+    result.assert_success()
+
+
+def test_extra_setup_commands_with_package_install(tox_project: ToxProjectCreator) -> None:
+    ini = "[testenv]\nextra_setup_commands = python -c 'print(\"after package install\")'"
+    proj = tox_project({"tox.ini": ini})
+    result = proj.run("r", "--notest")
+    result.assert_success()
+    assert "after package install" in result.out
+
+
+def test_extra_setup_commands_failure_stops_execution(tox_project: ToxProjectCreator) -> None:
+    ini = """
+        [testenv]
+        package = skip
+        extra_setup_commands = python -c 'import sys; sys.exit(1)'
+        commands = python -c 'print("should not run")'
+    """
+    proj = tox_project({"tox.ini": ini})
+    result = proj.run("r", "--notest")
+    result.assert_failed()
+    assert "extra_setup_commands failed" in result.out
+
+
+def test_extra_setup_commands_failure_with_ignore_errors(tox_project: ToxProjectCreator) -> None:
+    ini = """
+        [testenv]
+        package = skip
+        ignore_errors = true
+        extra_setup_commands = python -c 'import sys; sys.exit(1)'
+        commands = python -c 'print("main command")'
+    """
+    proj = tox_project({"tox.ini": ini})
+    result = proj.run("r")
+    result.assert_success()
+    assert "main command" in result.out
+
+
+def test_extra_setup_commands_multiple_commands(tox_project: ToxProjectCreator) -> None:
+    ini = """
+        [testenv]
+        package = skip
+        extra_setup_commands =
+            python -c 'print("cmd1")'
+            python -c 'print("cmd2")'
+            python -c 'print("cmd3")'
+    """
+    proj = tox_project({"tox.ini": ini})
+    result = proj.run("r", "--notest")
+    result.assert_success()
+    assert "cmd1" in result.out
+    assert "cmd2" in result.out
+    assert "cmd3" in result.out
+
+
+def test_extra_setup_commands_empty_default(tox_project: ToxProjectCreator) -> None:
+    ini = "[testenv]\npackage = skip"
+    proj = tox_project({"tox.ini": ini})
+    result = proj.run("r", "--notest")
+    result.assert_success()
+
+
+def test_extra_setup_commands_execution_order(tox_project: ToxProjectCreator) -> None:
+    ini = """
+        [testenv]
+        package = skip
+        deps = pip
+        extra_setup_commands = python -c 'print("EXTRA_SETUP")'
+        commands_pre = python -c 'print("COMMANDS_PRE")'
+        commands = python -c 'print("COMMANDS")'
+        commands_post = python -c 'print("COMMANDS_POST")'
+    """
+    proj = tox_project({"tox.ini": ini})
+    result = proj.run("r")
+    result.assert_success()
+
+    assert "EXTRA_SETUP" in result.out
+    assert "COMMANDS_PRE" in result.out
+    assert "COMMANDS" in result.out
+    assert "COMMANDS_POST" in result.out
+
+    lines = result.out.split("\n")
+    extra_setup_idx = next(i for i, line in enumerate(lines) if "EXTRA_SETUP" in line)
+    commands_pre_idx = next(i for i, line in enumerate(lines) if "COMMANDS_PRE" in line)
+    commands_idx = next(
+        i
+        for i, line in enumerate(lines)
+        if "COMMANDS" in line and "COMMANDS_PRE" not in line and "COMMANDS_POST" not in line
+    )
+    commands_post_idx = next(i for i, line in enumerate(lines) if "COMMANDS_POST" in line)
+
+    assert extra_setup_idx < commands_pre_idx < commands_idx < commands_post_idx


### PR DESCRIPTION
When running `tox --notest` in CI pipelines, teams need to separate dependency installation from test execution. The existing `commands_pre`, `commands`, and `commands_post` all run during the test phase and are completely skipped with `--notest`, leaving no way to run setup tasks during the installation phase. 🔧

A common use case is installing pre-commit hooks with `pre-commit install-hooks` during the `--notest` phase, then running `pre-commit run` as the actual test command in a separate CI step. This separation allows faster feedback and better resource utilization in CI environments.

This PR introduces `extra_setup_commands` that executes after all installations (dependencies and package) complete but before the test phase begins. ✨ These commands run during `--notest`, enabling users to prepare their environment with tools and hooks while deferring test execution to a separate step.

The implementation adds the configuration option to `PythonRun` environments only, deliberately excluding packaging environments to maintain their clean separation of concerns. Commands execute with the same change directory and error handling semantics as other command sets.

Resolves #1504