### PR TITLE
🐛 fix(config): setup.cfg without [tox:tox] no longer blocks discovery

### DIFF
--- a/docs/changelog/3602.bugfix.rst
+++ b/docs/changelog/3602.bugfix.rst
@@ -1,0 +1,2 @@
+A ``setup.cfg`` without a ``[tox:tox]`` section no longer blocks discovery of ``pyproject.toml`` or ``tox.toml``
+configuration files in the same directory - by :user:`gaborbernat`.

--- a/src/tox/config/source/setup_cfg.py
+++ b/src/tox/config/source/setup_cfg.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tox.config.types import MissingRequiredConfigKeyError
+
 from .ini import IniSource
 from .ini_section import IniSection
 
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class SetupCfg(IniSource):
-    """Configuration sourced from a tox.ini file."""
+    """Configuration sourced from a setup.cfg file."""
 
     CORE_SECTION = IniSection("tox", "tox")
     FILENAME = "setup.cfg"
@@ -18,8 +20,7 @@ class SetupCfg(IniSource):
     def __init__(self, path: Path) -> None:
         super().__init__(path)
         if not self._parser.has_section(self.CORE_SECTION.key):
-            msg = f"section {self.CORE_SECTION.key} not found"
-            raise ValueError(msg)
+            raise MissingRequiredConfigKeyError(path)
 
 
 __all__ = ("SetupCfg",)


### PR DESCRIPTION
Projects that have a `setup.cfg` for packaging metadata (without any tox configuration) alongside a `pyproject.toml` or `tox.toml` for tox configuration were broken — tox failed to discover the actual config file and fell back to an empty default. This regression was introduced in #3578, which distinguished between "file lacks tox config" (`MissingRequiredConfigKeyError`) and "file is invalid" (`ValueError`) during source discovery.

🔧 The `SetupCfg` source was still raising `ValueError` when `[tox:tox]` was missing, which the discovery chain treated as a hard failure instead of skipping to the next candidate. The fix aligns `SetupCfg` with the other TOML-based sources by raising `MissingRequiredConfigKeyError`, letting discovery proceed to `pyproject.toml` or `tox.toml` in the same directory.

Fixes #3602, fixes #3645