### PR TITLE
🐛 fix(interrupt): suppress BrokenPipeError during teardown

### DIFF
--- a/docs/changelog/2660.bugfix.rst
+++ b/docs/changelog/2660.bugfix.rst
@@ -1,0 +1,2 @@
+Suppress ``BrokenPipeError`` during backend teardown when interrupted, preventing traceback spam during
+KeyboardInterrupt - by :user:`gaborjbernat`. Fixes :issue:`2660`.

--- a/src/tox/tox_env/python/virtual_env/package/pyproject.py
+++ b/src/tox/tox_env/python/virtual_env/package/pyproject.py
@@ -236,7 +236,7 @@ class Pep517VenvPackager(PythonPackageToxEnv, ABC):
             try:
                 if executor.is_alive:
                     self._frontend._send("_exit")  # try first on amicable shutdown  # noqa: SLF001
-            except SystemExit:  # pragma: no cover  # if already has been interrupted ignore
+            except (SystemExit, BrokenPipeError):  # pragma: no cover  # if interrupted or backend dead, ignore
                 pass
             finally:
                 executor.close()

--- a/tests/session/cmd/test_parallel.py
+++ b/tests/session/cmd/test_parallel.py
@@ -157,6 +157,10 @@ def test_keyboard_interrupt(tox_project: ToxProjectCreator, demo_pkg_inline: Pat
     assert "send signal SIGINT" in out, out
     assert "interrupt finished with success" in out, out
     assert "interrupt tox environment: .pkg" in out, out
+    assert "BrokenPipeError" not in out, out
+    assert "BrokenPipeError" not in err, err
+    assert "KeyError" not in out, out
+    assert "KeyError" not in err, err
 
 
 def test_parallels_help(tox_project: ToxProjectCreator) -> None:


### PR DESCRIPTION
When users interrupt tox with Ctrl-C, excessive tracebacks clutter the output and obscure the actual interrupt handling. The packaging backend process may already be terminated when teardown attempts to send the "_exit" shutdown message, causing BrokenPipeError exceptions that make it appear something went wrong when the interrupt is actually being handled correctly.

The fix catches BrokenPipeError alongside SystemExit during backend teardown in the pyproject packaging code. 🐛 Both exceptions indicate the process is being terminated cleanly and don't require error reporting. This approach keeps the existing interrupt flow intact while eliminating noise during cleanup.

Users will now see clean interrupt output focused on the actual teardown progress rather than pipe errors from attempting to communicate with already-dead processes.