### PR TITLE
🐛 fix(config): handle cross-drive posargs on Windows

### DIFF
--- a/docs/changelog/3086.bugfix.rst
+++ b/docs/changelog/3086.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``ValueError`` crash when using posargs on Windows with ``subst`` drive mappings -- ``os.path.relpath`` fails across
+drive letters, so fall back to absolute paths when the relative path cannot be computed - by :user:`gaborbernat`.

--- a/src/tox/config/main.py
+++ b/src/tox/config/main.py
@@ -65,9 +65,12 @@ class Config:
                 if path_arg.exists() and not path_arg.is_absolute():
                     # we use os.path to unroll .. in path without resolve
                     path_arg_str = os.path.abspath(str(path_arg))  # noqa: PTH100
-                    # we use os.path to not fail when not within
-                    relative = os.path.relpath(path_arg_str, to_path_str)
-                    args.append(relative)
+                    try:
+                        relative = os.path.relpath(path_arg_str, to_path_str)
+                    except ValueError:  # on Windows, relpath fails across drives (e.g. subst mounts)
+                        args.append(path_arg_str)
+                    else:
+                        args.append(relative)
                 else:
                     args.append(arg)
             return tuple(args)


### PR DESCRIPTION
On Windows, when tox is run from a `subst` drive (e.g. `O:` mapped to `C:\_work\py`), posargs resolution crashes with a `ValueError`. This happens because `Path.resolve()` resolves the subst letter back to the real drive, creating a mismatch: the current working directory is on `O:` but `change_dir` resolves to `C:`. When `os.path.relpath` is called to rewrite relative posargs paths, it raises `ValueError` because it cannot compute a relative path across different Windows drive mounts.

The fix catches the `ValueError` from `os.path.relpath` and falls back to using the absolute path for that argument instead of crashing. This is the correct behavior since a relative path genuinely cannot be expressed across drive boundaries — the absolute path preserves the user's intent without error.

Fixes #3086