### PR TITLE
✨ feat(config): add default_base_python config key

### DIFF
--- a/docs/changelog/2846.feature.rst
+++ b/docs/changelog/2846.feature.rst
@@ -1,0 +1,3 @@
+Add ``default_base_python`` configuration key to specify a fallback Python interpreter when no Python factor or explicit
+``base_python`` is defined. This allows projects to pin a default Python version for reproducibility across different
+machines without conflicting with ``pyXY`` factor-named environments - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -73,10 +73,11 @@ The primary tox states are:
    1. **Creation**: create a fresh environment; by default :pypi:`virtualenv` is used, but configurable via
       :ref:`runner`. For ``virtualenv`` tox will use the `virtualenv discovery logic
       <https://virtualenv.pypa.io/en/latest/user_guide.html#python-discovery>`_ where the python specification is
-      defined by the tox environments :ref:`base_python` (if not set will default to the environments name). This is
-      created at first run only to be reused at subsequent runs. If certain aspects of the project change (python
-      version, dependencies removed, etc.), a re-creation of the environment is automatically triggered. To force the
-      recreation tox can be invoked with the :ref:`recreate` flag (``-r``).
+      defined by the tox environments :ref:`base_python` (if not set will try to extract it from the environment name,
+      then fall back to :ref:`default_base_python`, and finally to the Python running tox). This is created at first run
+      only to be reused at subsequent runs. If certain aspects of the project change (python version, dependencies
+      removed, etc.), a re-creation of the environment is automatically triggered. To force the recreation tox can be
+      invoked with the :ref:`recreate` flag (``-r``).
    2. **Install dependencies** (optional): install the environment dependencies specified inside the ``deps``
       configuration section, and then the earlier packaged source distribution. By default ``pip`` is used to install
       packages, however one can customize this via ``install_command``.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -1084,6 +1084,36 @@ Signal numbers are documented in the `signal man page <https://man7.org/linux/ma
 
 .. ------------------------------------------------------------------------------------------
 
+.. _pin-default-python:
+
+******************************
+ Pin a default Python version
+******************************
+
+When environments like ``lint`` or ``type`` don't contain a Python factor, tox uses the Python it's installed into. This
+varies across machines -- a contributor on Ubuntu 22.04 gets Python 3.10, while Fedora 37 gives 3.11 -- leading to
+unreproducible results or failures when dependencies don't support the host's Python version.
+
+Set :ref:`default_base_python` to pin a fallback interpreter for all environments without a Python factor:
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+        [env_run_base]
+        default_base_python = ["3.14", "3.13"]
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+        [testenv]
+        default_base_python = 3.14, 3.13
+
+Environments with a Python factor (e.g. ``3.13``, ``py313``) or an explicit :ref:`base_python` setting are unaffected.
+
+.. ------------------------------------------------------------------------------------------
+
 .. _eol-version-support:
 
 **********************************

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1262,7 +1262,8 @@ Python options
     This determines in practice the Python for what we'll create a virtual isolated environment. Use this to specify the
     Python version for a tox environment. If not specified, the virtual environments factors (e.g. name part) will be
     used to automatically set one. For example, ``py310`` means ``python3.10``, ``py3`` means ``python3`` and ``py``
-    means ``python``. If the name does not match this pattern the same Python version tox is installed into will be used.
+    means ``python``. If the name does not match this pattern, :ref:`default_base_python` is consulted, and if that is
+    also not set, the same Python version tox is installed into will be used.
     A base interpreter ending with ``t`` means that only free threaded Python implementations are accepted.
 
     The preferred naming convention is ``N.M`` (e.g. ``3.14``, ``3.13``) rather than ``pyNMM`` (e.g. ``py314``,
@@ -1281,6 +1282,37 @@ Python options
        and tox is installed into a Python that's not supported by the package. For example, if your package requires
        Python 3.10 or later, and you install tox in Python 3.9, when you run a tox environment that has left this
        unspecified tox will use Python 3.9 to build and install your package which will fail given it requires 3.10.
+
+.. conf::
+    :keys: default_base_python
+    :default: <python version of tox>
+    :version_added: 4.42
+
+    Fallback Python interpreter used when the environment name contains no Python factor and no explicit
+    :ref:`base_python` is set. Accepts a list of specifications -- the first one found wins. This provides a way to
+    pin a default Python version for reproducibility across different machines without conflicting with ``pyXY``
+    factor-named environments.
+
+    The resolution order for an environment's Python interpreter is:
+
+    1. Python factor extracted from the environment name (e.g. ``3.13``, ``py313``)
+    2. Explicit :ref:`base_python` setting on the environment
+    3. ``default_base_python`` (this setting)
+    4. The Python running tox (``sys.executable``)
+
+    .. tab:: TOML
+
+        .. code-block:: toml
+
+            [env_run_base]
+            default_base_python = ["3.14", "3.13"]
+
+    .. tab:: INI
+
+        .. code-block:: ini
+
+            [testenv]
+            default_base_python = 3.14, 3.13
 
 .. conf::
     :keys: env_site_packages_dir, envsitepackagesdir

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -167,7 +167,15 @@ naturally in environment lists and CI output, and avoids confusion for Python ve
 digits become three characters.
 
 If the name doesn't match any pattern, tox uses the same Python as the one tox is installed into (this is the case for
-``lint`` in our example).
+``lint`` in our example). To override this fallback, set :ref:`default_base_python`:
+
+.. code-block:: toml
+
+    [env_run_base]
+    default_base_python = ["3.14", "3.13"]
+
+This pins a default Python version for environments without a Python factor, improving reproducibility across machines
+with different system Pythons.
 
 For the full list of environment options, see :ref:`conf-testenv`.
 

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -74,13 +74,20 @@ class Python(ToxEnv, ABC):
     def register_config(self) -> None:
         super().register_config()
 
+        self.conf.add_config(
+            keys=["default_base_python"],
+            of_type=list[str],
+            default=[sys.executable],
+            desc="fallback python interpreter used when no factor or explicit base_python is defined",
+        )
+
         def validate_base_python(value: list[str]) -> list[str]:
             return self._validate_base_python(self.name, value, self.core["ignore_base_python_conflict"])
 
         self.conf.add_config(  # ty: ignore[no-matching-overload] # https://github.com/astral-sh/ty/issues/2428
             keys=["base_python", "basepython"],
             of_type=list[str],
-            default=self.default_base_python,
+            default=self._base_python_default,
             desc="environment identifier for python, first one found wins",
             post_process=validate_base_python,
         )
@@ -147,9 +154,9 @@ class Python(ToxEnv, ABC):
         env.extend(["REQUESTS_CA_BUNDLE"])
         return env
 
-    def default_base_python(self, conf: Config, env_name: str | None) -> list[str]:  # noqa: ARG002
+    def _base_python_default(self, conf: Config, env_name: str | None) -> list[str]:  # noqa: ARG002
         base_python = None if env_name is None else self.extract_base_python(env_name)
-        return [sys.executable if base_python is None else base_python]
+        return self.conf["default_base_python"] if base_python is None else [base_python]
 
     @classmethod
     def extract_base_python(cls, env_name: str) -> str | None:


### PR DESCRIPTION
Environments without a Python factor in their name (e.g. `lint`, `type`, `docs`) currently fall back to `sys.executable` when `base_python` isn't explicitly set. This means the interpreter varies across machines — Ubuntu 22.04 defaults to 3.10, Fedora 37 to 3.11 — harming reproducibility and causing unexpected failures when dependencies don't support the host's Python version. 🔧 Setting `base_python` globally in `[env_run_base]` works around this but conflicts with `pyXY` factor-named environments.

The new `default_base_python` key sits at the environment config level and acts as a fallback only when no Python factor is detected and no explicit `base_python` is set. This gives it clear precedence semantics: Python factor > explicit `base_python` > `default_base_python` > `sys.executable`. Placing it in `[env_run_base]` rather than `[tox]` allows per-environment overrides when needed.

```toml
[env_run_base]
default_base_python = ["python3.10", "python3.9"]
```

✨ Existing configurations are unaffected since the default remains `sys.executable`. This closes #2846.