### PR TITLE
🐛 fix(config): break changedir/posargs circular dependency

### DIFF
--- a/docs/changelog/3062.bugfix.rst
+++ b/docs/changelog/3062.bugfix.rst
@@ -1,0 +1,1 @@
+Using ``{posargs}`` in ``change_dir`` no longer causes a ``RecursionError`` - by :user:`gaborbernat`.

--- a/src/tox/config/loader/replacer.py
+++ b/src/tox/config/loader/replacer.py
@@ -245,11 +245,15 @@ def load_posargs(conf: Config, conf_args: ConfigLoadArgs) -> tuple[str, ...] | N
     if conf_args.env_name is not None:  # pragma: no branch
         env_conf = conf.get_env(conf_args.env_name)
         try:
-            if env_conf["args_are_paths"]:  # pragma: no branch
+            if env_conf["args_are_paths"] and not _loading_change_dir(conf_args):  # pragma: no branch
                 to_path = env_conf["change_dir"]
         except KeyError:
             pass
     return conf.pos_args(to_path)
+
+
+def _loading_change_dir(conf_args: ConfigLoadArgs) -> bool:
+    return any(entry.endswith(".change_dir") for entry in conf_args.chain)
 
 
 def replace_env(conf: Config | None, args: list[str], conf_args: ConfigLoadArgs) -> str:

--- a/tests/tox_env/test_tox_env_api.py
+++ b/tests/tox_env/test_tox_env_api.py
@@ -161,6 +161,20 @@ def test_disallow_pass_env_empty(tox_project: ToxProjectCreator) -> None:
     assert "bar" in result.out
 
 
+def test_change_dir_posargs_no_recursion(tox_project: ToxProjectCreator) -> None:
+    toml = """\
+[env.foo]
+package = "skip"
+change_dir = "{posargs}"
+commands = [["python", "--version"]]
+"""
+    prj = tox_project({"tox.toml": toml})
+    (prj.path / "subdir").mkdir()
+    result = prj.run("r", "-e", "foo", "--", "subdir")
+    result.assert_success()
+    assert f"foo: commands[0] {prj.path / 'subdir'}>" in result.out
+
+
 def test_change_dir_is_created_if_not_exist(tox_project: ToxProjectCreator) -> None:
     prj = tox_project({"tox.ini": "[testenv]\npackage=skip\nchange_dir=a{/}b\ncommands=python --version"})
     result_first = prj.run("r")


### PR DESCRIPTION
Setting `change_dir = {posargs}` (or the INI equivalent `changedir = {posargs}`) causes a `RecursionError` because resolving `{posargs}` requires loading `change_dir` for path rewriting when `args_are_paths` is enabled (the default). 🐛 This creates an infinite loop: `change_dir` needs `{posargs}`, which needs `change_dir`, which needs `{posargs}`, and so on.

The fix detects when `change_dir` is already being loaded by inspecting the config load chain. In that case, the path rewriting step for posargs is skipped, breaking the cycle. The posargs value is still returned correctly — just without relative path adjustment, which is the right behavior since the directory itself hasn't been determined yet.

Fixes #3062.