### PR TITLE
🐛 fix(provision): skip requires with false environment markers

### DIFF
--- a/docs/changelog/3136.bugfix.rst
+++ b/docs/changelog/3136.bugfix.rst
@@ -1,0 +1,3 @@
+Requirements in ``requires`` with environment markers that evaluate to false (e.g. ``virtualenv<20.22.0; python_version
+< "3.8"``) are now correctly skipped during provisioning instead of causing an infinite provisioning loop - by
+:user:`gaborbernat`.

--- a/src/tox/provision.py
+++ b/src/tox/provision.py
@@ -129,6 +129,8 @@ def provision(state: State) -> int | bool:
 def _get_missing(requires: list[Requirement]) -> list[tuple[Requirement, str | None]]:
     missing: list[tuple[Requirement, str | None]] = []
     for package in requires:
+        if package.marker and not package.marker.evaluate():
+            continue
         package_name = canonicalize_name(package.name)
         try:
             dist = distribution(package_name)

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -149,6 +149,34 @@ def test_provision_requires_nok(tox_project: ToxProjectCreator) -> None:
     )
 
 
+def test_provision_requires_skips_false_markers(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.toml": """
+            requires = ['pkg-does-not-exist; python_version < "2.0"']
+
+            [env_run_base]
+            package = "skip"
+        """,
+    })
+    outcome = project.run("c", "-e", "py")
+    outcome.assert_success()
+    assert "provisioned" not in outcome.out
+
+
+def test_provision_requires_checks_true_markers(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.toml": """
+            requires = ['pkg-does-not-exist; python_version >= "3.0"']
+
+            [env_run_base]
+            package = "skip"
+        """,
+    })
+    outcome = project.run("c", "-e", "py")
+    outcome.assert_failed()
+    assert "pkg-does-not-exist" in outcome.out
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures("_pypi_index_self")
 @pytest.mark.timeout(120)


### PR DESCRIPTION
When a requirement in `requires` includes a PEP 508 environment marker that evaluates to false for the current interpreter (e.g. `virtualenv<20.22.0; python_version < "3.8"` on Python 3.14), tox enters an infinite provisioning loop. 🔄 It repeatedly detects the requirement as "missing" because the installed version doesn't match the specifier, provisions a new environment, and starts over — never recognizing that the requirement simply doesn't apply.

The fix evaluates environment markers before checking whether a requirement is satisfied. Requirements whose markers evaluate to false are skipped entirely, matching the behavior users expect from standard PEP 508 semantics. This is the same evaluation that pip and other tools perform when processing dependency specifications.

Fixes #3136