### PR TITLE
✨ feat(env): add recreate_commands config key

### DIFF
--- a/docs/changelog/3423.feature.rst
+++ b/docs/changelog/3423.feature.rst
@@ -1,0 +1,2 @@
+Add ``recreate_commands`` configuration option to run cleanup commands (e.g. clearing external caches like pre-commit)
+before the environment directory is removed during recreation (``-r``) - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -77,7 +77,9 @@ The primary tox states are:
       then fall back to :ref:`default_base_python`, and finally to the Python running tox). This is created at first run
       only to be reused at subsequent runs. If certain aspects of the project change (python version, dependencies
       removed, etc.), a re-creation of the environment is automatically triggered. To force the recreation tox can be
-      invoked with the :ref:`recreate` flag (``-r``).
+      invoked with the :ref:`recreate` flag (``-r``). When recreation occurs, any :ref:`recreate_commands` run inside
+      the old environment before its directory is removed -- this lets tools like pre-commit clean their external
+      caches. Failures in these commands are logged as warnings but never block the recreation.
    2. **Install dependencies** (optional): install the environment dependencies specified inside the ``deps``
       configuration section, and then the earlier packaged source distribution. By default ``pip`` is used to install
       packages, however one can customize this via ``install_command``.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -739,6 +739,37 @@ variables:
 Any CLI flag for virtualenv can be set as an environment variable with the ``VIRTUALENV_`` prefix (in uppercase).
 Consult the :pypi:`virtualenv` documentation for supported values.
 
+.. _howto_clean_caches:
+
+*****************************************
+ Clean external caches during recreation
+*****************************************
+
+Tools like :pypi:`pre-commit` maintain their own caches outside the tox environment directory. When you recreate an
+environment with ``tox run -r``, those external caches are left behind. Use :ref:`recreate_commands` to run cleanup
+commands inside the old environment before it is removed:
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+         [env_run_base]
+         deps = ["pre-commit"]
+         recreate_commands = [["{env_python}", "-Im", "pre_commit", "clean"]]
+         commands = [["pre-commit", "run", "--all-files"]]
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+         [testenv]
+         deps = pre-commit
+         recreate_commands = {env_python} -Im pre_commit clean
+         commands = pre-commit run --all-files
+
+These commands only run during recreation -- they are skipped on first creation and on normal re-runs. Failures are
+logged as warnings and never block the recreation itself.
+
 ***************************
  Ignore command exit codes
 ***************************

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1064,6 +1064,34 @@ Run
     ``--notest``, all commands including ``extra_setup_commands`` will execute.
 
 .. conf::
+    :keys: recreate_commands
+    :default: <empty list>
+    :version_added: 4.42
+
+    Commands to run before the environment directory is removed during recreation (``tox run -r``). These commands
+    execute inside the existing environment, so tools installed there are available. Useful for cleaning external caches
+    managed by tools like pre-commit. Failures are logged as warnings but never block recreation.
+
+    .. tab:: TOML
+
+       .. code-block:: toml
+
+          [env_run_base]
+          deps = ["pre-commit"]
+          recreate_commands = [["{env_python}", "-Im", "pre_commit", "clean"]]
+
+    .. tab:: INI
+
+       .. code-block:: ini
+
+          [testenv]
+          deps = pre-commit
+          recreate_commands = {env_python} -Im pre_commit clean
+
+    These commands do **not** run on first creation (the environment directory does not exist yet) or on normal
+    re-runs without ``-r``.
+
+.. conf::
     :keys: commands_pre
     :default: <empty list>
     :version_added: 3.4

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -244,6 +244,9 @@ recreation with the ``-r`` flag:
 
     tox run -e 3.13 -r
 
+If tools inside the environment maintain their own caches (e.g. pre-commit), you can use :ref:`recreate_commands` to
+clean them before the environment directory is removed. See :ref:`howto_clean_caches` for details.
+
 ********************************
  Listing available environments
 ********************************

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -265,6 +265,16 @@
           },
           "description": "the commands to be called after testing"
         },
