### PR TITLE
✨ feat(pkg): cache external packaging env build across envs

### DIFF
--- a/docs/changelog/2729.feature.rst
+++ b/docs/changelog/2729.feature.rst
@@ -1,0 +1,2 @@
+External packaging environments (``package = external``) now only run their build commands once per session, reusing the
+built package for all test environments that depend on them - by :user:`gaborbernat`.


### PR DESCRIPTION
When using `package = external` with a shared `package_env`, the build commands run once per test environment that depends on it, rebuilding an identical package each time. For projects compiling C extensions or running complex build pipelines, this wastes significant time — often several minutes per redundant build.

🚀 The built package path is now cached after the first successful build within a session. Subsequent test environments that share the same external packaging env skip the build entirely and reuse the already-built artifact. Per-environment extras and dependencies are still resolved individually, so environments with different `extras` configurations continue to get the correct dependency set.

This mirrors the caching behavior that `wheel_build_env` already provides for PEP-517 wheel builds, extending the same optimization to external packaging workflows.

Fixes #2729