### PR TITLE
🐛 fix(env): restore compound factor conditionals

### DIFF
--- a/docs/changelog/3780.bugfix.rst
+++ b/docs/changelog/3780.bugfix.rst
@@ -1,0 +1,4 @@
+Compound factor conditionals (e.g., ``np-cov: coverage``) now correctly allow their individual factors to be used when
+specifying environments with ``-e``. Previously, running ``tox -e py310-np-cov`` with a factor conditional ``np-cov:
+coverage`` in the config would fail with "provided environments not found" because the individual factor ``cov`` was not
+recognized as combinable - by :user:`gaborbernat`.

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -245,15 +245,28 @@ class EnvSelector:
         if label_envs:
             yield label_envs.keys(), False
 
-    def _ensure_envs_valid(self) -> None:
+    def _combinable_factors(self) -> tuple[set[str], set[str], set[str]]:
         known_envs = set(self._state.conf)
+        env_list = set(self._state.conf.core["env_list"])
         # factors that can be freely combined: from env_list entries and known env names themselves
-        combinable = set(chain.from_iterable(env.split("-") for env in self._state.conf.core["env_list"]))
+        combinable = set(chain.from_iterable(env.split("-") for env in env_list))
         combinable.update(known_envs)
         combinable.add(".pkg")
+        # section header env names are valid only as whole identifiers (not split into factors)
+        section_envs: set[str] = set()
+        for section in self._state.conf.sections():
+            if hasattr(section, "is_test_env") and not section.is_test_env:
+                continue
+            section_envs.update(getattr(section, "names", [section.name]))
+        # env names from factor conditionals: their individual factors are freely combinable
+        combinable.update(chain.from_iterable(env.split("-") for env in known_envs - env_list - section_envs))
         # broader pool for suggestions includes factors from all known env names
         all_factors = set(chain.from_iterable(env.split("-") for env in known_envs))
         all_factors.update(combinable)
+        return known_envs, combinable, all_factors
+
+    def _ensure_envs_valid(self) -> None:
+        known_envs, combinable, all_factors = self._combinable_factors()
         invalid_envs: dict[str, str | None] = {}
         for env in self._cli_envs or []:
             if env.startswith(".pkg_external") or env in known_envs:

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -368,6 +368,22 @@ def test_partial_section_match_rejected(env_name: str, tox_project: ToxProjectCr
     assert "provided environments not found in configuration file" in outcome.out
 
 
+def test_factor_conditional_compound_accepted(tox_project: ToxProjectCreator) -> None:
+    tox_ini = f"""
+        [tox]
+        env_list = py3{{{_MINOR},{_MINOR + 1}}}
+        [testenv]
+        package = skip
+        commands =
+            np: python -c 'print("np")'
+            np-cov: python -c 'print("cov")'
+    """
+    proj = tox_project({"tox.ini": tox_ini})
+    outcome = proj.run("r", "-e", f"py3{_MINOR}-np-cov")
+    outcome.assert_success()
+    assert f"py3{_MINOR}-np-cov" in outcome.out
+
+
 def test_suggest_env(tox_project: ToxProjectCreator) -> None:
     tox_ini = f"[testenv:release]\n[testenv:py3{_MINOR}]\n[testenv:alpha-py3{_MINOR}]\n"
     proj = tox_project({"tox.ini": tox_ini})


### PR DESCRIPTION
PR #3753 fixed section header names from being decomposed into freely combinable factors, preventing `tox -e functional-py312` from silently falling back to `[testenv]` when only `[testenv:functional{-py310}]` was defined. However, it also broke compound factor conditionals like `np-cov: coverage` — running `tox -e py310-np-cov` would fail with "provided environments not found" because the individual factor `cov` (from the compound conditional `np-cov`) was no longer recognized as combinable.

🔍 The fix distinguishes between env names from section headers and env names discovered from factor conditionals. Section header names remain valid only as whole identifiers (preserving the #3753 fix), while factor-conditional env names have their individual factors added to the combinable set. This is done by collecting section-derived env names via `Config.sections()` and treating everything else in `known_envs` (minus `env_list`) as factor-conditional — splitting those into individual factors.

Fixes #3780