### PR TITLE
🐛 fix(config): preserve colors in provisioned tox on Windows

### DIFF
--- a/docs/changelog/3331.bugfix.rst
+++ b/docs/changelog/3331.bugfix.rst
@@ -1,0 +1,2 @@
+On Windows, colored output is now preserved when running provisioned tox by explicitly passing the ``--colored yes``
+flag to the provisioned subprocess when the parent has colors enabled - by :user:`gaborbernat`.

--- a/src/tox/provision.py
+++ b/src/tox/provision.py
@@ -153,6 +153,8 @@ def run_provision(name: str, state: State) -> int:
         try:
             tox_env.setup()
             args: list[str] = [str(env_python), "-m", "tox"]
+            if state.conf.options.is_colored and "--colored" not in state.args:
+                args.extend(["--colored", "yes"])
             args.extend(state.args)
             outcome = tox_env.execute(
                 cmd=args, stdin=StdinSource.user_only(), show=True, run_id="provision", cwd=Path.cwd()


### PR DESCRIPTION
On Windows, when tox provisions a separate environment to satisfy `minversion` or `requires` constraints, colored output was completely lost in the provisioned subprocess. 🎨 This affected all Windows users who rely on tox's automatic provisioning feature, making it harder to parse test results and warnings since everything appeared in monochrome.

Windows lacks PTY support, so `sys.stdout.isatty()` returns `False` in subprocesses even when the parent terminal supports colors. The provisioning mechanism spawns tox as a subprocess, triggering this limitation and causing the color detection logic to disable ANSI codes.

The fix explicitly passes `--colored yes` to the provisioned tox subprocess when the parent process has colors enabled. ✨ This approach preserves the user's color preference across the provision boundary without requiring PTY emulation or platform-specific terminal handling. The flag is only added when not already present in the arguments, avoiding duplication if the user explicitly set it.

Closes #3331