### PR TITLE
✨ feat(run): add commands_retry config option

### DIFF
--- a/docs/changelog/1578.feature.rst
+++ b/docs/changelog/1578.feature.rst
@@ -1,0 +1,1 @@
+Add ``commands_retry`` configuration option to automatically retry failed commands - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -85,7 +85,8 @@ The primary tox states are:
       installations complete but before test commands, and run during the ``--notest`` phase.
    5. **Commands**: run the specified commands in the specified order. Whenever the exit code of any of them is not
       zero, stop and mark the environment failed. When you start a command with a dash character, the exit code will be
-      ignored.
+      ignored. If :ref:`commands_retry` is set, failed commands are retried up to the configured number of times before
+      being treated as a failure.
 
 3. **Report** print out a report of outcomes for each tox environment:
 

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -597,6 +597,33 @@ To invert the exit code (fail if the command returns 0, succeed otherwise), use 
              python --version
 
 **********************
+ Retry flaky commands
+**********************
+
+Commands that fail due to transient errors (network timeouts, flaky tests) can be automatically retried using
+:ref:`commands_retry`. The value specifies how many times to retry a failed command -- a value of ``2`` means each
+command is attempted up to 3 times total. Retries apply to :ref:`commands_pre`, :ref:`commands`, and
+:ref:`commands_post`. Commands prefixed with ``-`` (ignore exit code) are never retried.
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+         [env.integration]
+         description = "run integration tests with retries for flaky network calls"
+         commands_retry = 2
+         commands = [["pytest", "tests/integration"]]
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+         [testenv:integration]
+         description = run integration tests with retries for flaky network calls
+         commands_retry = 2
+         commands = pytest tests/integration
+
+**********************
  Control color output
 **********************
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1103,6 +1103,31 @@ Run
     setting is analogous to the ``-k`` or ``--keep-going`` option of GNU Make.
 
 .. conf::
+    :keys: commands_retry
+    :default: 0
+    :version_added: 4.41
+
+    Number of times to retry a failed command before giving up. A value of ``N`` means each command can be attempted up
+    to ``N + 1`` times total. Applies to :ref:`commands_pre`, :ref:`commands`, and :ref:`commands_post`. Commands
+    prefixed with ``-`` (ignore exit code) are never retried since their failures are already ignored.
+
+    .. tab:: TOML
+
+       .. code-block:: toml
+
+          [env_run_base]
+          commands_retry = 2
+          commands = [["pytest", "tests"]]
+
+    .. tab:: INI
+
+       .. code-block:: ini
+
+          [testenv]
+          commands_retry = 2
+          commands = pytest tests
+
+.. conf::
     :keys: ignore_outcome
     :default: False
     :version_added: 2.2

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -280,6 +280,11 @@
           "type": "boolean",
           "description": "when executing the commands keep going even if a sub-command exits with non-zero exit code"
         },
