### PR TITLE
🐛 fix(config): skip non-tox sections in env discovery

### DIFF
--- a/docs/changelog/3134.bugfix.rst
+++ b/docs/changelog/3134.bugfix.rst
@@ -1,0 +1,2 @@
+Fix spurious environment discovery from non-tox sections in ``setup.cfg`` -- ``packages = find:`` in ``[options]`` was
+incorrectly interpreted as a tox factor marker, creating a phantom ``find`` environment - by :user:`gaborbernat`.

--- a/src/tox/config/source/ini.py
+++ b/src/tox/config/source/ini.py
@@ -100,7 +100,15 @@ class IniSource(Source):
                     yield name
         # add all conditional markers that are not part of the explicitly defined sections
         for section in self.sections():
-            yield from self._discover_from_section(section, known_factors)
+            if self._is_tox_section(section):
+                yield from self._discover_from_section(section, known_factors)
+
+    def _is_tox_section(self, section: IniSection) -> bool:
+        if section.is_test_env or section == self.CORE_SECTION:
+            return True
+        if section.prefix != self.CORE_SECTION.prefix:
+            return False
+        return section.name == TEST_ENV_PREFIX or section.name.startswith(f"{TEST_ENV_PREFIX}{Section.SEP}")
 
     def _discover_from_section(self, section: IniSection, known_factors: set[str]) -> Iterator[str]:
         for value in self._parser[section.key].values():

--- a/tests/config/source/test_setup_cfg.py
+++ b/tests/config/source/test_setup_cfg.py
@@ -22,6 +22,14 @@ def test_setup_cfg_without_tox_section(tox_project: ToxProjectCreator) -> None:
     assert outcome.out == f"ROOT: HandledError| could not recognize config file {filename}\n"
 
 
+def test_setup_cfg_non_tox_section_not_discovered_as_env(tox_project: ToxProjectCreator) -> None:
+    cfg = "[tox:tox]\nenv_list = py\n[tox:testenv]\npackage = skip\n[options]\npackages = find:\n"
+    project = tox_project({"setup.cfg": cfg})
+    outcome = project.run("l")
+    outcome.assert_success()
+    assert "find" not in outcome.out
+
+
 def test_setup_cfg_does_not_block_pyproject_toml(tox_project: ToxProjectCreator) -> None:
     project = tox_project({
         "setup.cfg": "[metadata]\nname = test-pkg\n",


### PR DESCRIPTION
When tox reads configuration from `setup.cfg`, it scans all section values for factor-conditional markers (colon-separated syntax like `py38: dep`) to discover environments. This scanning was applied to every section in the file, including non-tox sections like `[options]`. The common setuptools pattern `packages = find:` was misinterpreted as a factor marker, creating a phantom `find` environment that appeared in `tox list` output.

The fix restricts factor-based environment discovery to tox-related sections only. For `setup.cfg`, tox sections use the `tox:` prefix (e.g., `[tox:tox]`, `[tox:testenv]`), so non-tox sections like `[options]` and `[metadata]` are now correctly skipped. For `tox.ini`, only sections with tox-relevant names (`tox`, `testenv`, `testenv:NAME`) are scanned, which also prevents potential false positives from tool configuration sections like `[flake8]` or `[mypy]`.

Fixes #3134