### PR TITLE
✨ feat(config): add {glob:PATTERN} substitution

### DIFF
--- a/docs/changelog/1571.feature.rst
+++ b/docs/changelog/1571.feature.rst
@@ -1,0 +1,3 @@
+Add ``{glob:PATTERN}`` substitution to expand file system glob/wildcard patterns in configuration values. Supports
+default values, recursive ``**`` matching, and both INI string syntax and TOML dict syntax (``{ replace = "glob",
+pattern = "..." }``) - by :user:`gaborbernat`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1922,6 +1922,32 @@ dictionaries to ``set_env`` they will be merged together, for example:
 
 Here the ``magic`` tox environment will have both ``A``, ``B``, ``C`` and ``D`` environments set.
 
+Glob pattern reference
+======================
+
+.. versionadded:: 4.40
+
+You can expand file system glob patterns via the ``glob`` replacement. Matched paths are sorted for deterministic
+output, and relative patterns are resolved against ``tox_root``. The ``**`` wildcard matches any number of directories
+recursively.
+
+.. code-block:: toml
+
+    [env.A]
+    commands = [["twine", "upload", { replace = "glob", pattern = "dist/*.whl", extend = true }]]
+
+When used with ``extend = true`` the matched files are expanded as separate arguments in the host list. Without
+``extend`` the matches are joined as a single space-separated string.
+
+If no files match and a ``default`` is provided it will be used as fallback:
+
+.. code-block:: toml
+
+    [env.A]
+    commands = [["twine", "upload", { replace = "glob", pattern = "dist/*.whl", default = ["fallback.whl"], extend = true }]]
+
+When no files match and no default is given, the result is an empty string (or empty list with ``extend``).
+
 **********
  INI only
 **********
@@ -2271,6 +2297,50 @@ will make the ``--opt1 ARG1`` appear in all test commands where ``[]`` or ``{pos
 ``args_are_paths`` setting), ``tox`` rewrites each positional argument if it is a relative path and exists on the
 filesystem to become a path relative to the ``changedir`` setting.
 
