### PR TITLE
✨ feat(env): gracefully skip environments with unavailable runners

### DIFF
--- a/docs/changelog/3504.feature.rst
+++ b/docs/changelog/3504.feature.rst
@@ -1,0 +1,4 @@
+Environments with unavailable runners (missing plugins) are now gracefully skipped instead of causing a fatal error,
+shown with status "NOT AVAILABLE". If such an environment is explicitly requested with ``-e``, a clear error message is
+shown indicating which runner is missing and that the plugin may not be installed. Unavailable environments in the
+configuration don't cause the overall run to fail - by :user:`gaborbernat`.

--- a/src/tox/session/cmd/run/single.py
+++ b/src/tox/session/cmd/run/single.py
@@ -28,6 +28,7 @@ class ToxEnvRunResult(NamedTuple):
     duration: float
     ignore_outcome: bool = False
     fail_fast: bool = False
+    unavailable: bool = False
 
 
 def run_one(tox_env: RunToxEnv, no_test: bool, suspend_display: bool) -> ToxEnvRunResult:  # noqa: FBT001

--- a/src/tox/tox_env/errors.py
+++ b/src/tox/tox_env/errors.py
@@ -13,3 +13,7 @@ class Skip(Exception):  # noqa: N818
 
 class Fail(Exception):  # noqa: N818
     """Failed creating env."""
+
+
+class RunnerUnavailable(Exception):  # noqa: N818
+    """Runner for this environment is not available."""

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -381,3 +381,93 @@ def test_suggest_env(tox_project: ToxProjectCreator) -> None:
         f"alph-p{_MINOR} - did you mean alpha-py3{_MINOR}?\n"
     )
     assert outcome.out == msg
+
+
+def test_unavailable_runner_in_config_not_explicitly_requested(tox_project: ToxProjectCreator) -> None:
+    """Unavailable runner in config should be marked NOT AVAILABLE if not explicitly requested."""
+    tox_toml = """
+        [tool.tox]
+        env_list = ["available", "unavailable"]
+
+        [tool.tox.env_run_base]
+        skip_install = true
+
+        [tool.tox.env.available]
+        commands = [["python", "-c", "print('available')"]]
+
+        [tool.tox.env.unavailable]
+        runner = "nonexistent-runner"
+        commands = [["python", "-c", "print('unavailable')"]]
+        """
+    proj = tox_project({"pyproject.toml": tox_toml})
+    outcome = proj.run("r", "-e", "available")
+    outcome.assert_success()
+    assert "available: OK" in outcome.out
+    assert "unavailable: NOT AVAILABLE" in outcome.out
+
+
+def test_unavailable_runner_explicitly_requested(tox_project: ToxProjectCreator) -> None:
+    """Explicitly requesting unavailable runner should fail with clear error."""
+    tox_toml = """
+        [tool.tox.env_run_base]
+        skip_install = true
+
+        [tool.tox.env.unavailable]
+        runner = "nonexistent-runner"
+        commands = [["python", "-c", "print('unavailable')"]]
+        """
+    proj = tox_project({"pyproject.toml": tox_toml})
+    outcome = proj.run("r", "-e", "unavailable")
+    outcome.assert_failed()
+    assert "runner 'nonexistent-runner' for environment 'unavailable' is not available" in outcome.out
+
+
+def test_unavailable_runner_in_env_list(tox_project: ToxProjectCreator) -> None:
+    """Unavailable runner in env_list should be shown as NOT AVAILABLE."""
+    tox_toml = """
+        [tool.tox]
+        env_list = ["available", "unavailable"]
+
+        [tool.tox.env_run_base]
+        skip_install = true
+
+        [tool.tox.env.available]
+        commands = [["python", "-c", "print('available')"]]
+
+        [tool.tox.env.unavailable]
+        runner = "nonexistent-runner"
+        commands = [["python", "-c", "print('unavailable')"]]
+        """
+    proj = tox_project({"pyproject.toml": tox_toml})
+    outcome = proj.run("r")
+    outcome.assert_success()
+    assert "available: OK" in outcome.out
+    assert "unavailable: NOT AVAILABLE" in outcome.out
+
+
+def test_multiple_unavailable_runners_implicit(tox_project: ToxProjectCreator) -> None:
+    """Multiple unavailable runners should all be marked NOT AVAILABLE when not explicitly requested."""
+    tox_toml = """
+        [tool.tox]
+        env_list = ["available", "unavailable1", "unavailable2"]
+
+        [tool.tox.env_run_base]
+        skip_install = true
+
+        [tool.tox.env.available]
+        commands = [["python", "-c", "print('available')"]]
+
+        [tool.tox.env.unavailable1]
+        runner = "nonexistent-runner-1"
+        commands = [["python", "-c", "print('unavailable1')"]]
+
+        [tool.tox.env.unavailable2]
+        runner = "nonexistent-runner-2"
+        commands = [["python", "-c", "print('unavailable2')"]]
+        """
+    proj = tox_project({"pyproject.toml": tox_toml})
+    outcome = proj.run("r")
+    outcome.assert_success()
+    assert "available: OK" in outcome.out
+    assert "unavailable1: NOT AVAILABLE" in outcome.out
+    assert "unavailable2: NOT AVAILABLE" in outcome.out


### PR DESCRIPTION
When environments reference unavailable runners (from missing plugins), tox now gracefully skips them instead of failing catastrophically. 🔧 If a user explicitly requests an unavailable environment with `-e`, they get a clear error message indicating which runner is missing and that the plugin may not be installed.

Environments discovered from config but not explicitly selected are shown with "NOT AVAILABLE" status without failing the overall run. This enables better plugin dependency management, allowing users to depend on optional plugins without breaking tox for users who haven't installed them.

The implementation introduces a `RunnerUnavailable` exception to distinguish missing runners from other skip scenarios, extends `_ToxEnvInfo` to track unavailable environments, and updates the reporting layer to show "NOT AVAILABLE" in yellow (matching the SKIP status level). Success calculations treat unavailable environments like skipped—they don't cause the run to fail.

Comprehensive TOML-based tests verify all scenarios: unavailable runners in discovered env_list, explicitly requested environments, mixed available/unavailable environments, and multiple unavailable runners.

Fixes #3504