### PR TITLE
📝 docs(faq): document Debian python3-venv limitation

### DIFF
--- a/docs/changelog/3195.doc.rst
+++ b/docs/changelog/3195.doc.rst
@@ -1,0 +1,1 @@
+Document Debian/Ubuntu ``python3-venv`` limitation in known limitations - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -548,6 +548,32 @@ Alternative workarounds if you cannot use ``--no-capture``:
 - For IPython, pass ``--simple-prompt`` to disable ``prompt_toolkit``'s advanced terminal features.
 - For other tools, look for a "dumb terminal" or "no-color" mode that avoids VT100 escape sequences.
 
+Debian/Ubuntu without ``python3-venv``
+======================================
+
+On Debian and Ubuntu, the system Python is split into multiple packages. The ``python3`` package does not include the
+:mod:`venv` module or :mod:`ensurepip` — these are in the separate ``python3-venv`` package.
+
+tox itself is **not affected** because it uses :pypi:`virtualenv` (which bundles its own bootstrap mechanism) rather
+than stdlib :mod:`venv`. However, tools that tox *runs as commands* inside environments may use stdlib :mod:`venv`
+internally and fail. A common example is :pypi:`build` (``pyproject-build``), which creates an isolated build
+environment using :mod:`venv` when a recent ``pip`` is available.
+
+If you see errors like:
+
+.. code-block:: text
+
+    The virtual environment was not created successfully because ensurepip is not available.
+    On Debian/Ubuntu systems, you need to install the python3-venv package.
+
+this is the tool inside the tox environment hitting the missing system package, not tox itself.
+
+**Solutions:**
+
+- Install the system venv package: ``apt install python3-venv`` (or ``python3.X-venv`` for a specific version).
+- Use :pypi:`tox-uv`, which replaces both the environment creation and package installation with :pypi:`uv`, avoiding
+  the stdlib :mod:`venv` dependency entirely.
+
 ******************
  Related projects
 ******************


### PR DESCRIPTION
On Debian and Ubuntu the system Python splits `venv` and `ensurepip` into a separate `python3-venv` package. tox itself is unaffected — it uses `virtualenv` which bundles its own bootstrap — but tools that tox runs as commands inside environments (most commonly `pyproject-build`) may use stdlib `venv` internally and fail with a confusing "ensurepip is not available" error.

This adds a "Known limitations" entry in the concepts documentation explaining the root cause and providing two solutions: installing `python3-venv`, or using `tox-uv` to bypass stdlib `venv` entirely.

Closes #3195