### PR TITLE
🐛 fix(release): format changelog with pre-commit before committing

### DIFF
--- a/docs/changelog/3717.bugfix.rst
+++ b/docs/changelog/3717.bugfix.rst
@@ -1,0 +1,1 @@
+Run pre-commit on changelog.rst after towncrier build to ensure proper formatting before committing the release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ pkg-meta = [
 release = [
   "gitpython>=3.1.46",
   "packaging>=26",
+  "pre-commit>=4.5.1",
   "towncrier>=25.8",
 ]
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -116,6 +116,13 @@ def get_upstream(repo: Repo) -> Remote:
 def release_changelog(repo: Repo, version: Version) -> Commit:
     print("generate release commit")  # noqa: T201
     check_call(["towncrier", "build", "--yes", "--version", version.public], cwd=str(ROOT_SRC_DIR))  # noqa: S607
+    print("format changelog with pre-commit")  # noqa: T201
+    changelog_path = ROOT_SRC_DIR / "docs" / "changelog.rst"
+    try:
+        check_call(["pre-commit", "run", "--files", str(changelog_path)], cwd=str(ROOT_SRC_DIR))  # noqa: S607
+    except CalledProcessError:
+        print("pre-commit made formatting changes, staging them")  # noqa: T201
+    repo.index.add([str(changelog_path)])
     return repo.index.commit(f"release {version}")
 
 


### PR DESCRIPTION
The release process generates `changelog.rst` using towncrier, but towncrier's output doesn't always match our pre-commit formatting rules. 📝 This leads to the release commit containing unformatted changelog text that later gets flagged by CI, requiring follow-up formatting commits.

This PR modifies the release script to run pre-commit on the generated `changelog.rst` immediately after towncrier builds it but before creating the release commit. The pre-commit hooks apply all necessary formatting (line wrapping, trailing whitespace removal, etc.) so the changelog is properly formatted from the start.

The implementation catches and handles the case where pre-commit makes changes (exit code 1), stages those changes, and includes them in the release commit. This keeps the release history clean without requiring manual intervention or subsequent formatting commits.