### PR TITLE
🐛 fix(config): set_env file| no longer overrides later values

### DIFF
--- a/docs/changelog/3335.bugfix.rst
+++ b/docs/changelog/3335.bugfix.rst
@@ -1,0 +1,2 @@
+``set_env`` values defined after a ``file|`` reference now correctly take precedence over values loaded from the env
+file - by :user:`gaborbernat`.

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -23,7 +23,7 @@ class SetEnv:
         self._raw: dict[str, str] = {}  # could still need replacement
         self._markers: dict[str, Marker] = {}  # PEP-496 markers for conditional env vars
         self._needs_replacement: list[str] = []  # env vars that need replacement
-        self._env_files: list[str] = []
+        self._env_files: list[tuple[str, set[str]]] = []
         self._replacer: Replacer = lambda s, c: s  # noqa: ARG005
         self._name, self._env_name, self._root = name, env_name, root
         from .loader.replacer import MatchExpression, find_replace_expr  # noqa: PLC0415
@@ -35,10 +35,11 @@ class SetEnv:
             merged = reduce(lambda a, b: {**a, **b}, raw)
             self._parse_dict(merged)
             return
+        keys_after_file: set[str] = set()
         for line in raw.splitlines():  # noqa: PLR1702
             if line.strip():
                 if self._is_file_line(line):
-                    self._env_files.append(self._parse_file_line(line))
+                    self._env_files.append((self._parse_file_line(line), keys_after_file := set()))
                 else:
                     try:
                         key, value, marker = self._extract_key_value_marker(line)
@@ -54,20 +55,24 @@ class SetEnv:
                             raise
                     else:
                         self._raw[key] = value
+                        keys_after_file.add(key)
                         if marker:
                             self._markers[key] = Marker(marker)
 
     def _parse_dict(self, raw: dict[str, Any]) -> None:
+        keys_after_file: set[str] = set()
         for key, value in raw.items():
             if key == "file":
-                self._env_files.append(value)
+                self._env_files.append((value, keys_after_file := set()))
             elif isinstance(value, dict):
                 if "value" in value:
                     self._raw[key] = value["value"]
+                    keys_after_file.add(key)
                     if marker := value.get("marker"):
                         self._markers[key] = Marker(marker)
             else:
                 self._raw[key] = value
+                keys_after_file.add(key)
 
     @staticmethod
     def _is_file_line(line: str) -> bool:
@@ -84,8 +89,10 @@ class SetEnv:
 
     def use_replacer(self, value: Replacer, args: ConfigLoadArgs) -> None:
         self._replacer = value
-        for filename in self._env_files:
-            self._raw.update(self._stream_env_file(filename, args))
+        for filename, keys_after in self._env_files:
+            for key, val in self._stream_env_file(filename, args):
+                if key not in keys_after:
+                    self._raw[key] = val
 
     def _stream_env_file(self, filename: str, args: ConfigLoadArgs) -> Iterator[tuple[str, str]]:
         # Our rules in the documentation, some upstream environment file rules (we follow mostly the docker one):


### PR DESCRIPTION
When `set_env` mixes `file|` references with inline variable definitions, values from the env file always took precedence regardless of ordering. This broke the intuitive "last definition wins" rule that works correctly for purely inline definitions.

```ini
[testenv]
set_env =
    file|.env       # .env contains FOO=BAR
    FOO=QUX         # expected QUX, got BAR
```

🔧 The fix tracks which keys are defined after each `file|` reference during parsing, then skips those keys when loading the env file. Variables only defined in the file still come through normally, while explicit inline overrides now take precedence as expected.

⚠️ Users who relied on env file values silently overriding later inline definitions will see changed behavior. The new behavior matches the principle of least surprise — definitions appearing later in the config win.

Fixes #3335