### PR TITLE
🐛 fix(env): reject partial testenv section matches

### DIFF
--- a/docs/changelog/3219.bugfix.rst
+++ b/docs/changelog/3219.bugfix.rst
@@ -1,0 +1,3 @@
+Environments like ``functional-py312`` no longer incorrectly match when only ``functional{-py310}`` is defined as a
+testenv section -- factors from section headers are no longer treated as freely combinable with CLI ``-e`` selections -
+by :user:`gaborbernat`.

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -211,11 +211,17 @@ class EnvSelector:
             yield label_envs.keys(), False
 
     def _ensure_envs_valid(self) -> None:
-        valid_factors = set(chain.from_iterable(env.split("-") for env in self._state.conf))
-        valid_factors.add(".pkg")  # packaging factor
+        known_envs = set(self._state.conf)
+        # factors that can be freely combined: from env_list entries and known env names themselves
+        combinable = set(chain.from_iterable(env.split("-") for env in self._state.conf.core["env_list"]))
+        combinable.update(known_envs)
+        combinable.add(".pkg")
+        # broader pool for suggestions includes factors from all known env names
+        all_factors = set(chain.from_iterable(env.split("-") for env in known_envs))
+        all_factors.update(combinable)
         invalid_envs: dict[str, str | None] = {}
         for env in self._cli_envs or []:
-            if env.startswith(".pkg_external"):  # external package
+            if env.startswith(".pkg_external") or env in known_envs:
                 continue
             factors: dict[str, str | None] = dict.fromkeys(env.split("-"))
             found_factors: set[str] = set()
@@ -223,12 +229,13 @@ class EnvSelector:
                 if (
                     _DYNAMIC_ENV_FACTORS.fullmatch(factor)
                     or _PY_PRE_RELEASE_FACTOR.fullmatch(factor)
-                    or factor in valid_factors
+                    or factor in combinable
                 ):
                     found_factors.add(factor)
                 else:
-                    closest = get_close_matches(factor, valid_factors, n=1)
-                    factors[factor] = closest[0] if closest else None
+                    closest = get_close_matches(factor, all_factors, n=1)
+                    suggestion = closest[0] if closest else None
+                    factors[factor] = None if suggestion == factor else suggestion
             if set(factors) - found_factors:
                 invalid_envs[env] = (
                     None

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -324,6 +324,15 @@ def test_dynamic_env_factors_not_match(env: str) -> None:
     assert not _DYNAMIC_ENV_FACTORS.fullmatch(env)
 
 
+@pytest.mark.parametrize("env_name", ["functional-py312", "functional"])
+def test_partial_section_match_rejected(env_name: str, tox_project: ToxProjectCreator) -> None:
+    tox_ini = "[testenv]\nskip_install = true\ncommands=python -c 'print(1)'\n[testenv:functional{-py310}]\n"
+    proj = tox_project({"tox.ini": tox_ini})
+    outcome = proj.run("r", "-e", env_name)
+    outcome.assert_failed(code=-2)
+    assert "provided environments not found in configuration file" in outcome.out
+
+
 def test_suggest_env(tox_project: ToxProjectCreator) -> None:
     tox_ini = f"[testenv:release]\n[testenv:py3{_MINOR}]\n[testenv:alpha-py3{_MINOR}]\n"
     proj = tox_project({"tox.ini": tox_ini})


### PR DESCRIPTION
When a testenv section uses generative syntax like `[testenv:functional{-py310}]`, only `functional-py310` should be a valid environment. However, running `tox -e functional-py312` or `tox -e functional` silently passed validation and fell back to the base `[testenv]`, producing unexpected results. 🔍 This was a regression from tox 3, where these would correctly error as unknown environments.

The root cause was that `_ensure_envs_valid` decomposed *all* known env names — including those from section headers — into individual factors, then treated them as freely combinable. So `functional` (from `functional-py310`) became a valid factor that could be mixed with any Python version factor. The fix distinguishes between factors that are genuinely combinable (from `env_list` generative expressions and conditional markers) and complete env names from section headers. Section names are recognized as whole identifiers but their component parts can no longer be arbitrarily recombined via `-e`.

⚠️ This is a behavioral change: users who relied on partial section name matching to silently fall back to `[testenv]` will now get a clear error message pointing them to the correct environment name. Matrix-style `env_list` combinations like `py312-django50` continue to work as expected.

Fixes #3219