### PR TITLE
🐛 fix(ci): add completion extras to type checker environments

### DIFF
--- a/docs/changelog/3728.bugfix.rst
+++ b/docs/changelog/3728.bugfix.rst
@@ -1,0 +1,2 @@
+Fix type checker CI failure by adding ``completion`` extras to ``type`` and ``type-min`` environments so ``ty`` can
+resolve the ``argcomplete`` import - by :user:`gaborbernat`.

--- a/tox.toml
+++ b/tox.toml
@@ -65,12 +65,14 @@ commands = [ [ "pre-commit", "run", "--all-files", "--show-diff-on-failure", { r
 [env.type]
 base_python = ["3.14"]
 description = "run type check on code base"
+extras = [ "completion" ]
 dependency_groups = [ "type" ]
 commands = [ [ "ty", "check", "--python-platform", "all", "--output-format", "concise", "--error-on-warning", "." ] ]
 
 [env.type-min]
 base_python = ["3.10"]
 description = "run type check on code base for the minimum supported Python"
+extras = [ "completion" ]
 dependency_groups = [ "type-min" ]
 commands = [ [ "ty", "check", "--python-version", "3.10", "--python-platform", "all", "--output-format", "concise", "--error-on-warning", "src", "tests" ] ]
 


### PR DESCRIPTION
The `type` and `type-min` CI environments fail because `ty` cannot resolve the `argcomplete` module imported in `src/tox/config/cli/parse.py` and `tests/config/cli/test_argcomplete.py`. While `env_run_base` declares `extras = ["completion"]`, the type environments weren't picking it up reliably, causing `error[unresolved-import]` on fresh CI runs.

🔧 The fix explicitly sets `extras = ["completion"]` on both `env.type` and `env.type-min` in `tox.toml`, reusing the existing `optional-dependencies.completion` that already defines `argcomplete>=3.6.3` rather than duplicating the dependency.