### PR TITLE
✨ feat(config): warn on unused config keys with -v

### DIFF
--- a/docs/changelog/3188.feature.rst
+++ b/docs/changelog/3188.feature.rst
@@ -1,0 +1,1 @@
+Warn about unused configuration keys during ``tox run -v`` - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -591,6 +591,27 @@ this is the tool inside the tox environment hitting the missing system package, 
 - Use :pypi:`tox-uv`, which replaces both the environment creation and package installation with :pypi:`uv`, avoiding
   the stdlib :mod:`venv` dependency entirely.
 
+Misplaced configuration keys
+============================
+
+tox configuration is split into two sections: **core** (``[tox]`` / top-level TOML) and **environment** (``[testenv]`` /
+``env_run_base`` in TOML). Options placed in the wrong section are silently ignored because tox cannot distinguish a
+misplaced option from a plugin-defined key that isn't loaded yet (e.g. during provisioning).
+
+To detect misplaced keys:
+
+- Run ``tox run -v`` — unused keys are printed as warnings before the final report.
+- Run ``tox config`` — unused keys appear as ``# !!! unused:`` comments per section.
+
+For example, putting ``ignore_base_python_conflict`` in ``[testenv]`` instead of ``[tox]`` produces:
+
+.. code-block:: text
+
+    [testenv:py] unused config key(s): ignore_base_python_conflict
+
+See the :ref:`Core <conf-core>` and :ref:`tox environment <conf-testenv>` reference sections for which options belong
+where.
+
 ******************
  Related projects
 ******************

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -1010,6 +1010,14 @@ When an environment fails, use these techniques to investigate:
 
        tox run -e 3.13 -r
 
+6. **Check for misplaced config keys**. Options in the wrong section are silently ignored. Use ``-v`` to surface
+   warnings about unrecognized keys, or run ``tox config`` to see ``# !!! unused:`` markers:
+
+   .. code-block:: bash
+
+       tox run -v
+       tox config -e 3.13
+
 .. _run-interactive-programs:
 
 **************************

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -301,7 +301,9 @@ For example:
  Core
 ******
 
-The following options are set in the ``[tox]`` section of ``tox.ini`` or the ``[tox:tox]`` section of ``setup.cfg``.
+The following options are set in the ``[tox]`` section of ``tox.ini``, the ``[tox:tox]`` section of ``setup.cfg``, or
+the top level of ``tox.toml``. Placing these options in an environment section (e.g. ``[testenv]``) has no effect. Run
+``tox config`` or ``tox run -v`` to check for misplaced keys.
 
 .. conf::
     :keys: requires
@@ -485,7 +487,9 @@ Python language core options
  tox environment
 *****************
 
-These are configuration for the tox environments (either packaging or run type).
+These are configuration for the tox environments (either packaging or run type). Set these in ``[testenv]`` (INI),
+``env_run_base`` (TOML), or per-environment sections. Placing these options in the core ``[tox]`` section has no effect.
+Run ``tox config`` or ``tox run -v`` to check for misplaced keys.
 
 Base options
 ============

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -149,6 +149,11 @@ Each tox environment has its own configuration. Settings defined at the base lev
 
 Here the ``lint`` environment overrides the base settings entirely, while ``3.13`` and ``3.12`` inherit from the base.
 
+.. tip::
+
+    Options must go in the correct section — placing a core option in an environment section (or vice versa) silently
+    has no effect. Run ``tox run -v`` or ``tox config`` to check for misplaced keys.
+
 Environment names and Python versions
 =====================================
 

--- a/tests/session/cmd/run/test_unused_config.py
+++ b/tests/session/cmd/run/test_unused_config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tox.pytest import ToxProjectCreator
+
+
+def test_unused_config_testenv_warns_at_verbose(tox_project: ToxProjectCreator) -> None:
+    toml = '[env_run_base]\npackage = "skip"\ncommands = [["python", "-c", ""]]\nbogus_key = "yes"\n'
+    outcome = tox_project({"tox.toml": toml}).run("r", "-v")
+    outcome.assert_success()
+    assert "[testenv:py] unused config key(s): bogus_key" in outcome.out
+
+
+def test_unused_config_core_warns_at_verbose(tox_project: ToxProjectCreator) -> None:
+    toml = 'not_a_real_key = "yes"\n[env_run_base]\npackage = "skip"\ncommands = [["python", "-c", ""]]\n'
+    outcome = tox_project({"tox.toml": toml}).run("r", "-v")
+    outcome.assert_success()
+    assert "[tox] unused config key(s): not_a_real_key" in outcome.out
+
+
+def test_unused_config_no_warning_at_default_verbosity(tox_project: ToxProjectCreator) -> None:
+    toml = '[env_run_base]\npackage = "skip"\ncommands = [["python", "-c", ""]]\nbogus_key = "yes"\n'
+    outcome = tox_project({"tox.toml": toml}).run("r")
+    outcome.assert_success()
+    assert "unused config key" not in outcome.out
+
+
+def test_no_unused_config_warning_when_all_valid(tox_project: ToxProjectCreator) -> None:
+    toml = '[env_run_base]\npackage = "skip"\ncommands = [["python", "-c", ""]]\n'
+    outcome = tox_project({"tox.toml": toml}).run("r", "-v")
+    outcome.assert_success()
+    assert "unused config key" not in outcome.out


### PR DESCRIPTION
Config directives placed in the wrong section (e.g. `ignore_base_python_conflict` in `[testenv]` instead of `[tox]`) are silently ignored. The only way to discover this was via `tox config` and inspecting the `# !!! unused:` markers — something new users are unlikely to know about.

This surfaces unused config key warnings during `tox run -v`, printing them in yellow before the final report. The warnings are gated behind `-v` (one level above default verbosity) so existing workflows are unaffected. This also cannot be an error because unused keys can be legitimate — for example, plugin-defined keys that only exist in a provisioned environment.

Documentation updated across all four Diataxis dimensions:
- **Reference** (`config.rst`): added notes to Core and tox environment section headers clarifying section boundaries
- **Explanation** (`explanation.rst`): new "Misplaced configuration keys" section in Known limitations
- **How-to** (`usage.rst`): added step 6 to troubleshooting guide
- **Tutorial** (`getting-started.rst`): added tip after first section explanation

Fixes #3188