### PR TITLE
✨ feat(env): add virtualenv_spec for per-env version pinning

### DIFF
--- a/docs/changelog/3656.feature.rst
+++ b/docs/changelog/3656.feature.rst
@@ -1,0 +1,4 @@
+Add ``virtualenv_spec`` configuration key that allows pinning a specific virtualenv version per environment (e.g.
+``virtualenv_spec = "virtualenv<20.22.0"``). When set, tox bootstraps the specified version in an isolated environment
+and drives it via subprocess, enabling environments targeting Python versions incompatible with the installed virtualenv
+- by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -528,6 +528,36 @@ it falls back to the base section (:ref:`base` configuration). For ``tox.toml`` 
 
 Here ``test`` inherits ``commands`` from the base because it is not specified in ``[env.test]``.
 
+.. _virtualenv-version-pinning:
+
+****************************
+ Virtualenv version pinning
+****************************
+
+tox creates isolated environments using :pypi:`virtualenv`, which it imports as a library. This works well when the
+installed virtualenv supports all target Python versions, but breaks down at the edges: older virtualenv releases
+(pre-20.22) are required for Python 3.6 support, while the latest virtualenv is needed for Python 3.15+. Since tox can
+only import one virtualenv version per process, projects that need both old and new Pythons in a single ``tox.toml`` hit
+a wall.
+
+The :ref:`virtualenv_spec` setting resolves this by decoupling the virtualenv used for environment creation from the one
+tox imports. When set, tox:
+
+1. Creates a bootstrap venv (using the stdlib ``venv`` module) in ``.tox/.virtualenv-bootstrap/``.
+2. Installs the specified virtualenv version into that bootstrap venv via pip.
+3. Runs the bootstrapped virtualenv as a subprocess instead of calling ``session_via_cli()`` from the imported library.
+
+The bootstrap is content-addressed by a hash of the spec string, so different specs get separate cached environments. A
+file lock protects against concurrent bootstrap creation (relevant in parallel mode). Once bootstrapped, subsequent runs
+skip directly to step 3.
+
+When ``virtualenv_spec`` is empty (the default), tox uses the imported virtualenv with zero overhead -- the subprocess
+path only activates when explicitly configured. The spec is included in the environment cache key, so changing it
+triggers automatic recreation.
+
+This design mirrors tox's own auto-provisioning mechanism (``requires`` / ``min_version``), where tox bootstraps itself
+into a separate environment when the running installation doesn't meet the declared requirements.
+
 *******************
  Known limitations
 *******************

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -770,6 +770,43 @@ commands inside the old environment before it is removed:
 These commands only run during recreation -- they are skipped on first creation and on normal re-runs. Failures are
 logged as warnings and never block the recreation itself.
 
+*****************************************
+ Test across old and new Python versions
+*****************************************
+
+When a project must support both very old (e.g. Python 3.6) and very new (e.g. Python 3.15) interpreters, no single
+virtualenv release covers both. Use :ref:`virtualenv_spec` to pin a different virtualenv version per environment:
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+         env_list = ["3.6", "3.15", "3.13"]
+
+         [env_run_base]
+         deps = ["pytest"]
+         commands = [["pytest"]]
+
+         [env."3.6"]
+         virtualenv_spec = "virtualenv<20.22.0"
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+         [tox]
+         env_list = 3.6, 3.15, 3.13
+
+         [testenv]
+         deps = pytest
+         commands = pytest
+
+         [testenv:3.6]
+         virtualenv_spec = virtualenv<20.22.0
+
+The ``3.6`` environment uses an older virtualenv that still supports Python 3.6, while other environments use the
+default (imported) virtualenv. The first run bootstraps the pinned version; subsequent runs reuse the cached bootstrap.
+
 ***************************
  Ignore command exit codes
 ***************************

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1652,6 +1652,50 @@ Python virtual environment
     overwritten by the ``VIRTUALENV_DOWNLOAD`` environment variable. If (and only if) you want to choose a specific
     version (not necessarily the latest) then you can add ``VIRTUALENV_PIP=20.3.3`` (and similar) to your :ref:`set_env`.
 
