### PR TITLE
🐛 fix(config): treat backslash-space as path separator on Windows

### DIFF
--- a/docs/changelog/3222.bugfix.rst
+++ b/docs/changelog/3222.bugfix.rst
@@ -1,0 +1,3 @@
+On Windows, a trailing path separator (e.g. from ``{/}``) no longer causes the next command argument to be merged into
+the path - backslash before whitespace is now treated as a literal path separator rather than a space escape - by
+:user:`gaborbernat`.

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -87,7 +87,7 @@ class StrConvert(Convert[str]):
             value = StrConvert._win32_process_path_backslash(
                 value,
                 escape=s.escape,
-                special_chars=s.quotes + s.whitespace,
+                special_chars=s.quotes,
             )
         splitter = shlex.shlex(value, posix=True)
         splitter.whitespace_split = True


### PR DESCRIPTION
On Windows, when a command argument ended with a trailing backslash from `{/}` path separator substitution, the backslash would escape the following space character, causing tox to incorrectly merge separate arguments. For example, `command path{/}to{/}sep{/} -b foo` became `["command", "path\to\sep -b", "foo"]` instead of the expected three separate arguments.

The fix changes Windows path backslash preprocessing to only preserve escape semantics for quotes, not for whitespace. Backslash before whitespace is now treated as a literal path separator character followed by an argument boundary. This aligns with Windows conventions where spaces in paths are handled using quotes rather than backslash escaping.

Fixes #3222