### PR TITLE
Prefer TOML-native config over legacy_tox_ini in pyproject.toml

### DIFF
--- a/docs/changelog/3402.feature.rst
+++ b/docs/changelog/3402.feature.rst
@@ -1,0 +1,3 @@
+Prefer TOML-native configuration (``[tool.tox]``) over ``legacy_tox_ini`` when both are present in ``pyproject.toml``,
+allowing users to include a ``legacy_tox_ini`` section with ``min_version`` for older tox versions while using native
+TOML config for newer ones - by :user:`rahuldevikar`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -36,9 +36,9 @@ Out of box tox supports five configuration locations prioritized in the followin
     flowchart TD
         search[tox searches current directory] --> tox_ini
         tox_ini[tox.ini — INI] -- not found --> setup_cfg[setup.cfg — INI]
-        setup_cfg -- not found --> pyproject_legacy[pyproject.toml — legacy_tox_ini]
-        pyproject_legacy -- not found --> pyproject_native[pyproject.toml — tool.tox]
-        pyproject_native -- not found --> tox_toml[tox.toml — TOML]
+        setup_cfg -- not found --> pyproject_native[pyproject.toml — tool.tox]
+        pyproject_native -- not found --> pyproject_legacy[pyproject.toml — legacy_tox_ini]
+        pyproject_legacy -- not found --> tox_toml[tox.toml — TOML]
 
         classDef ini fill:#dbeafe,stroke:#3b82f6,stroke-width:2px,color:#1e3a5f
         classDef toml fill:#dcfce7,stroke:#22c55e,stroke-width:2px,color:#14532d
@@ -50,8 +50,8 @@ Out of box tox supports five configuration locations prioritized in the followin
 
 1. ``tox.ini`` (INI),
 2. ``setup.cfg`` (INI),
-3. ``pyproject.toml`` with the ``tool.tox`` table, having ``legacy_tox_ini`` key (containing INI),
-4. Native ``pyproject.toml`` under the ``tool.tox`` table (TOML),
+3. Native ``pyproject.toml`` under the ``tool.tox`` table (TOML),
+4. ``pyproject.toml`` with the ``tool.tox`` table, having ``legacy_tox_ini`` key (containing INI),
 5. ``tox.toml`` (TOML).
 
 Historically, the INI format was created first, and TOML was added in 2024. **TOML is the recommended format for new

--- a/src/tox/config/source/discover.py
+++ b/src/tox/config/source/discover.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
 SOURCE_TYPES: tuple[type[Source], ...] = (
     ToxIni,
     SetupCfg,
-    LegacyToml,
     TomlPyProject,
+    LegacyToml,
     TomlTox,
 )
 

--- a/src/tox/config/source/toml_pyproject.py
+++ b/src/tox/config/source/toml_pyproject.py
@@ -89,6 +89,8 @@ class TomlPyProject(Source):
             self._our_content = our_content
         except KeyError as exc:
             raise MissingRequiredConfigKeyError(path) from exc
+        if set(self._our_content.keys()) == {"legacy_tox_ini"}:
+            raise MissingRequiredConfigKeyError(path)
         super().__init__(path)
 
     def get_core_section(self) -> Section:


### PR DESCRIPTION
Swap the discovery priority of TomlPyProject and LegacyToml so that native TOML configuration ([tool.tox]) is preferred over legacy_tox_ini when both are present in pyproject.toml. This allows users to include a legacy_tox_ini section with min_version for backward compatibility with older tox versions while using native TOML config for newer ones.

Fixes #3402 

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
