### PR TITLE
✨ feat(cli): accept plugin CLI options during provisioning

### DIFF
--- a/docs/changelog/2935.feature.rst
+++ b/docs/changelog/2935.feature.rst
@@ -1,0 +1,2 @@
+CLI options added by plugins listed in ``requires`` are now accepted during provisioning instead of failing with
+"unrecognized arguments" - by :user:`gaborbernat`.

--- a/src/tox/config/cli/parse.py
+++ b/src/tox/config/cli/parse.py
@@ -6,7 +6,7 @@ import locale
 import os
 from contextlib import redirect_stderr
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, cast
+from typing import TYPE_CHECKING, NamedTuple
 
 from tox.config.source import Source, discover_source
 from tox.report import ToxHandler, setup_report
@@ -76,7 +76,10 @@ def _get_all(args: Sequence[str]) -> tuple[Parsed, dict[str, Callable[[State], i
         argcomplete.autocomplete(tox_parser)
     except ImportError:
         pass
-    parsed = cast("Parsed", tox_parser.parse_args(args))
+    parsed, unknown = tox_parser.parse_known_args(args)
+    parsed.remainder = unknown
+    if getattr(parsed, "no_capture", False) and getattr(parsed, "result_json", None):
+        tox_parser.error("argument -i/--no-capture: not allowed with argument --result-json")
     handlers = {k: p for k, (_, p) in tox_parser.handlers.items()}
     return parsed, handlers
 

--- a/src/tox/provision.py
+++ b/src/tox/provision.py
@@ -104,6 +104,12 @@ def provision(state: State) -> int | bool:
     state.envs._mark_provision(bool(missing), provision_tox_env)  # noqa: SLF001
 
     if not missing:
+        if remainder := getattr(state.conf.options, "remainder", []):
+            msg = (
+                f"unrecognized arguments: {' '.join(remainder)}\n"
+                "hint: if you tried to pass arguments to a command use -- to separate them from tox ones"
+            )
+            raise HandledError(msg)
         return False
 
     miss_msg = f"is missing [requires (has)]: {deps}"

--- a/tests/config/cli/test_cli_env_var.py
+++ b/tests/config/cli/test_cli_env_var.py
@@ -72,6 +72,7 @@ def test_verbose_no_test() -> None:
         "labels": [],
         "skip_env": "",
         "list_dependencies": is_ci(),
+        "remainder": [],
     }
 
 
@@ -135,6 +136,7 @@ def test_env_var_exhaustive_parallel_values(
         "exit_and_dump_after": 0,
         "skip_env": "",
         "list_dependencies": is_ci(),
+        "remainder": [],
     }
     assert options.parsed.verbosity == 4
     assert options.cmd_handlers == core_handlers

--- a/tests/config/cli/test_cli_ini.py
+++ b/tests/config/cli/test_cli_ini.py
@@ -61,6 +61,7 @@ def default_options() -> dict[str, Any]:
         "exit_and_dump_after": 0,
         "skip_env": "",
         "list_dependencies": is_ci(),
+        "remainder": [],
     }
 
 
@@ -239,6 +240,7 @@ def test_ini_exhaustive_parallel_values(core_handlers: dict[str, Callable[[State
         "exit_and_dump_after": 0,
         "skip_env": "",
         "list_dependencies": is_ci(),
+        "remainder": [],
     }
     assert options.parsed.verbosity == 4
     assert options.cmd_handlers == core_handlers

--- a/tests/demo_pkg_inline/build.py
+++ b/tests/demo_pkg_inline/build.py
@@ -24,6 +24,7 @@ content = {
     logic: f"def do():\n    print('greetings from {name}')",
     plugin: """
         try:
+            from tox.config.cli.parser import ToxParser
             from tox.plugin import impl
             from tox.tox_env.python.virtual_env.runner import VirtualEnvRunner
             from tox.tox_env.register import ToxEnvRegister
@@ -37,6 +38,9 @@ content = {
             @impl
             def tox_register_tox_env(register: ToxEnvRegister) -> None:
                 register.add_run_env(ExampleVirtualEnvRunner)
+            @impl
+            def tox_add_option(parser: ToxParser) -> None:
+                parser.add_argument("--demo-plugin", action="store_true", help="demo plugin flag")
         """,
 }
 metadata_files = {


### PR DESCRIPTION
Plugins that add CLI options via `tox_add_option` couldn't be used with `requires`-based provisioning. Running `tox --demo-plugin` where `--demo-plugin` is defined by a plugin in `requires` would fail with "unrecognized arguments" because CLI argument validation happened before provisioning had a chance to install the plugin and re-execute tox.

🔧 The fix defers unknown argument validation until after the provisioning check. During initial CLI parsing, `parse_known_args` is used instead of `parse_args`, allowing unrecognized flags through. If provisioning is needed, tox re-executes in the provisioned environment where the plugin is installed and the flag is recognized. If provisioning is *not* needed, any remaining unknown arguments still raise the familiar error message — so typos and invalid flags are still caught.

The demo plugin used in integration tests now also registers a `--demo-plugin` CLI flag via `tox_add_option` to exercise this path.

Fixes #2935