### PR TITLE
✨ feat(config): add env_site_packages_dir_plat substitution

### DIFF
--- a/docs/changelog/2302.feature.rst
+++ b/docs/changelog/2302.feature.rst
@@ -1,0 +1,3 @@
+Add ``{env_site_packages_dir_plat}`` / ``{envsitepackagesdir_plat}`` substitution that returns the platform-specific
+(platlib) site-packages directory. On some Linux distributions (Fedora, RHEL) this resolves to ``lib64`` instead of
+``lib``, which is no longer symlinked since virtualenv 20.x - by :user:`gaborbernat`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1287,7 +1287,16 @@ Python options
     :constant:
     :version_added: 1.4.3
 
-    The Python environments site package - where packages are installed (the purelib folder path).
+    The Python environments site package - where pure-python packages are installed (the purelib folder path).
+
+.. conf::
+    :keys: env_site_packages_dir_plat, envsitepackagesdir_plat
+    :constant:
+    :version_added: 4.42
+
+    The Python environments platform-specific site package (the platlib folder path). On most platforms this is the same
+    as :ref:`env_site_packages_dir`, but on some Linux distributions (Fedora, RHEL) platlib resolves to ``lib64`` instead
+    of ``lib``.
 
 .. conf::
     :keys: env_bin_dir, envbindir
@@ -2570,7 +2579,9 @@ or via ``{name}`` in INI.
     - - ``{env_python}`` / ``{envpython}``
       - Path to the Python executable in the virtual environment.
     - - ``{env_site_packages_dir}`` / ``{envsitepackagesdir}``
-      - Site-packages directory of the virtual environment.
+      - Pure-python site-packages directory (purelib) of the virtual environment.
+    - - ``{env_site_packages_dir_plat}`` / ``{envsitepackagesdir_plat}``
+      - Platform-specific site-packages directory (platlib) of the virtual environment.
     - - ``{base_python}`` / ``{basepython}``
       - The configured base Python interpreter.
     - - ``{py_dot_ver}``

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -92,8 +92,13 @@ class Python(ToxEnv, ABC):
         )
         self.conf.add_constant(
             keys=["env_site_packages_dir", "envsitepackagesdir"],
-            desc="the python environments site package",
+            desc="the python environments site package - pure python (purelib)",
             value=self.env_site_package_dir,
+        )
+        self.conf.add_constant(
+            keys=["env_site_packages_dir_plat", "envsitepackagesdir_plat"],
+            desc="the python environments platform-specific site package (platlib)",
+            value=self.env_site_package_dir_plat,
         )
         self.conf.add_constant(
             keys=["env_bin_dir", "envbindir"],
@@ -223,12 +228,21 @@ class Python(ToxEnv, ABC):
 
     @abstractmethod
     def env_site_package_dir(self) -> Path:
-        """Return the site-packages directory for this environment.
+        """Return the pure-python site-packages directory (purelib) for this environment.
 
         Debian derivatives change site-packages to dist-packages, so we look at the last path under prefix.
 
         """
         raise NotImplementedError
+
+    def env_site_package_dir_plat(self) -> Path:
+        """Return the platform-specific site-packages directory (platlib) for this environment.
+
+        On most platforms this is the same as purelib, but on some Linux distributions (Fedora, RHEL) platlib uses lib64
+        instead of lib. Defaults to purelib so third-party runners don't need to override this.
+
+        """
+        return self.env_site_package_dir()
 
     @abstractmethod
     def env_python(self) -> Path:

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -170,6 +170,9 @@ class VirtualEnv(Python, ABC):
     def env_site_package_dir(self) -> Path:
         return cast("Path", cast("Describe", self._creator_with_skip()).purelib)
 
+    def env_site_package_dir_plat(self) -> Path:
+        return cast("Path", cast("Describe", self._creator_with_skip()).platlib)
+
     def env_python(self) -> Path:
         return cast("Path", cast("Describe", self._creator_with_skip()).exe)
 

--- a/tests/tox_env/python/virtual_env/test_virtualenv_api.py
+++ b/tests/tox_env/python/virtual_env/test_virtualenv_api.py
@@ -194,6 +194,17 @@ def test_posargs_colon_in_inactive_env_does_not_crash(tox_project: ToxProjectCre
     assert "ok" in outcome.out
 
 
+def test_env_site_packages_dir_plat(tox_project: ToxProjectCreator) -> None:
+    toml = """\
+[env_run_base]
+package = "skip"
+commands = [["python", "-c", "print('ok')"]]
+"""
+    result = tox_project({"tox.toml": toml}).run("c", "-e", "py", "-k", "env_site_packages_dir_plat")
+    result.assert_success()
+    assert "site-packages" in result.out
+
+
 def test_pip_user_disabled(tox_project: ToxProjectCreator) -> None:
     proj = tox_project(
         {


### PR DESCRIPTION
Since virtualenv 20.x, the `lib64` directory is no longer symlinked to `lib` on Linux distributions like Fedora and RHEL (see [virtualenv#1751](https://github.com/pypa/virtualenv/issues/1751)). This means `{env_site_packages_dir}` (which returns purelib) doesn't cover the platform-specific `lib64/pythonX.Y/site-packages` path where compiled extensions live.

🔧 The new `{env_site_packages_dir_plat}` / `{envsitepackagesdir_plat}` substitution exposes the platlib path from virtualenv's `Describe` interface. On most platforms (macOS, Windows) this is identical to purelib, but on affected Linux distributions it correctly resolves to the `lib64` directory. The base `Python` class provides a default implementation that returns purelib, so third-party runners like `tox-uv` continue to work without changes. The built-in `VirtualEnv` runner overrides it to return the actual platlib.

Closes #2302.