### PR TITLE
🐛 fix(env): allow set_env to modify PATH variable

### DIFF
--- a/docs/changelog/3445.bugfix.rst
+++ b/docs/changelog/3445.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``PATH`` environment variable modifications in ``set_env`` being ignored. The ``_paths`` setter was directly
+updating the cached environment variables, bypassing ``set_env`` values — by :user:`gaborbernat`.

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -406,11 +406,8 @@ class ToxEnv(ABC):
     @_paths.setter
     def _paths(self, value: list[Path]) -> None:
         self._paths_private = value
-        # also update the environment variable with the new value
-        if self._env_vars is not None:  # pragma: no branch
-            # remove duplicates and prepend the tox env paths
-            result = self._make_path()
-            self._env_vars["PATH"] = result
+        if self._env_vars is not None:
+            self._env_vars = None
 
     @property
     def _allow_externals(self) -> list[str]:

--- a/tests/tox_env/test_api.py
+++ b/tests/tox_env/test_api.py
@@ -38,6 +38,24 @@ def test_setenv_section_substitution(tox_project: ToxProjectCreator) -> None:
     result.assert_success()
 
 
+def test_setenv_can_modify_path(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+                [env_run_base]
+                package = "skip"
+                set_env.PATH = "{env:PATH}:/custom/path"
+                commands = [
+                    ["python", "-c", "import os; print(os.environ.get('PATH', ''))"]
+                ]
+            """,
+        },
+    )
+    result = project.run("r", "-e", "py")
+    result.assert_success()
+    assert "/custom/path" in result.out
+
+
 @pytest.mark.parametrize(
     ("key", "do_redact"),
     [


### PR DESCRIPTION
Users attempting to append or modify `PATH` via `set_env` found their changes completely ignored. 🐛 This affected common workflows like adding custom tool directories or prepending build paths, forcing users to work around the issue or abandon tox configuration in favor of wrapper scripts.

The problem was a race condition in environment variable composition. The `_paths` property setter was directly updating the cached environment variables dictionary, overwriting `PATH` after `set_env` had already been applied. The `environment_variables` property at line 386 already handles `PATH` composition correctly by building it from `_make_path()` and then allowing `set_env` to override it.

Removing the redundant update from the setter allows the normal environment variable flow to work. ✨ Users can now modify `PATH` through `set_env` just like any other environment variable.

Fixes #3445