### PR TITLE
🐛 fix(config): set_env substitution honors skip_missing_interpreters

### DIFF
--- a/docs/changelog/3597.bugfix.rst
+++ b/docs/changelog/3597.bugfix.rst
@@ -1,0 +1,3 @@
+``set_env`` substitution referencing ``{envsitepackagesdir}``, ``{envbindir}``, or ``{envpython}`` for environments with
+missing interpreters now raises ``Skip`` instead of ``RuntimeError``, allowing ``skip_missing_interpreters`` to work
+correctly - by :user:`gaborbernat`.

--- a/src/tox/config/loader/ini/__init__.py
+++ b/src/tox/config/loader/ini/__init__.py
@@ -11,6 +11,7 @@ from tox.config.loader.replacer import replace
 from tox.config.loader.str_convert import StrConvert
 from tox.config.set_env import SetEnv
 from tox.report import HandledError
+from tox.tox_env.errors import Skip
 
 if TYPE_CHECKING:
     from configparser import ConfigParser, SectionProxy
@@ -77,7 +78,7 @@ class IniLoader(StrConvert, Loader[str]):
                 try:
                     replaced = replace(conf, reference_replacer, raw_, args_)  # do replacements
                 except Exception as exception:
-                    if isinstance(exception, HandledError):
+                    if isinstance(exception, (HandledError, Skip)):
                         raise
                     name = self.core_section.key if args_.env_name is None else args_.env_name
                     msg = f"replace failed in {name}.{key} with {exception!r}"

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -17,6 +17,7 @@ from virtualenv.discovery.py_spec import PythonSpec
 
 from tox.config.loader.str_convert import StrConvert
 from tox.execute.local_sub_process import LocalSubProcessExecutor
+from tox.tox_env.errors import Skip
 from tox.tox_env.python.api import Python, PythonInfo, VersionInfo
 from tox.tox_env.python.pip.pip_install import Pip
 
@@ -167,13 +168,19 @@ class VirtualEnv(Python, ABC):
         return list(dict.fromkeys((creator.bin_dir, creator.script_dir)))
 
     def env_site_package_dir(self) -> Path:
-        return cast("Path", cast("Describe", self.creator).purelib)
+        return cast("Path", cast("Describe", self._creator_with_skip()).purelib)
 
     def env_python(self) -> Path:
-        return cast("Path", cast("Describe", self.creator).exe)
+        return cast("Path", cast("Describe", self._creator_with_skip()).exe)
 
     def env_bin_dir(self) -> Path:
-        return cast("Path", cast("Describe", self.creator).script_dir)
+        return cast("Path", cast("Describe", self._creator_with_skip()).script_dir)
+
+    def _creator_with_skip(self) -> Creator:
+        try:
+            return self.creator
+        except RuntimeError as exc:
+            raise Skip(str(exc)) from exc
 
     @property
     def runs_on_platform(self) -> str:

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -100,7 +100,7 @@ def test_show_config_exception(tox_project: ToxProjectCreator) -> None:
     outcome.assert_failed(code=-1)
     txt = (
         "\nenv_site_packages_dir = # Exception: "
-        "RuntimeError(\"failed to find interpreter for Builtin discover of python_spec='missing-python'"
+        "Skip(\"failed to find interpreter for Builtin discover of python_spec='missing-python'"
     )
     assert txt in outcome.out
 


### PR DESCRIPTION
When `set_env` contains substitution variables like `{envsitepackagesdir}`, `{envbindir}`, or `{envpython}` — either directly or via cross-section references like `{[testenv]set_env}` — and the target environment has a missing interpreter, tox crashes with a `HandledError` instead of gracefully skipping the environment. 🐛 This defeats the purpose of `skip_missing_interpreters = true`, forcing users to remove useful substitutions from their config as a workaround.

The fix converts the `RuntimeError` from failed virtualenv session creation into a `Skip` exception at the source — in the `env_site_package_dir`, `env_python`, and `env_bin_dir` accessors. The INI loader's replacer is also updated to let `Skip` propagate without wrapping it as `HandledError`. This ensures the standard `skip_missing_interpreters` machinery catches the exception and skips the environment cleanly, regardless of whether the missing interpreter is encountered during `set_env` expansion or elsewhere.

⚠️ The exception type surfaced in `tox config` output for missing-interpreter environments changes from `RuntimeError` to `Skip`, which is semantically more accurate. No behavioral change for `tox run` — environments are skipped the same way.

Fixes #3597