### PR TITLE
🐛 fix(cli): make multiple -e flags additive

### DIFF
--- a/docs/changelog/3199.bugfix.rst
+++ b/docs/changelog/3199.bugfix.rst
@@ -1,0 +1,2 @@
+Multiple ``-e`` flags are now additive (``tox r -e a -e b`` runs both ``a`` and ``b``), matching tox 3 behavior - by
+:user:`gaborbernat`.


### PR DESCRIPTION
In tox 3, running `tox -e a -e b` would execute both environments. In tox 4 the second `-e` silently replaced the first, so only `b` would run. 🔍 This broke CI pipelines and scripts that relied on the additive behavior, with no error or warning to indicate environments were being dropped.

The fix uses a custom argparse action that accumulates values from repeated `-e` flags into a single `CliEnv` instance instead of replacing it. This restores tox 3 behavior while preserving full backward compatibility — `tox -e a,b` (comma-separated) continues to work exactly as before.

⚠️ Users who were relying on later `-e` flags to override earlier ones will now get the union of all specified environments. The comma-separated form `tox -e a,b` remains the canonical way to specify multiple environments in a single flag.

Fixes #3199