### PR TITLE
🐛 fix(config): set_env cross-section substitution loses values

### DIFF
--- a/docs/changelog/2872.bugfix.rst
+++ b/docs/changelog/2872.bugfix.rst
@@ -1,0 +1,2 @@
+``set_env`` values from cross-section substitution (e.g., ``{[testenv]set_env}``) now correctly override default
+environment variables like ``PYTHONHASHSEED`` - by :user:`gaborbernat`.

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -172,6 +172,7 @@ class SetEnv:
                     sub_raw[key] = value
                     if marker:
                         self._markers[key] = Marker(marker)
+            self._materialized = {k: v for k, v in self._materialized.items() if k not in sub_raw}
             self._raw.update(sub_raw)
             self.changed = True  # loading while iterating can cause these values to be missed
             for key in sub_raw:

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -239,6 +239,20 @@ def test_python_keep_hash_seed(tox_project: ToxProjectCreator) -> None:
     assert result.out.splitlines()[1] == "12"
 
 
+def test_python_hash_seed_via_section_substitution(tox_project: ToxProjectCreator) -> None:
+    ini = """
+    [testenv]
+    package=skip
+    set_env=PYTHONHASHSEED=12
+    [testenv:hs]
+    commands=python -c 'import os; print(os.environ["PYTHONHASHSEED"])'
+    set_env={[testenv]set_env}
+    """
+    result = tox_project({"tox.ini": ini}).run("r", "-e", "hs")
+    result.assert_success()
+    assert result.out.splitlines()[1] == "12"
+
+
 def test_python_disable_hash_seed(tox_project: ToxProjectCreator) -> None:
     ini = "[testenv]\npackage=skip\ncommands=python -c 'import os; print(os.environ.get(\"PYTHONHASHSEED\"))'"
     prj = tox_project({"tox.ini": ini})


### PR DESCRIPTION
When a child environment inherits `set_env` via cross-section substitution (e.g., `set_env = {[testenv]set_env}`), environment variables like `PYTHONHASHSEED` were silently replaced with their auto-generated defaults. This meant explicitly setting `PYTHONHASHSEED=0` in the base environment had no effect in child environments that referenced it — the child would always get a random hash seed. 🐛

The root cause is a timing issue: tox applies default environment variables (including `PYTHONHASHSEED`) during post-processing, before the `{[testenv]...}` substitution is expanded. Since the unexpanded reference is not yet in the raw config dict, the defaults are materialized first. When the substitution later expands and populates the raw dict, the already-materialized default takes precedence during lookup.

The fix ensures that when a deferred substitution is expanded, any previously materialized defaults for the same keys are evicted, allowing the explicitly configured values to take priority as intended.

Fixes #2872.