+.. _glob substitution:
+
+Glob pattern substitution
+=========================
+
+.. versionadded:: 4.40
+
+You can expand glob/wildcard patterns to matching file paths:
+
+::
+
+    {glob:PATTERN}
+
+Matches are sorted and returned as a space-separated string. If no files match, the result is an empty string. You can
+provide a default value for when no files match:
+
+::
+
+    {glob:PATTERN:DEFAULT}
+
+Relative patterns are resolved against ``tox_root``. Use ``**`` for recursive matching across directories.
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+        [env.A]
+        commands = [["twine", "upload", "{glob:dist/*.whl}"]]
+
+    Or using the TOML dict syntax (see :ref:`pyproject-toml-native`):
+
+    .. code-block:: toml
+
+        [env.A]
+        commands = [["twine", "upload", { replace = "glob", pattern = "dist/*.whl", extend = true }]]
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+        [testenv]
+        commands = twine upload {glob:dist/*.whl}
+        deps = {glob:requirements/*.txt:requirements.txt}
+
 Other substitutions
 ===================
 
@@ -2327,6 +2397,9 @@ or via ``{name}`` in INI.
       - Positional arguments passed after ``--``, with optional defaults.
     - - ``{tty:ON:OFF}``
       - ``ON`` value when running in an interactive terminal, ``OFF`` otherwise.
+    - - ``{glob:PATTERN}`` / ``{glob:PATTERN:DEFAULT}``
+      - Expand glob pattern to matching file paths (space-separated, sorted). Relative paths resolve against
+        ``tox_root``.
     - - ``{/}``
       - OS path separator (``/`` or ``\``).
     - - ``{:}``
@@ -2334,5 +2407,5 @@ or via ``{name}`` in INI.
     - - ``{[section]key}`` *(INI only)*
       - Value of ``key`` from ``[section]`` (cross-section reference).
 
-For TOML-specific replacement syntax (``replace = "ref"``, ``replace = "posargs"``, ``replace = "env"``), see
-:ref:`pyproject-toml-native`.
+For TOML-specific replacement syntax (``replace = "ref"``, ``replace = "posargs"``, ``replace = "env"``, ``replace =
+"glob"``), see :ref:`pyproject-toml-native`.

--- a/tests/config/loader/ini/replace/test_replace_glob.py
+++ b/tests/config/loader/ini/replace/test_replace_glob.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.config.loader.conftest import ReplaceOne
+
+
+def test_replace_glob_matches(replace_one: ReplaceOne, tmp_path: Path) -> None:
+    (tmp_path / "a.txt").touch()
+    (tmp_path / "b.txt").touch()
+    result = replace_one(f"{{glob:{tmp_path}/*.txt}}")
+    assert str(tmp_path / "a.txt") in result
+    assert str(tmp_path / "b.txt") in result
+
+
+def test_replace_glob_sorted(replace_one: ReplaceOne, tmp_path: Path) -> None:
+    (tmp_path / "c.txt").touch()
+    (tmp_path / "a.txt").touch()
+    (tmp_path / "b.txt").touch()
+    result = replace_one(f"{{glob:{tmp_path}/*.txt}}")
+    paths = result.split()
+    assert paths == sorted(paths)
+
+
+def test_replace_glob_no_matches_empty(replace_one: ReplaceOne, tmp_path: Path) -> None:
+    result = replace_one(f"{{glob:{tmp_path}/*.xyz}}")
+    assert not result
+
+
+def test_replace_glob_no_matches_default(replace_one: ReplaceOne, tmp_path: Path) -> None:
+    result = replace_one(f"{{glob:{tmp_path}/*.xyz:fallback}}")
+    assert result == "fallback"
+
+
+def test_replace_glob_relative_path(replace_one: ReplaceOne, tmp_path: Path) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "pkg.whl").touch()
+    result = replace_one("{glob:dist/*.whl}")
+    assert result == str(tmp_path / "dist" / "pkg.whl")
+
+
+def test_replace_glob_recursive(replace_one: ReplaceOne, tmp_path: Path) -> None:
+    sub = tmp_path / "src" / "pkg"
+    sub.mkdir(parents=True)
+    (sub / "mod.py").touch()
+    pattern = tmp_path / "src" / "**" / "*.py"
+    result = replace_one(f"{{glob:{pattern}}}")
+    assert str(sub / "mod.py") in result
+
+
+def test_replace_glob_no_pattern_error(replace_one: ReplaceOne) -> None:
+    with pytest.raises(Exception, match="No pattern was supplied"):
+        replace_one("{glob:}")
+
+
+def test_replace_glob_nested_substitution(replace_one: ReplaceOne, tmp_path: Path) -> None:
+    (tmp_path / "marker.txt").touch()
+    result = replace_one("{glob:{tox_root}/*.txt}")
+    assert str(tmp_path / "marker.txt") in result


### PR DESCRIPTION
A common pain point for tox users is referencing files by wildcard patterns in configuration — uploading all wheels from a dist directory, pointing deps at requirement files matching a pattern, or collecting test artifacts. Until now this required shell expansion or external scripting, which breaks cross-platform compatibility and complicates configuration.

This adds a `{glob:PATTERN}` substitution that expands file system glob patterns inline. It works in both INI string syntax (`{glob:dist/*.whl}`, with optional `{glob:dist/*.whl:fallback}` default) and TOML dict syntax (`{ replace = "glob", pattern = "dist/*.whl", extend = true }`). Relative patterns resolve against `tox_root`, results are sorted for deterministic builds, and `**` enables recursive directory matching.

The `extend` flag in TOML dict syntax controls whether matched paths are inserted as separate list elements (useful in `commands`) or joined as a single space-separated string (useful in `description` or other string fields). When no files match and no default is provided, the result is an empty string or empty list depending on context.

Closes #1571