### PR TITLE
🐛 fix(config): resolve overrides with alias config keys

### DIFF
--- a/docs/changelog/3127.bugfix.rst
+++ b/docs/changelog/3127.bugfix.rst
@@ -1,0 +1,2 @@
+``TOX_OVERRIDE`` with ``+=`` (append) now works correctly when the override key name differs from the config file key
+name (e.g., overriding ``pass_env`` when config uses ``passenv``, or vice versa) - by :user:`gaborbernat`.

--- a/tests/config/test_main.py
+++ b/tests/config/test_main.py
@@ -95,6 +95,25 @@ def test_config_override_appends_to_empty_list(tox_ini_conf: ToxIniCreator) -> N
     assert conf["passenv"] == ["bar"]
 
 
+@pytest.mark.parametrize(
+    ("ini_key", "override_key"),
+    [
+        pytest.param("passenv", "pass_env", id="ini_old_override_new"),
+        pytest.param("pass_env", "passenv", id="ini_new_override_old"),
+    ],
+)
+def test_config_override_append_alias_key(tox_ini_conf: ToxIniCreator, ini_key: str, override_key: str) -> None:
+    example = f"""
+    [testenv]
+    {ini_key} = foo
+    """
+    conf = tox_ini_conf(example, override=[Override(f"testenv.{override_key}+=bar")]).get_env("testenv")
+    conf.add_config(["pass_env", "passenv"], of_type=list[str], default=[], desc="desc")
+    result = conf["pass_env"]
+    assert "foo" in result
+    assert "bar" in result
+
+
 def test_config_override_appends_to_setenv(tox_ini_conf: ToxIniCreator) -> None:
     example = """
     [testenv]


### PR DESCRIPTION
Many tox configuration keys have aliases for backward compatibility (e.g., `pass_env`/`passenv`, `set_env`/`setenv`, `env_list`/`envlist`). When using `TOX_OVERRIDE` with the append operator (`+=`) and the override key name differed from what was used in the config file, tox would silently drop either the config value or the override value. For example, `TOX_OVERRIDE=testenv.pass_env+=BAR` would lose `FOO` if the ini file used `passenv = FOO`, and vice versa. 🐛 This has been a pain point for projects relying on CI-level overrides to extend environment variables.

The root cause was in how config loading iterated over alias keys independently. The loader tried each key name separately with each config source, and would stop on the first key that produced any result — even if that result was only from the override, missing the raw config value stored under the alias. The fix consolidates alias resolution: `Loader.load()` now receives all alias keys upfront, collects overrides from any of them, and tries loading the raw value from all aliases before applying overrides.

Fixes #3127, fixes #3348.