### PR TITLE
🐛 fix(env): posargs with colon no longer crash inactive envs

### DIFF
--- a/docs/changelog/2860.bugfix.rst
+++ b/docs/changelog/2860.bugfix.rst
@@ -1,0 +1,2 @@
+Posargs containing colons no longer crash tox when an inactive environment uses ``{posargs}`` in path-like configuration
+values such as ``env_dir`` - by :user:`gaborbernat`.

--- a/tests/tox_env/python/virtual_env/test_virtualenv_api.py
+++ b/tests/tox_env/python/virtual_env/test_virtualenv_api.py
@@ -174,6 +174,26 @@ def test_list_dependencies_command(tox_project: ToxProjectCreator) -> None:
     assert request.cmd == ["python", "-m", "pip", "freeze"]
 
 
+def test_posargs_colon_in_inactive_env_does_not_crash(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.toml": """
+            env_list = ["hello"]
+
+            [env.hello]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+
+            [env.dev]
+            env_dir = "{posargs:venv}"
+            package = "editable"
+            commands = [["python", "-c", "print('dev')"]]
+        """,
+    })
+    outcome = project.run("r", "-e", "hello", "--", "x:y")
+    outcome.assert_success()
+    assert "ok" in outcome.out
+
+
 def test_pip_user_disabled(tox_project: ToxProjectCreator) -> None:
     proj = tox_project(
         {


### PR DESCRIPTION
When running tox with posargs containing colons (e.g. `tox -e hello -- x:y`), tox crashes if any *inactive* environment uses `{posargs}` in path-like configuration such as `env_dir`. This happens because tox eagerly evaluates all environments during discovery — even ones not being run — and virtualenv's argument parser rejects paths containing `:` with a `SystemExit`. 💥 The crash prevents users from passing pytest node IDs or other colon-containing arguments when such environments exist.

The fix catches `SystemExit` from `session_via_cli` in the `VirtualEnv.session` property and converts it to a `RuntimeError`, which is already handled by `_get_python` (returning `None` to signal the interpreter couldn't be resolved). This lets the inactive environment be gracefully skipped while the active environment runs normally. The virtualenv stderr output is also suppressed to avoid confusing error messages for environments that aren't being used.

Fixes #2860