### PR TITLE
✨ feat(config): add conditional replace for TOML

### DIFF
--- a/docs/changelog/3650.feature.rst
+++ b/docs/changelog/3650.feature.rst
@@ -1,0 +1,3 @@
+Add conditional value selection via ``replace = "if"`` in TOML configuration. Supports a ``condition`` expression with
+``env.VAR`` lookups, ``==``/``!=`` comparisons, and ``and``/``or``/``not`` boolean logic to select between ``then`` and
+``else`` values - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -146,6 +146,35 @@ conditionally set variables based on platform:
         COVERAGE_FILE = {work_dir}/.coverage.{env_name}
         LDFLAGS = -L/usr/local/lib ; sys_platform == "darwin"
 
+.. _conditional-values-explained:
+
+Conditional value evaluation
+============================
+
+.. versionadded:: 4.40
+
+TOML configurations support ``replace = "if"`` to conditionally select values at configuration load time. The
+``condition`` field accepts expressions that are parsed using Python's ``ast`` module and evaluated against the host
+``os.environ``.
+
+The expression language supports:
+
+- ``env.VAR`` -- resolves to the value of the environment variable ``VAR``, or empty string if unset. An empty string is
+  falsy, any non-empty string is truthy.
+- ``'literal'`` -- a string literal for comparison.
+- ``==``, ``!=`` -- string equality and inequality.
+- ``and``, ``or``, ``not`` -- boolean combinators with standard Python precedence.
+
+Conditions are evaluated before ``set_env`` is applied. The ``env.VAR`` lookup reads directly from ``os.environ``, not
+from the tox ``set_env`` configuration. This avoids circular dependencies -- a ``set_env`` value can use ``replace =
+"if"`` to check a host variable without triggering a recursive load.
+
+Both ``then`` and ``else`` values are processed through the normal TOML replacement pipeline, so they can contain nested
+substitutions like ``{env_name}`` or ``{ replace = "env", ... }``. Only the selected branch is evaluated.
+
+For syntax details and examples, see :ref:`conditional-value-reference`. For practical recipes, see
+:ref:`howto_conditional_values`.
+
 Dependency change detection
 ===========================
 

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -317,7 +317,43 @@ entire environment is skipped. Conditional factors (``lin:``, ``mac:``, ``win:``
 .. note::
 
     Conditional factors and generative environments are currently only supported in the INI format (see
-    :ref:`toml-feature-gaps`).
+    :ref:`toml-feature-gaps`). For TOML, use ``replace = "if"`` with a condition expression to achieve similar results
+    (see :ref:`conditional-value-reference`).
+
+.. _howto_conditional_values:
+
+*********************************
+ Set values based on a condition
+*********************************
+
+.. versionadded:: 4.40
+
+TOML configurations can conditionally select values based on environment variables using ``replace = "if"``. The
+``condition`` field accepts expressions with ``env.VAR`` lookups, ``==``/``!=`` comparisons, and ``and``/``or``/``not``
+boolean logic.
+
+Set a variable depending on whether you are in CI:
+
+.. code-block:: toml
+
+    [env_run_base]
+    set_env.MATURITY = { replace = "if", condition = "env.CI", then = "release", "else" = "dev" }
+
+Add verbose flags to commands when a ``DEBUG`` variable is set:
+
+.. code-block:: toml
+
+    [env_run_base]
+    commands = [["pytest", { replace = "if", condition = "env.DEBUG", then = ["-vv", "--tb=long"], "else" = [], extend = true }]]
+
+Combine multiple conditions:
+
+.. code-block:: toml
+
+    [env.deploy]
+    commands = [["deploy", { replace = "if", condition = "env.CI and env.TAG_NAME != ''", then = ["--production"], "else" = ["--dry-run"], extend = true }]]
+
+For the full expression syntax and more examples, see :ref:`conditional-value-reference`.
 
 *****************************************
  Handle env names that match subcommands