+.. conf::
+    :keys: virtualenv_spec
+    :default: ""
+    :version_added: 4.42
+
+    A :pep:`440` version specifier for virtualenv (e.g. ``virtualenv<20.22.0``). When set, tox bootstraps the specified
+    virtualenv version into an isolated environment and drives it via subprocess, instead of using the imported
+    virtualenv library. This enables environments targeting Python versions that are incompatible with the virtualenv
+    installed alongside tox.
+
+    The bootstrap environment is cached under ``.tox/.virtualenv-bootstrap/`` (keyed by a hash of the spec string) and
+    reused across runs. Concurrent access is protected by a file lock. When the spec is empty (the default), tox uses
+    the imported virtualenv with zero overhead.
+
+    .. tab:: TOML
+
+        .. code-block:: toml
+
+            [env.legacy]
+            base_python = ["python3.6"]
+            virtualenv_spec = "virtualenv<20.22.0"
+            commands = [["python", "-c", "import sys; print(sys.version)"]]
+
+            [env.modern]
+            base_python = ["python3.15"]
+            commands = [["python", "-c", "import sys; print(sys.version)"]]
+
+    .. tab:: INI
+
+        .. code-block:: ini
+
+            [testenv:legacy]
+            base_python = python3.6
+            virtualenv_spec = virtualenv<20.22.0
+            commands = python -c 'import sys; print(sys.version)'
+
+            [testenv:modern]
+            base_python = python3.15
+            commands = python -c 'import sys; print(sys.version)'
+
+    Changing this value triggers automatic environment recreation (the spec is included in the cache key).
+
+    See :ref:`virtualenv-version-pinning` for background on when and why to use this setting.
+
 Python virtual environment packaging
 ====================================
 

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -287,6 +287,7 @@ This is useful for debugging configuration issues.
 Now that you have a working tox setup, explore these topics:
 
 - :doc:`../explanation` -- understand how tox works (parallel mode, packaging, auto-provisioning)
-- :doc:`../how-to/usage` -- practical recipes for common tasks
+- :doc:`../how-to/usage` -- practical recipes for common tasks (including testing across old and new Python versions
+  with :ref:`virtualenv_spec`)
 - :ref:`configuration` -- full configuration reference
 - :ref:`cli` -- complete CLI reference