+        "recreate_commands": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/subs"
+            }
+          },
+          "description": "commands to run before the environment is removed during recreation (e.g. cache cleanup)"
+        },
         "change_dir": {
           "type": "string",
           "description": "change to this working directory when executing the test command"

--- a/tests/tox_env/test_tox_env_runner.py
+++ b/tests/tox_env/test_tox_env_runner.py
@@ -8,6 +8,115 @@ if TYPE_CHECKING:
     from tox.pytest import ToxProjectCreator
 
 
+def test_recreate_commands_run_on_recreate(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """
+[env_run_base]
+package = "skip"
+recreate_commands = [["python", "-c", "print('RECREATE_CLEANUP')"]]
+commands = [["python", "-c", "print('MAIN')"]]
+""",
+    })
+    first = proj.run("r")
+    first.assert_success()
+    assert "RECREATE_CLEANUP" not in first.out
+
+    second = proj.run("r", "-r")
+    second.assert_success()
+    assert "RECREATE_CLEANUP" in second.out
+    assert "MAIN" in second.out
+
+
+def test_recreate_commands_not_run_on_first_creation(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """
+[env_run_base]
+package = "skip"
+recreate_commands = [["python", "-c", "print('RECREATE_CLEANUP')"]]
+""",
+    })
+    result = proj.run("r")
+    result.assert_success()
+    assert "RECREATE_CLEANUP" not in result.out
+
+
+def test_recreate_commands_failure_does_not_block_recreation(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """
+[env_run_base]
+package = "skip"
+recreate_commands = [["python", "-c", "raise SystemExit(1)"]]
+commands = [["python", "-c", "print('MAIN')"]]
+""",
+    })
+    first = proj.run("r")
+    first.assert_success()
+
+    second = proj.run("r", "-r")
+    second.assert_success()
+    assert "MAIN" in second.out
+
+
+def test_recreate_commands_not_run_without_recreate(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """
+[env_run_base]
+package = "skip"
+recreate_commands = [["python", "-c", "print('RECREATE_CLEANUP')"]]
+commands = [["python", "-c", "print('MAIN')"]]
+""",
+    })
+    first = proj.run("r")
+    first.assert_success()
+
+    second = proj.run("r")
+    second.assert_success()
+    assert "RECREATE_CLEANUP" not in second.out
+    assert "MAIN" in second.out
+
+
+def test_recreate_commands_multiple(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """
+[env_run_base]
+package = "skip"
+recreate_commands = [
+    ["python", "-c", "print('CLEANUP_1')"],
+    ["python", "-c", "print('CLEANUP_2')"],
+]
+commands = [["python", "-c", "print('MAIN')"]]
+""",
+    })
+    first = proj.run("r")
+    first.assert_success()
+
+    second = proj.run("r", "-r")
+    second.assert_success()
+    assert "CLEANUP_1" in second.out
+    assert "CLEANUP_2" in second.out
+    assert "MAIN" in second.out
+
+
+def test_recreate_commands_run_before_env_removed(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": """
+[env_run_base]
+package = "skip"
+recreate_commands = [["python", "-c", "print('RECREATE_CLEANUP')"]]
+commands = [["python", "-c", "print('MAIN')"]]
+""",
+    })
+    first = proj.run("r")
+    first.assert_success()
+
+    second = proj.run("r", "-r")
+    second.assert_success()
+    lines = second.out.split("\n")
+    cleanup_idx = next(i for i, line in enumerate(lines) if "RECREATE_CLEANUP" in line)
+    remove_idx = next(i for i, line in enumerate(lines) if "remove tox env folder" in line)
+    assert cleanup_idx < remove_idx
+
+
 def test_package_only(
     tox_project: ToxProjectCreator,
     demo_pkg_inline: Path,


### PR DESCRIPTION
When `tox run -r` recreates an environment, external caches managed by tools inside that environment (e.g. pre-commit) survive the directory wipe. Users had no mechanism to clean those caches as part of the recreation lifecycle, leading to stale state that defeats the purpose of recreation.

🧹 `recreate_commands` is a new `list[Command]` config key that runs inside the still-existing environment before its directory is removed. This placement is deliberate -- the old virtualenv and its installed tools remain available, so commands like `{env_python} -Im pre_commit clean` work naturally. The env's bin directory is temporarily added to the allowlist so command resolution works correctly even though `_setup_env` hasn't run yet in the current session.

Failures in `recreate_commands` are logged as warnings but never block recreation -- the environment is being destroyed anyway, so a cleanup failure shouldn't prevent a fresh start. The commands are skipped entirely on first creation (no env directory exists yet) and on normal re-runs without `-r`.

Closes #3423