+        "commands_retry": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "number of times to retry a failed command (0 means no retries)"
+        },
         "ignore_outcome": {
           "type": "boolean",
           "description": "if set to true a failing result of this testenv will not make tox fail (instead just warn)"

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -76,6 +76,12 @@ class RunToxEnv(ToxEnv, ABC):
             desc="when executing the commands keep going even if a sub-command exits with non-zero exit code",
         )
         self.conf.add_config(
+            keys=["commands_retry"],
+            of_type=int,
+            default=0,
+            desc="number of times to retry a failed command (0 means no retries)",
+        )
+        self.conf.add_config(
             keys=["ignore_outcome"],
             of_type=bool,
             default=False,

--- a/tests/session/cmd/test_commands_retry.py
+++ b/tests/session/cmd/test_commands_retry.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from tox.pytest import ToxProjectCreator
+
+
+def test_retry_succeeds_after_failure(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """\
+[env_run_base]
+package = "skip"
+commands_retry = 3
+commands = [["python", "-c", \
+"from pathlib import Path; p = Path('counter.txt'); \
+c = int(p.read_text()) + 1 if p.exists() else 1; \
+p.write_text(str(c)); raise SystemExit(0 if c >= 3 else 1)"]]
+"""
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_success()
+    assert "command failed (attempt 1 of 4), retrying" in result.out
+    assert "command failed (attempt 2 of 4), retrying" in result.out
+
+
+def test_retry_all_exhausted(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """\
+[env_run_base]
+package = "skip"
+commands_retry = 2
+commands = [["python", "-c", "raise SystemExit(1)"]]
+"""
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_failed(code=1)
+    assert "command failed (attempt 1 of 3), retrying" in result.out
+    assert "command failed (attempt 2 of 3), retrying" in result.out
+
+
+def test_retry_default_no_retry(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """\
+[env_run_base]
+package = "skip"
+commands = [["python", "-c", "raise SystemExit(1)"]]
+"""
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_failed(code=1)
+    assert "retrying" not in result.out
+
+
+def test_retry_dash_prefix_no_retry(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """\
+[env_run_base]
+package = "skip"
+commands_retry = 3
+commands = [["-", "python", "-c", "raise SystemExit(1)"]]
+"""
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_success()
+    assert "retrying" not in result.out
+
+
+def test_retry_with_ignore_errors(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """\
+[env_run_base]
+package = "skip"
+ignore_errors = true
+commands_retry = 1
+commands = [["python", "-c", "raise SystemExit(1)"]]
+"""
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_failed(code=1)
+    assert "command failed (attempt 1 of 2), retrying" in result.out
+
+
+def test_retry_bang_prefix_succeeds_on_nonzero(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """\
+[env_run_base]
+package = "skip"
+commands_retry = 2
+commands = [["!", "python", "-c", "raise SystemExit(1)"]]
+"""
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_success()
+    assert "retrying" not in result.out
+
+
+def test_retry_bang_prefix_retries_on_zero(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """\
+[env_run_base]
+package = "skip"
+commands_retry = 2
+commands = [["!", "python", "-c", \
+"from pathlib import Path; p = Path('counter_bang.txt'); \
+c = int(p.read_text()) + 1 if p.exists() else 1; \
+p.write_text(str(c)); raise SystemExit(0 if c < 3 else 1)"]]
+"""
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_success()
+    assert "command failed (attempt 1 of 3), retrying" in result.out
+    assert "command failed (attempt 2 of 3), retrying" in result.out
+
+
+@pytest.mark.parametrize("command_key", ["commands_pre", "commands_post"])
+def test_retry_applies_to_pre_and_post(tox_project: ToxProjectCreator, command_key: str) -> None:
+    proj = tox_project({
+        "tox.toml": f"""\
+[env_run_base]
+package = "skip"
+commands_retry = 3
+{command_key} = [["python", "-c", \
+"from pathlib import Path; p = Path('counter_{command_key}.txt'); \
+c = int(p.read_text()) + 1 if p.exists() else 1; \
+p.write_text(str(c)); raise SystemExit(0 if c >= 2 else 1)"]]
+"""
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_success()
+    assert "command failed (attempt 1 of 4), retrying" in result.out


### PR DESCRIPTION
Users running commands subject to transient failures -- network timeouts, flaky integration tests, intermittent CI infrastructure issues -- had no built-in way to automatically retry. The only workarounds were shell-level retry loops or wrapping commands in helper scripts, both of which add friction and reduce portability across platforms.

This adds a `commands_retry` integer configuration option (default `0`) to each environment. Setting it to `N` means each command can be attempted up to `N + 1` times total. The retry applies uniformly to `commands_pre`, `commands`, and `commands_post`. When a command fails and retries remain, tox logs a warning with the attempt count and re-executes. Commands prefixed with `-` (ignore exit code) are never retried since their failures are already ignored. The feature composes naturally with `ignore_errors` -- retries are exhausted first, then the existing error-handling logic takes over.

The default of `0` preserves existing behavior. No configuration changes are required for users who don't need retries.

Fixes #1578