### PR TITLE
🐛 fix(legacy): --parallel-no-spinner no longer suppresses output

### DIFF
--- a/docs/changelog/3193.bugfix.rst
+++ b/docs/changelog/3193.bugfix.rst
@@ -1,0 +1,2 @@
+``TOX_PARALLEL_NO_SPINNER`` / ``--parallel-no-spinner`` no longer forces parallel mode in the legacy command, fixing
+output suppression for sequential runs in CI - by :user:`gaborbernat`.

--- a/src/tox/session/cmd/legacy.py
+++ b/src/tox/session/cmd/legacy.py
@@ -110,7 +110,7 @@ def legacy(state: State) -> int:
             option.env = CliEnv(["py"])
         option.devenv_path = Path(option.devenv_path)
         return devenv(state)
-    if option.parallel_no_spinner is True or option.parallel != 0:  # only 0 means sequential
+    if option.parallel != 0:  # only 0 means sequential
         return run_parallel(state)
     return run_sequential(state)
 

--- a/src/tox/session/cmd/run/parallel.py
+++ b/src/tox/session/cmd/run/parallel.py
@@ -79,10 +79,7 @@ def parallel_flags(
         action="store_true",
         dest="parallel_no_spinner",
         default=default_spinner,
-        help=(
-            "run tox environments in parallel, but don't show the spinner, implies --parallel. "
-            "Disabled by default if CI is detected (not in legacy API)."
-        ),
+        help="disable the spinner when running in parallel, enabled by default in CI",
     )
 
 

--- a/tests/session/cmd/test_legacy.py
+++ b/tests/session/cmd/test_legacy.py
@@ -136,6 +136,16 @@ def test_legacy_run_sequential_ci(
     assert run_sequential.call_count == 1
 
 
+def test_legacy_no_spinner_does_not_suppress_output(
+    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TOX_PARALLEL_NO_SPINNER", "1")
+    ini = "[testenv]\npackage=skip\ncommands=python -c 'print(\"hello-from-env\")'"
+    result = tox_project({"tox.ini": ini}).run("le", "-e", "py")
+    result.assert_success()
+    assert "hello-from-env" in result.out
+
+
 def test_legacy_help(tox_project: ToxProjectCreator) -> None:
     outcome = tox_project({"tox.ini": ""}).run("le", "-h")
     outcome.assert_success()

--- a/tests/session/cmd/test_parallel.py
+++ b/tests/session/cmd/test_parallel.py
@@ -218,13 +218,23 @@ def test_parallel_no_spinner_ci(
     )
 
 
-def test_parallel_no_spinner_legacy(tox_project: ToxProjectCreator) -> None:
+def test_parallel_no_spinner_legacy_sequential(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+    """--parallel-no-spinner alone should not force parallel mode in legacy command."""
+    mocked = mocker.patch("tox.session.cmd.legacy.run_sequential")
+
+    tox_project({"tox.ini": ""}).run("--parallel-no-spinner")
+
+    mocked.assert_called_once()
+
+
+def test_parallel_no_spinner_legacy_with_parallel(tox_project: ToxProjectCreator) -> None:
+    """--parallel-no-spinner combined with -p should still run parallel without spinner."""
     with mock.patch.object(parallel, "execute") as mocked:
-        tox_project({"tox.ini": ""}).run("--parallel-no-spinner")
+        tox_project({"tox.ini": ""}).run("--parallel-no-spinner", "-p", "all")
 
     mocked.assert_called_once_with(
         mock.ANY,
-        max_workers=auto_detect_cpus(),
+        max_workers=None,
         has_spinner=False,
         live=False,
     )


### PR DESCRIPTION
Since tox 4.12.0, setting `TOX_PARALLEL_NO_SPINNER=1` or passing `--parallel-no-spinner` in the legacy command unconditionally forced parallel execution mode, even when no `-p` flag was given. 🔇 In parallel mode, output is buffered and only shown on failure, so CI environments that set this variable lost all command output from successful runs.

The fix removes `parallel_no_spinner` from the condition that routes between parallel and sequential execution in the legacy command. The flag now only controls spinner display when parallel mode is already active via `-p`. The `--parallel-no-spinner` help text is also corrected to reflect this intended behavior.

⚠️ This is a behavioral change for users who relied on `--parallel-no-spinner` implying `--parallel` in the legacy command. Those users should explicitly pass `-p` alongside `--parallel-no-spinner` to get parallel execution.

Fixes #3193