### PR TITLE
🐛 fix(test): resolve Windows CI flake in provision integration tests

### DIFF
--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -151,7 +151,7 @@ def test_provision_requires_nok(tox_project: ToxProjectCreator) -> None:
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("_pypi_index_self")
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows subprocess deadlocks during provision recreate")
+@pytest.mark.timeout(120)
 def test_provision_requires_ok(tox_project: ToxProjectCreator, tmp_path: Path) -> None:
     proj = tox_project({"tox.ini": "[tox]\nrequires=demo-pkg-inline\n[testenv]\npackage=skip"})
     log = tmp_path / "out.log"
@@ -279,6 +279,7 @@ def test_provision_default_arguments_exists(tox_project: ToxProjectCreator, subc
 @pytest.mark.integration
 @pytest.mark.usefixtures("_pypi_index_mirrored")
 @pytest.mark.flaky(max_runs=3, min_passes=1)
+@pytest.mark.timeout(120)
 def test_provision_install_pkg_pep517(
     tmp_path_factory: TempPathFactory,
     tox_project: ToxProjectCreator,


### PR DESCRIPTION
The Windows CI job `test 3.12 on windows-2025` fails intermittently on `test_provision_install_pkg_pep517`. Investigation showed the test consistently takes ~32s on Windows due to provisioned subprocess pip installs, which exceeds the global 30s `pytest-timeout`. The "deadlock" stack trace is actually `pytest-timeout` dumping threads before killing the test. 🔍

The fix raises the timeout to 120s for both provision integration tests that spawn real subprocesses. This also re-enables `test_provision_requires_ok` on Windows, which was skipped under the assumption it deadlocked — the actual cause was the same 30s timeout being too tight for these heavier integration tests.

Validated with 20/20 passes on `windows-2025` CI runners.