### PR TITLE
Fix type/type-min CI: suppress argcomplete unresolved-import

### DIFF
--- a/src/tox/config/cli/parse.py
+++ b/src/tox/config/cli/parse.py
@@ -71,7 +71,7 @@ def _get_all(args: Sequence[str]) -> tuple[Parsed, dict[str, Callable[[State], i
     """Parse all the options."""
     tox_parser = _get_parser()
     try:
-        import argcomplete  # noqa: PLC0415
+        import argcomplete  # noqa: PLC0415  # ty: ignore[unresolved-import] # optional dependency
 
         argcomplete.autocomplete(tox_parser)
     except ImportError:

--- a/tests/config/cli/test_argcomplete.py
+++ b/tests/config/cli/test_argcomplete.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import argcomplete
+import argcomplete  # ty: ignore[unresolved-import] # optional dependency, only installed via extras=["completion"]
 
 from tox.config.cli.parse import get_options
 


### PR DESCRIPTION
## Summary

The `type` and `type-min` CI jobs fail because `ty check` cannot resolve the `argcomplete` import:

```
src/tox/config/cli/parse.py:74:16: error[unresolved-import] Cannot resolve imported module `argcomplete`
tests/config/cli/test_argcomplete.py:5:8: error[unresolved-import] Cannot resolve imported module `argcomplete`
```

`argcomplete` is an optional dependency under `extras=["completion"]` and may not be installed in the type check environment. The import in `parse.py` is already guarded with `try/except ImportError`, and the test file only runs when argcomplete is available.

## Changes

Added `# ty: ignore[unresolved-import]` comments to both import sites, matching the existing pattern used for other optional/platform-specific imports (e.g., `_overlapped`, `pty`, `termios` in `local_sub_process/__init__.py`).

## Test plan

- [ ] Verify type/type-min CI jobs pass (they currently fail on main with the same error)