--- a/src/tox/config/loader/toml/_replace.py
+++ b/src/tox/config/loader/toml/_replace.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ast
 import glob
+import os
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -82,6 +84,9 @@ class Unroll:
                 if replace_type == "glob":
                     glob_result = _replace_glob_toml(self.conf, value)
                     return {"value": glob_result, "marker": marker} if marker else glob_result
+                if replace_type == "if":
+                    if_result = _replace_if_toml(value, self, depth, skip_str=skip_str)
+                    return {"value": if_result, "marker": marker} if marker else if_result
                 if replace_type == "ref":  # pragma: no branch
                     ref_result = self._replace_ref(value, depth, skip_str=skip_str)
                     return {"value": ref_result, "marker": marker} if marker else ref_result
@@ -116,6 +121,51 @@ def _replace_glob_toml(conf: Config | None, value: dict[str, Any]) -> list[str] 
     if default is None:
         return [] if extending else ""
     return validate(default, list) if extending else validate(default, str)
+
+
+def _replace_if_toml(value: dict[str, Any], unroll: Unroll, depth: int, *, skip_str: bool = False) -> TomlTypes:
+    condition = value.get("condition")
+    if not condition or not isinstance(condition, str):
+        msg = "No condition was supplied in if replacement"
+        raise MatchError(msg)
+    if "then" not in value:
+        msg = "No 'then' value was supplied in if replacement"
+        raise MatchError(msg)
+    return unroll(value["then"] if _evaluate_condition(condition) else value.get("else", ""), depth, skip_str=skip_str)
+
+
+def _evaluate_condition(expr: str) -> bool:  # noqa: C901
+    """Evaluate a condition expression supporting env.VAR lookups, comparisons, and boolean logic."""
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except SyntaxError:
+        msg = f"Invalid condition expression: {expr}"
+        raise MatchError(msg) from None
+
+    def _eval(node: ast.expr) -> str | bool:  # noqa: PLR0911
+        if isinstance(node, ast.BoolOp):
+            if isinstance(node.op, ast.And):
+                return all(bool(_eval(v)) for v in node.values)
+            return any(bool(_eval(v)) for v in node.values)
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+            return not bool(_eval(node.operand))
+        if isinstance(node, ast.Compare) and len(node.ops) == 1 and len(node.comparators) == 1:
+            left = _eval(node.left)
+            right = _eval(node.comparators[0])
+            if isinstance(node.ops[0], ast.Eq):
+                return left == right
+            if isinstance(node.ops[0], ast.NotEq):
+                return left != right
+            msg = f"Unsupported comparison operator in condition: {expr}"
+            raise MatchError(msg)
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == "env":
+            return os.environ.get(node.attr, "")
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        msg = f"Unsupported expression in condition: {ast.dump(node)}"
+        raise MatchError(msg)
+
+    return bool(_eval(tree.body))
 
 
 _REFERENCE_PATTERN = re.compile(


### PR DESCRIPTION
TOML configurations had no way to conditionally select values based on environment variables, forcing users to rely on external scripts or fall back to INI-only factor conditions. This was one of the most frequently requested features (#3650), particularly for CI/CD workflows where behavior needs to vary based on environment context.

The `replace = "if"` syntax introduces a `condition` expression field that supports `env.VAR` lookups, `==`/`!=` comparisons, and `and`/`or`/`not` boolean logic. 🔧 Expressions are parsed safely via Python's `ast` module — only a restricted set of node types is evaluated, so arbitrary code execution is not possible. The `env.VAR` lookups read directly from `os.environ` rather than `set_env`, avoiding circular dependency issues when conditionals are used inside `set_env` itself.

The expression language was chosen over PEP 508 markers because the `packaging` library's marker evaluator has a hard-coded set of allowed variable names and cannot be extended with `os.environ` lookups. A custom `ast`-based evaluator provides the same familiar Python syntax (`and`, `or`, `not`, `==`, `!=`) while supporting the actual use case of environment variable inspection.

Closes #3650