### PR TITLE
🐛 fix(config): support base inherit in TOML format

### DIFF
--- a/docs/changelog/3497.bugfix.rst
+++ b/docs/changelog/3497.bugfix.rst
@@ -1,0 +1,2 @@
+The ``base`` configuration key now works correctly in TOML format (``tox.toml`` and ``pyproject.toml``), allowing
+environments to inherit from arbitrary sections defined under ``[env.*]`` - by :user:`gaborbernat`.

--- a/src/tox/config/source/toml_pyproject.py
+++ b/src/tox/config/source/toml_pyproject.py
@@ -127,11 +127,13 @@ class TomlPyProject(Source):
                 raise HandledError(msg)
             yield self._Section.test_env(env_name)
 
-    def get_base_sections(self, base: list[str], in_section: Section) -> Iterator[Section]:  # noqa: ARG002
+    def get_base_sections(self, base: list[str], in_section: Section) -> Iterator[Section]:
         core_prefix = self._Section.core_prefix()
         strip = f"{core_prefix}{self._Section.SEP}" if core_prefix else ""
         for entry in base:
             yield self._Section(prefix=core_prefix or None, name=entry.removeprefix(strip))
+            if in_section.prefix is not None:
+                yield self._Section(prefix=in_section.prefix, name=entry)
 
     def get_tox_env_section(self, item: str) -> tuple[Section, list[str], list[str]]:
         return self._Section.test_env(item), [self._Section.run_env_base()], [self._Section.package_env_base()]

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -449,3 +449,26 @@ def test_config_env_pkg_base_deps_reference_with_additional_deps(tox_project: To
     outcome.assert_success()
     out = "[testenv:pkg]\ndeps =\n  build\n  wheel\n  setuptools>=40\n"
     outcome.assert_out_err(out, "")
+
+
+def test_config_env_base_inherit_from_arbitrary_section(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "pyproject.toml": """
+        [tool.tox]
+        env_list = ["a", "b"]
+
+        [tool.tox.env.shared]
+        description = "shared config"
+        skip_install = true
+
+        [tool.tox.env.a]
+        base = ["shared"]
+
+        [tool.tox.env.b]
+        base = ["shared"]
+        """
+    })
+    outcome = project.run("c", "-e", "a,b", "-k", "description")
+    outcome.assert_success()
+    out = "[testenv:a]\ndescription = shared config\n\n[testenv:b]\ndescription = shared config\n"
+    outcome.assert_out_err(out, "")


### PR DESCRIPTION
The `base` configuration key allows environments to inherit settings from arbitrary sections, which is useful for sharing configuration across multiple environments without repeating it. This worked correctly in INI format (e.g. `base = py_base` in `[testenv:py3.11]` resolving `[testenv:py_base]`) but silently failed in TOML format — `base = ["shared"]` in `[env.a]` would not find `[env.shared]`. 🔍

The INI source already handled this by looking up base entries at both the explicit level and within the current section's prefix (e.g. `testenv`). The TOML source was missing this second lookup, only searching at the top level where environment sections don't live. The fix aligns TOML with INI by also yielding a section scoped to the current prefix, so `base = ["shared"]` correctly resolves against `[env.shared]` in both `tox.toml` and `pyproject.toml`.

This is a pure bugfix — existing configurations that don't use `base` in TOML are unaffected. Users who previously worked around this limitation by duplicating configuration across TOML environment sections can now use `base` as intended.

Fixes #3497