### PR TITLE
🐛 fix(config): defer TOML set_env string substitution

### DIFF
--- a/docs/changelog/3758.bugfix.rst
+++ b/docs/changelog/3758.bugfix.rst
@@ -1,0 +1,3 @@
+Fix ``RecursionError`` when TOML ``set_env`` contains substitutions like ``{env_site_packages_dir}`` that trigger config
+loading cycles -- the TOML loader now defers string substitution in ``set_env`` values, matching the INI loader's lazy
+resolution behavior - by :user:`gaborbernat`.

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -419,6 +419,20 @@ def test_config_set_env_ref(tox_project: ToxProjectCreator) -> None:
     outcome.assert_out_err(out, "")
 
 
+def test_config_set_env_substitution_deferred(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.toml": """
+        [env_run_base]
+        package = "skip"
+        set_env.COVERAGE_SRC = "{env_site_packages_dir}{/}mypackage"
+        """
+    })
+    outcome = project.run("c", "-e", "py", "-k", "set_env")
+    outcome.assert_success()
+    assert "COVERAGE_SRC=" in outcome.out
+    assert "mypackage" in outcome.out
+
+
 def test_config_env_run_base_deps_reference_with_additional_deps(tox_project: ToxProjectCreator) -> None:
     project = tox_project({
         "pyproject.toml": """


### PR DESCRIPTION
Using substitutions like `{env_site_packages_dir}` inside `set_env` in TOML format causes a `RecursionError` because the TOML loader eagerly resolves all string substitutions via `Unroll` before constructing `SetEnv`. This creates a circular dependency: `set_env` → `env_site_packages_dir` → `create_python_env()` → `system_site_packages` → `environment_variables` → `set_env`.

The INI loader already handles this correctly by detecting `SetEnv` type and deferring string substitution — raw strings are stored as-is and only resolved when individual env vars are accessed via `SetEnv.load()`. 🔧 This applies the same pattern to the TOML loader: structural TOML constructs (`replace: ref`, `replace: posargs`, `replace: env`) are still resolved during config loading, but string-level `{...}` substitutions are deferred via a proper TOML-aware replacer passed to `SetEnv.use_replacer()`.

Discovered via pypa/virtualenv#3050 when migrating virtualenv's config from `tox.ini` to `tox.toml`. The same configuration that worked in INI format caused infinite recursion in TOML because of the eager substitution.

Closes #3758