--- a/src/tox/tox_env/python/virtual_env/subprocess_adapter.py
+++ b/src/tox/tox_env/python/virtual_env/subprocess_adapter.py
@@ -1,0 +1,207 @@
+"""Subprocess-based virtualenv session/creator for use with pinned virtualenv versions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import subprocess
+import sys
+import venv
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from filelock import FileLock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_PROBE_SCRIPT = """\
+import json, struct, sys, sysconfig
+print(json.dumps({
+    "implementation": sys.implementation.name,
+    "version_info": list(sys.version_info[:5]),
+    "version": sys.version.split()[0],
+    "architecture": struct.calcsize("P") * 8,
+    "platform": sys.platform,
+    "system_executable": sys.executable,
+    "free_threaded": sysconfig.get_config_var("Py_GIL_DISABLED") == 1,
+}))
+"""
+
+
+@dataclass
+class _VersionInfo:
+    major: int
+    minor: int
+    micro: int
+    releaselevel: str
+    serial: int
+
+
+@dataclass
+class SubprocessPythonInfo:
+    """Python interpreter information gathered via subprocess probe."""
+
+    implementation: str
+    version_info: _VersionInfo
+    version: str
+    architecture: int
+    platform: str
+    system_executable: str
+    free_threaded: bool
+
+
+@dataclass
+class SubprocessCreator:
+    """Mimics virtualenv Creator + Describe interface using known venv directory layout."""
+
+    _env_dir: Path
+    interpreter: SubprocessPythonInfo
+    _is_win: bool = field(default_factory=lambda: sys.platform == "win32")
+
+    @property
+    def bin_dir(self) -> Path:
+        return self._env_dir / ("Scripts" if self._is_win else "bin")
+
+    @property
+    def script_dir(self) -> Path:
+        return self.bin_dir
+
+    @property
+    def purelib(self) -> Path:
+        if self._is_win:
+            return self._env_dir / "Lib" / "site-packages"
+        vi = self.interpreter.version_info
+        return self._env_dir / "lib" / f"python{vi.major}.{vi.minor}" / "site-packages"
+
+    @property
+    def platlib(self) -> Path:
+        return self.purelib
+
+    @property
+    def exe(self) -> Path:
+        return self.bin_dir / ("python.exe" if self._is_win else "python")
+
+
+class SubprocessSession:
+    """Mimics virtualenv Session interface, runs a bootstrapped virtualenv via subprocess."""
+
+    def __init__(
+        self,
+        env_dir: Path,
+        bootstrap_python: Path,
+        env_vars: dict[str, str],
+        interpreter: SubprocessPythonInfo | None,
+    ) -> None:
+        self._env_dir = env_dir
+        self._bootstrap_python = bootstrap_python
+        self._env_vars = env_vars
+        self._creator = SubprocessCreator(env_dir, interpreter) if interpreter is not None else None
+
+    def run(self) -> None:
+        cmd = [str(self._bootstrap_python), "-m", "virtualenv", str(self._env_dir)]
+        try:
+            result = subprocess.run(cmd, env=self._env_vars, capture_output=True, text=True, check=False)
+        except FileNotFoundError as exc:
+            msg = f"virtualenv subprocess failed: {exc}"
+            raise RuntimeError(msg) from exc
+        if result.returncode != 0:
+            msg = f"virtualenv subprocess failed (exit {result.returncode}): {result.stderr}"
+            raise RuntimeError(msg)
+
+    @property
+    def creator(self) -> SubprocessCreator:
+        if self._creator is None:
+            msg = "no interpreter discovered"
+            raise RuntimeError(msg)
+        return self._creator
+
+
+def probe_python(python_path: str) -> SubprocessPythonInfo | None:
+    """Probe a Python executable to extract interpreter metadata."""
+    try:
+        result = subprocess.run(
+            [python_path, "-c", _PROBE_SCRIPT], capture_output=True, text=True, timeout=30, check=False
+        )
+        if result.returncode != 0:
+            return None
+        raw = json.loads(result.stdout)
+    except (subprocess.SubprocessError, json.JSONDecodeError, FileNotFoundError, OSError):
+        return None
+    vi = raw["version_info"]
+    return SubprocessPythonInfo(
+        implementation=raw["implementation"],
+        version_info=_VersionInfo(major=vi[0], minor=vi[1], micro=vi[2], releaselevel=vi[3], serial=vi[4]),
+        version=raw["version"],
+        architecture=raw["architecture"],
+        platform=raw["platform"],
+        system_executable=raw["system_executable"],
+        free_threaded=raw["free_threaded"],
+    )
+
+
+def _bootstrap_path(work_dir: Path, virtualenv_spec: str) -> Path:
+    digest = hashlib.sha256(virtualenv_spec.encode()).hexdigest()[:16]
+    return work_dir / ".virtualenv-bootstrap" / digest
+
+
+def _bin_dir(base: Path) -> Path:
+    return base / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+def _bootstrap_python(base: Path) -> Path:
+    return _bin_dir(base) / ("python.exe" if sys.platform == "win32" else "python")
+
+
+def _bootstrap_pip(base: Path) -> Path:
+    return _bin_dir(base) / ("pip.exe" if sys.platform == "win32" else "pip")
+
+
+def _has_correct_virtualenv(python: Path, virtualenv_spec: str) -> bool:
+    if not python.exists():
+        return False
+    try:
+        result = subprocess.run(
+            [str(python), "-c", "from importlib.metadata import version; print(version('virtualenv'))"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            return False
+        from packaging.specifiers import SpecifierSet  # noqa: PLC0415
+
+        installed = result.stdout.strip()
+        spec = virtualenv_spec.removeprefix("virtualenv")
+        return installed in SpecifierSet(spec) if spec else True
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return False
+
+
+def ensure_bootstrap(work_dir: Path, virtualenv_spec: str) -> Path:
+    """Create or reuse a cached bootstrap venv with the specified virtualenv version."""
+    base = _bootstrap_path(work_dir, virtualenv_spec)
+    python = _bootstrap_python(base)
+    if _has_correct_virtualenv(python, virtualenv_spec):
+        return python
+
+    lock_path = base.parent / f"{base.name}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(lock_path):
+        if _has_correct_virtualenv(python, virtualenv_spec):
+            return python
+        logging.info("bootstrapping %s into %s", virtualenv_spec, base)
+        if base.exists():
+            import shutil  # noqa: PLC0415
+
+            shutil.rmtree(base)
+        venv.create(str(base), with_pip=True, clear=True)
+        pip = _bootstrap_pip(base)
+        result = subprocess.run([str(pip), "install", virtualenv_spec], capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            msg = f"failed to install {virtualenv_spec} into bootstrap env: {result.stderr}"
+            raise RuntimeError(msg)
+        return python

--- a/tests/tox_env/python/virtual_env/test_subprocess_adapter.py
+++ b/tests/tox_env/python/virtual_env/test_subprocess_adapter.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tox.tox_env.python.virtual_env.subprocess_adapter import (
+    SubprocessCreator,
+    SubprocessPythonInfo,
+    SubprocessSession,
+    _bootstrap_path,  # noqa: PLC2701
+    _has_correct_virtualenv,  # noqa: PLC2701
+    _VersionInfo,  # noqa: PLC2701
+    ensure_bootstrap,
+    probe_python,
+)
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from tox.pytest import ToxProjectCreator
+
+
+def test_probe_python_current_interpreter() -> None:
+    info = probe_python(sys.executable)
+    assert info is not None
+    assert info.version_info.major == sys.version_info.major
+    assert info.version_info.minor == sys.version_info.minor
+    assert info.version_info.micro == sys.version_info.micro
+    assert info.implementation == sys.implementation.name
+    assert info.architecture in {32, 64}
+    assert info.system_executable
+
+
+def test_probe_python_nonexistent() -> None:
+    assert probe_python("/nonexistent/python999") is None
+
+
+def test_probe_python_failing_script(tmp_path: Path) -> None:
+    if sys.platform == "win32":
+        bad_script = tmp_path / "bad_python.cmd"
+        bad_script.write_text("@exit /b 1\n")
+    else:
+        bad_script = tmp_path / "bad_python"
+        bad_script.write_text("#!/bin/sh\nexit 1\n")
+        bad_script.chmod(0o755)
+    assert probe_python(str(bad_script)) is None
+
+
+def test_subprocess_creator_paths_unix(tmp_path: Path) -> None:
+    vi = _VersionInfo(major=3, minor=11, micro=0, releaselevel="final", serial=0)
+    env_dir = tmp_path / "env"
+    info = SubprocessPythonInfo(
+        implementation="cpython",
+        version_info=vi,
+        version="3.11.0",
+        architecture=64,
+        platform="linux",
+        system_executable="/usr/bin/python3.11",
+        free_threaded=False,
+    )
+    creator = SubprocessCreator(_env_dir=env_dir, interpreter=info, _is_win=False)
+    assert creator.bin_dir == env_dir / "bin"
+    assert creator.script_dir == env_dir / "bin"
+    assert creator.purelib == env_dir / "lib" / "python3.11" / "site-packages"
+    assert creator.platlib == env_dir / "lib" / "python3.11" / "site-packages"
+    assert creator.exe == env_dir / "bin" / "python"
+
+
+def test_subprocess_creator_paths_windows(tmp_path: Path) -> None:
+    vi = _VersionInfo(major=3, minor=11, micro=0, releaselevel="final", serial=0)
+    env_dir = tmp_path / "env"
+    info = SubprocessPythonInfo(
+        implementation="cpython",
+        version_info=vi,
+        version="3.11.0",
+        architecture=64,
+        platform="win32",
+        system_executable="C:\\Python311\\python.exe",
+        free_threaded=False,
+    )
+    creator = SubprocessCreator(_env_dir=env_dir, interpreter=info, _is_win=True)
+    assert creator.bin_dir == env_dir / "Scripts"
+    assert creator.purelib == env_dir / "Lib" / "site-packages"
+    assert creator.exe == env_dir / "Scripts" / "python.exe"
+
+
+def test_subprocess_session_run_not_found(tmp_path: Path) -> None:
+    vi = _VersionInfo(major=3, minor=11, micro=0, releaselevel="final", serial=0)
+    info = SubprocessPythonInfo(
+        implementation="cpython",
+        version_info=vi,
+        version="3.11.0",
+        architecture=64,
+        platform=sys.platform,
+        system_executable=sys.executable,
+        free_threaded=False,
+    )
+    session = SubprocessSession(
+        env_dir=tmp_path / "env",
+        bootstrap_python=Path("/nonexistent/python"),
+        env_vars={},
+        interpreter=info,
+    )
+    with pytest.raises(RuntimeError, match="virtualenv subprocess failed"):
+        session.run()
+
+
+def test_subprocess_session_run_nonzero_exit(tmp_path: Path, mocker: MockerFixture) -> None:
+    vi = _VersionInfo(major=3, minor=11, micro=0, releaselevel="final", serial=0)
+    info = SubprocessPythonInfo(
+        implementation="cpython",
+        version_info=vi,
+        version="3.11.0",
+        architecture=64,
+        platform=sys.platform,
+        system_executable=sys.executable,
+        free_threaded=False,
+    )
+    session = SubprocessSession(
+        env_dir=tmp_path / "env",
+        bootstrap_python=Path(sys.executable),
+        env_vars={},
+        interpreter=info,
+    )
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter.subprocess.run",
+        return_value=mocker.MagicMock(returncode=1, stderr="error"),
+    )
+    with pytest.raises(RuntimeError, match="virtualenv subprocess failed \\(exit 1\\)"):
+        session.run()
+
+
+def test_subprocess_session_no_interpreter(tmp_path: Path) -> None:
+    session = SubprocessSession(
+        env_dir=tmp_path / "env",
+        bootstrap_python=tmp_path / "bootstrap" / "bin" / "python",
+        env_vars={},
+        interpreter=None,
+    )
+    with pytest.raises(RuntimeError, match="no interpreter discovered"):
+        _ = session.creator
+
+
+def test_bootstrap_path_deterministic(tmp_path: Path) -> None:
+    path1 = _bootstrap_path(tmp_path, "virtualenv<20.22.0")
+    path2 = _bootstrap_path(tmp_path, "virtualenv<20.22.0")
+    path3 = _bootstrap_path(tmp_path, "virtualenv<21.0.0")
+    assert path1 == path2
+    assert path1 != path3
+    assert path1.parent == tmp_path / ".virtualenv-bootstrap"
+
+
+def test_has_correct_virtualenv_nonexistent(tmp_path: Path) -> None:
+    assert _has_correct_virtualenv(tmp_path / "nonexistent", "virtualenv") is False
+
+
+def test_has_correct_virtualenv_matching(tmp_path: Path, mocker: MockerFixture) -> None:
+    python = tmp_path / "python"
+    python.touch()
+    run_mock = mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.subprocess.run")
+    run_mock.return_value = mocker.MagicMock(returncode=0, stdout="20.21.1\n")
+    assert _has_correct_virtualenv(python, "virtualenv<20.22.0") is True
+
+
+def test_has_correct_virtualenv_bare_spec(tmp_path: Path, mocker: MockerFixture) -> None:
+    python = tmp_path / "python"
+    python.touch()
+    run_mock = mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.subprocess.run")
+    run_mock.return_value = mocker.MagicMock(returncode=0, stdout="20.21.1\n")
+    assert _has_correct_virtualenv(python, "virtualenv") is True
+
+
+def test_has_correct_virtualenv_subprocess_fails(tmp_path: Path, mocker: MockerFixture) -> None:
+    python = tmp_path / "python"
+    python.touch()
+    run_mock = mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.subprocess.run")
+    run_mock.return_value = mocker.MagicMock(returncode=1)
+    assert _has_correct_virtualenv(python, "virtualenv<20.22.0") is False
+
+
+def test_has_correct_virtualenv_subprocess_error(tmp_path: Path, mocker: MockerFixture) -> None:
+    python = tmp_path / "python"
+    python.touch()
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter.subprocess.run",
+        side_effect=OSError("boom"),
+    )
+    assert _has_correct_virtualenv(python, "virtualenv<20.22.0") is False
+
+
+def test_ensure_bootstrap_creates_and_caches(tmp_path: Path, mocker: MockerFixture) -> None:
+    venv_create = mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.venv.create")
+    run_mock = mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.subprocess.run")
+    run_mock.return_value = mocker.MagicMock(returncode=0, stdout="20.21.1\n")
+
+    has_correct = mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter._has_correct_virtualenv",
+        side_effect=[False, False, True],
+    )
+
+    result = ensure_bootstrap(tmp_path, "virtualenv<20.22.0")
+    assert result.name == ("python.exe" if sys.platform == "win32" else "python")
+    venv_create.assert_called_once()
+    run_mock.assert_called_once()
+
+    result2 = ensure_bootstrap(tmp_path, "virtualenv<20.22.0")
+    assert result == result2
+    assert has_correct.call_count == 3
+
+
+def test_ensure_bootstrap_race_inside_lock(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter._has_correct_virtualenv",
+        side_effect=[False, True],
+    )
+    result = ensure_bootstrap(tmp_path, "virtualenv<20.22.0")
+    assert result.name == ("python.exe" if sys.platform == "win32" else "python")
+
+
+def test_ensure_bootstrap_removes_stale_base(tmp_path: Path, mocker: MockerFixture) -> None:
+    base = _bootstrap_path(tmp_path, "virtualenv<20.22.0")
+    base.mkdir(parents=True)
+    (base / "stale_file").touch()
+
+    mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.venv.create")
+    run_mock = mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.subprocess.run")
+    run_mock.return_value = mocker.MagicMock(returncode=1, stderr="fail")
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter._has_correct_virtualenv",
+        return_value=False,
+    )
+
+    with pytest.raises(RuntimeError, match="failed to install"):
+        ensure_bootstrap(tmp_path, "virtualenv<20.22.0")
+    assert not (base / "stale_file").exists()
+
+
+def test_ensure_bootstrap_install_failure(tmp_path: Path, mocker: MockerFixture) -> None:
+    mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.venv.create")
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter._has_correct_virtualenv",
+        return_value=False,
+    )
+    run_mock = mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.subprocess.run")
+    run_mock.return_value = mocker.MagicMock(returncode=1, stderr="no matching distribution")
+
+    with pytest.raises(RuntimeError, match="failed to install"):
+        ensure_bootstrap(tmp_path, "virtualenv==999.999.999")
+
+
+def test_virtualenv_spec_config_shown(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            [env_run_base]
+            package = "skip"
+            virtualenv_spec = "virtualenv<20.22.0"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("c", "-e", "py", "-k", "virtualenv_spec")
+    result.assert_success()
+    assert "virtualenv<20.22.0" in result.out
+
+
+def test_virtualenv_spec_cache_includes_spec(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter.ensure_bootstrap",
+        return_value=Path(sys.executable),
+    )
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter.probe_python",
+        return_value=SubprocessPythonInfo(
+            implementation=sys.implementation.name,
+            version_info=_VersionInfo(*sys.version_info[:5]),
+            version=f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            architecture=64,
+            platform=sys.platform,
+            system_executable=sys.executable,
+            free_threaded=False,
+        ),
+    )
+
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            [env_run_base]
+            package = "skip"
+            virtualenv_spec = "virtualenv<20.22.0"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_success()
+
+
+def test_virtualenv_spec_empty_uses_imported(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_success()
+    assert "ok" in result.out


### PR DESCRIPTION
No single virtualenv release covers the full range of Python versions that projects need to test against — older versions like `virtualenv<20.22.0` are required for Python 3.6, while the latest virtualenv is needed for Python 3.15+. Since tox imports virtualenv as a library, environments targeting unsupported Python versions simply fail with no workaround. ✨ This becomes a real blocker for projects that must maintain compatibility across a wide Python version range in a single `tox.toml`.

The new `virtualenv_spec` per-environment config key (e.g. `virtualenv_spec = "virtualenv<20.22.0"`) solves this by bootstrapping the specified virtualenv version into a cached venv under `.tox/.virtualenv-bootstrap/` and driving it via subprocess instead of the imported library. The bootstrap is content-addressed by spec hash, protected by file locks for concurrent safety, and reused across runs. When `virtualenv_spec` is empty (the default), tox continues using the imported virtualenv with zero overhead — the subprocess path only activates when explicitly configured.

The `VirtualEnv` class now operates in dual mode: its `session` property routes to either the imported `session_via_cli` or a new `SubprocessSession` that mimics the same `Session`/`Creator`/`Describe` interface. Path accessors (`bin_dir`, `purelib`, `exe`, etc.) dispatch through `isinstance` checks so both modes integrate transparently with the rest of the environment lifecycle. The `python_cache()` dict includes the spec string when set, ensuring environments are automatically recreated when the pinned version changes.

Closes #3656