### PR TITLE
🐛 fix(config): set_env cross-section substitution precedence

### DIFF
--- a/docs/changelog/2831.bugfix.rst
+++ b/docs/changelog/2831.bugfix.rst
@@ -1,0 +1,2 @@
+``set_env`` values explicitly defined in a section now take precedence over values inherited via cross-section
+substitution (e.g., ``{[testenv]set_env}``) - by :user:`gaborbernat`.

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -169,7 +169,8 @@ class SetEnv:
                             sub_raw[key] = value  # noqa: PERF403
                 else:
                     key, value, marker = self._extract_key_value_marker(sub_line)
-                    sub_raw[key] = value
+                    if key not in self._raw:
+                        sub_raw[key] = value
                     if marker:
                         self._markers[key] = Marker(marker)
             self._materialized = {k: v for k, v in self._materialized.items() if k not in sub_raw}


### PR DESCRIPTION
When a `set_env` section both inherits values via cross-section substitution (e.g., `{[testenv]set_env}`) and explicitly defines the same variable, the inherited value incorrectly overwrites the explicit one. 🔄 This means configurations like the common pattern of overriding a single variable from a base environment silently fail — the base value always wins.

```ini
[testenv]
set_env = OS_TEST_PATH=./tests/unit

[testenv:functional]
set_env =
    {[testenv]set_env}
    OS_TEST_PATH=./tests/functional  # this was silently ignored
```

The fix ensures that explicitly defined values in a section take precedence over values arriving from cross-section substitution expansion. This matches the intuitive "last definition wins" principle and restores the behavior users expect when layering environment configurations.

⚠️ Users who previously relied on cross-section substitution values overriding explicit values in the same section will see changed behavior. This was almost certainly unintentional in all cases, since placing a value after a substitution reference naturally implies it should override.

Fixes #2831