### PR TITLE
🐛 fix(plugin): skip toxfile.py with unknown hooks

### DIFF
--- a/docs/changelog/3593.bugfix.rst
+++ b/docs/changelog/3593.bugfix.rst
@@ -1,0 +1,2 @@
+Skip ``toxfile.py`` inline plugin when it uses hooks not available in the current tox version instead of crashing - this
+allows provisioning to upgrade tox to a version that supports those hooks - by :user:`gaborbernat`.

--- a/src/tox/pytest.py
+++ b/src/tox/pytest.py
@@ -73,7 +73,7 @@ def _disable_root_tox_py(request: SubRequest, mocker: MockerFixture) -> Iterator
 
         mocker.patch.object(manager, "_load_inline", _load_inline)
         yield
-        if module is not None:  # pragma: no branch
+        if module is not None and manager.MANAGER.manager.is_registered(module):  # pragma: no branch
             manager.MANAGER.manager.unregister(module)
     else:  # do not allow loading inline plugins
         mocker.patch("tox.plugin.inline._load_plugin", return_value=None)

--- a/tests/plugin/test_inline.py
+++ b/tests/plugin/test_inline.py
@@ -27,6 +27,19 @@ def test_inline_tox_py(tox_project: ToxProjectCreator) -> None:
     assert "--magic" in result.out
 
 
+def test_toxfile_unknown_hook_skipped(tox_project: ToxProjectCreator) -> None:
+    def plugin() -> None:  # pragma: no cover
+        from tox.plugin import impl  # noqa: PLC0415
+
+        @impl
+        def tox_nonexistent_hook() -> None: ...
+
+    project = tox_project({"toxfile.py": plugin, "tox.toml": ""})
+    result = project.run("l")
+    result.assert_success()
+    assert "skipping inline plugin" in result.out
+
+
 def test_toxfile_py_w_ephemeral_envs(tox_project: ToxProjectCreator) -> None:
     """Ensure additional ephemeral tox envs can be plugin-injected."""
 


### PR DESCRIPTION
When a `toxfile.py` uses hooks introduced in a newer version of tox (e.g. via `minversion` or `requires`), the current version crashes with a `PluginValidationError` during `check_pending()` before provisioning ever gets a chance to run. This means users cannot combine inline plugins with provisioned tox upgrades — the very mechanism designed to handle version mismatches is defeated by the load order.

The fix catches `PluginValidationError` during plugin registration and, when the error originates from the inline plugin, gracefully skips it with a warning instead of crashing. Provisioning then proceeds normally, installs the required tox version, and the provisioned process loads `toxfile.py` successfully with full hook support. If the validation error comes from a non-inline plugin, it still raises as before.

Fixes #3593