### PR TITLE
🐛 fix(parallel): show --list-dependencies output

### DIFF
--- a/docs/changelog/3322.bugfix.rst
+++ b/docs/changelog/3322.bugfix.rst
@@ -1,0 +1,2 @@
+``--list-dependencies`` output is now printed to stdout during parallel runs. Previously, the dependency list was
+captured in suspended output buffers and only shown on failure - by :user:`gaborbernat`.

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -385,7 +385,7 @@ def _handle_one_run_done(
             pkg_out_err = package_env.close_and_read_out_err()
             if pkg_out_err is not None:  # pragma: no branch
                 pkg_out_err_list.append(pkg_out_err)
-        if not success or tox_env.conf["parallel_show_output"]:
+        if not success or tox_env.conf["parallel_show_output"] or state.conf.options.list_dependencies:
             for pkg_out_err in pkg_out_err_list:
                 state._options.log_handler.write_out_err(pkg_out_err)  # pragma: no cover  # noqa: SLF001
             if out_err is not None:  # pragma: no branch # first show package build

--- a/tests/session/cmd/test_parallel.py
+++ b/tests/session/cmd/test_parallel.py
@@ -244,6 +244,19 @@ def test_parallel_no_spinner_legacy_with_parallel(tox_project: ToxProjectCreator
     )
 
 
+def test_parallel_list_dependencies(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """
+        [env_run_base]
+        skip_install = true
+        commands = [["python", "-c", "print('ok')"]]
+        """
+    })
+    result = proj.run("p", "-e", "py", "--list-dependencies")
+    result.assert_success()
+    assert "pip==" in result.out
+
+
 def test_no_capture_with_parallel_fails(tox_project: ToxProjectCreator) -> None:
     ini = "[testenv]\npackage=skip\ncommands=python --version"
     result = tox_project({"tox.ini": ini}).run("p", "-e", "py", "--no-capture")


### PR DESCRIPTION
Running `tox run-parallel --list-dependencies` silently discards the dependency output on successful runs. This happens because parallel mode suspends all stdout/stderr into in-memory buffers, and those buffers are only flushed when a test fails or when `parallel_show_output` is explicitly enabled. Since `--list-dependencies` writes via `logging.warning()`, the output gets captured and never reaches the user.

The fix adds `list_dependencies` as an additional condition for flushing the suspended output buffers after each environment completes. This sits alongside the existing `parallel_show_output` and failure checks in `_handle_one_run_done`, preserving the same flush-or-discard pattern while ensuring dependency output is always visible when requested.

Fixes #3322