### PR TITLE
🐛 fix(provision): serialize concurrent provisioning

### DIFF
--- a/docs/changelog/2515.bugfix.rst
+++ b/docs/changelog/2515.bugfix.rst
@@ -1,0 +1,2 @@
+Concurrent tox processes no longer corrupt the provision environment (``.tox``) -- a file lock now serializes
+provisioning across processes - by :user:`gaborbernat`.

--- a/src/tox/provision.py
+++ b/src/tox/provision.py
@@ -10,6 +10,7 @@ from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from filelock import FileLock
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import Version
@@ -146,16 +147,19 @@ def run_provision(name: str, state: State) -> int:
     tox_env: PythonRun = cast("PythonRun", state.envs[name])
     env_python = tox_env.env_python()
     logging.info("will run in a automatically provisioned python environment under %s", env_python)
-    try:
-        tox_env.setup()
-        args: list[str] = [str(env_python), "-m", "tox"]
-        args.extend(state.args)
-        outcome = tox_env.execute(
-            cmd=args, stdin=StdinSource.user_only(), show=True, run_id="provision", cwd=Path.cwd()
-        )
-        return cast("int", outcome.exit_code)
-    except Skip as exception:
-        msg = f"cannot provision tox environment {tox_env.conf['env_name']} because {exception}"
-        raise HandledError(msg) from exception
-    finally:
-        tox_env.teardown()
+    lock_path = tox_env.env_dir / "file.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(lock_path):
+        try:
+            tox_env.setup()
+            args: list[str] = [str(env_python), "-m", "tox"]
+            args.extend(state.args)
+            outcome = tox_env.execute(
+                cmd=args, stdin=StdinSource.user_only(), show=True, run_id="provision", cwd=Path.cwd()
+            )
+            return cast("int", outcome.exit_code)
+        except Skip as exception:
+            msg = f"cannot provision tox environment {tox_env.conf['env_name']} because {exception}"
+            raise HandledError(msg) from exception
+        finally:
+            tox_env.teardown()


### PR DESCRIPTION
When multiple tox processes run concurrently and provisioning is required (via `requires`), they all attempt to create and populate the same `.tox/.tox` provision environment without any coordination. 🔒 One process can delete or overwrite virtualenv files while another is actively importing from them, causing `ModuleNotFoundError` crashes like missing `pip._vendor` modules.

The provision environment is a `RunToxEnv`, which unlike `PackageToxEnv` has no file-based locking. Rather than adding locking to all `RunToxEnv` instances, wrapping just the `run_provision` lifecycle with a `FileLock` on `{env_dir}/file.lock` follows the existing pattern already used by packaging environments. The lock covers setup through execution so a second process waits until the first finishes before attempting its own provisioned run.

This uses the same `file.lock` convention that `_clean()` already preserves via `ensure_empty_dir(env_dir, except_filename="file.lock")`, so the lock file survives environment recreation.

Fixes #2515