### PR TITLE
✨ feat(toml): add generative env_list via product dict

### DIFF
--- a/docs/changelog/3797.feature.rst
+++ b/docs/changelog/3797.feature.rst
@@ -1,0 +1,2 @@
+Add TOML-native generative ``env_list`` via ``product`` dict syntax -- Cartesian product of factor groups with optional
+range dicts and exclusions - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -199,9 +199,10 @@ detects changes and applies them automatically.
 Open-ended range bounds
 =======================
 
-INI generative environment lists support open-ended ranges like ``py3{10-}`` and ``py3{-13}``. Instead of probing the
-system for available interpreters (which would be slow and environment-dependent), tox tracks the `supported CPython
-versions <https://devguide.python.org/versions/>`_ via two constants:
+Both INI and TOML support generative environment lists with open-ended ranges. INI uses curly-brace syntax
+(``py3{10-}``), while TOML uses range dicts (``{ prefix = "py3", start = 10 }``). Instead of probing the system for
+available interpreters (which would be slow and environment-dependent), tox tracks the `supported CPython versions
+<https://devguide.python.org/versions/>`_ via two constants:
 
 - ``LATEST_PYTHON_MINOR_MIN`` -- the oldest supported CPython minor version (currently **10**, for Python 3.10)
 - ``LATEST_PYTHON_MINOR_MAX`` -- the latest supported CPython minor version (currently **14**, for Python 3.14)

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -102,10 +102,10 @@ Core settings affect all environments or configure how tox itself behaves. They 
        [tox]
        env_list = 3.13, 3.12, lint
 
-The :ref:`env_list` setting defines which environments run by default when you invoke ``tox`` without specifying any. In
-INI format, you can use ranges to avoid listing every version manually — ``3.{10-}`` expands to all Python minor
-versions from 10 up to the latest `supported CPython version <https://devguide.python.org/versions/>`_ known to tox (see
-:ref:`generative-environment-list`). For the full list of core options, see :ref:`conf-core`.
+The :ref:`env_list` setting defines which environments run by default when you invoke ``tox`` without specifying any.
+Both formats support generating environment matrices from factor combinations — INI uses curly-brace expansion
+(``3.{10-}``), while TOML uses ``product`` dicts (``{ product = [{ prefix = "py3", start = 10 }, ["django42"]] }``). See
+:ref:`generative-environment-list` for details. For the full list of core options, see :ref:`conf-core`.
 
 Environment settings
 ====================

--- a/src/tox/config/loader/toml/__init__.py
+++ b/src/tox/config/loader/toml/__init__.py
@@ -122,7 +122,21 @@ class TomlLoader(Loader[TomlTypes]):
 
     @staticmethod
     def to_env_list(value: TomlTypes) -> EnvList:
-        return EnvList(envs=list(TomlLoader.to_list(value, str)))
+        from ._product import expand_product  # noqa: PLC0415
+
+        if not isinstance(value, list):
+            msg = f"env_list must be a list, got {type(value).__name__}"
+            raise TypeError(msg)
+        envs: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                envs.append(item)
+            elif isinstance(item, dict) and "product" in item:
+                envs.extend(expand_product(item))
+            else:
+                msg = f"env_list items must be strings or product dicts, got {type(item).__name__}"
+                raise TypeError(msg)
+        return EnvList(envs=envs)
 
 
 __all__ = [

--- a/src/tox/config/loader/toml/_product.py
+++ b/src/tox/config/loader/toml/_product.py
@@ -1,0 +1,59 @@
+"""Expand TOML product dicts into environment name lists."""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Any
+
+from tox.config.loader.ini.factor import LATEST_PYTHON_MINOR_MAX, LATEST_PYTHON_MINOR_MIN
+
+
+def expand_product(value: dict[str, Any]) -> list[str]:
+    """Expand a product dict into a flat list of environment names.
+
+    :param value: dict with ``product`` (list of factor groups) and optional ``exclude`` (list of env names to skip)
+
+    :returns: list of environment names from the cartesian product of all factor groups, joined with ``-``
+
+    """
+    raw_groups = value["product"]
+    if not isinstance(raw_groups, list):
+        msg = f"product value must be a list of factor groups, got {type(raw_groups).__name__}"
+        raise TypeError(msg)
+    if not raw_groups:
+        return []
+    expanded = [_expand_factor_group(g) for g in raw_groups]
+    exclude = set(value.get("exclude") or [])
+    return [name for combo in product(*expanded) if (name := "-".join(combo)) not in exclude]
+
+
+def _expand_factor_group(group: Any) -> list[str]:
+    if isinstance(group, list):
+        return [str(item) for item in group]
+    if isinstance(group, dict) and "prefix" in group:
+        return _expand_range(group)
+    msg = f"factor group must be a list of strings or a range dict with 'prefix', got {type(group).__name__}"
+    raise TypeError(msg)
+
+
+def _expand_range(range_dict: dict[str, Any]) -> list[str]:
+    prefix: str = str(range_dict["prefix"])
+    has_start = "start" in range_dict
+    has_stop = "stop" in range_dict
+    if not has_start and not has_stop:
+        msg = "range must have at least 'start' or 'stop'"
+        raise TypeError(msg)
+    start = range_dict.get("start", LATEST_PYTHON_MINOR_MIN)
+    stop = range_dict.get("stop", LATEST_PYTHON_MINOR_MAX)
+    if not isinstance(start, int):
+        msg = f"range 'start' must be an integer, got {type(start).__name__}"
+        raise TypeError(msg)
+    if not isinstance(stop, int):
+        msg = f"range 'stop' must be an integer, got {type(stop).__name__}"
+        raise TypeError(msg)
+    return [f"{prefix}{i}" for i in range(start, stop + 1)]
+
+
+__all__ = [
+    "expand_product",
+]

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -24,7 +24,55 @@
     "env_list": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/subs"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/subs"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "product": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": ["prefix"],
+                      "properties": {
+                        "prefix": {
+                          "type": "string"
+                        },
+                        "start": {
+                          "type": "integer"
+                        },
+                        "stop": {
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "description": "factor groups for cartesian product expansion"
+              },
+              "exclude": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "environment names to exclude from product"
+              }
+            },
+            "required": ["product"],
+            "additionalProperties": false
+          }
+        ]
       },
       "description": "define environments to automatically run"
     },

--- a/tests/config/loader/test_toml_loader.py
+++ b/tests/config/loader/test_toml_loader.py
@@ -122,7 +122,7 @@ def test_toml_loader_env_list_ok() -> None:
 
 
 def test_toml_loader_env_list_nok() -> None:
-    with pytest.raises(TypeError, match="1 is not of type 'str'"):
+    with pytest.raises(TypeError, match="env_list items must be strings or product dicts, got int"):
         perform_load(["a", 1], EnvList)
 
 

--- a/tests/config/loader/test_toml_product.py
+++ b/tests/config/loader/test_toml_product.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tox.config.loader.ini.factor import LATEST_PYTHON_MINOR_MAX, LATEST_PYTHON_MINOR_MIN
+from tox.config.loader.toml._product import (
+    _expand_factor_group,  # noqa: PLC2701
+    _expand_range,  # noqa: PLC2701
+    expand_product,  # noqa: PLC2701
+)
+
+if TYPE_CHECKING:
+    from tox.pytest import ToxProjectCreator
+
+
+def test_expand_product_two_groups() -> None:
+    result = expand_product({"product": [["a", "b"], ["x", "y"]]})
+    assert result == ["a-x", "a-y", "b-x", "b-y"]
+
+
+def test_expand_product_three_groups() -> None:
+    result = expand_product({"product": [["a"], ["b", "c"], ["d"]]})
+    assert result == ["a-b-d", "a-c-d"]
+
+
+def test_expand_product_single_group() -> None:
+    result = expand_product({"product": [["a", "b"]]})
+    assert result == ["a", "b"]
+
+
+def test_expand_product_empty() -> None:
+    assert expand_product({"product": []}) == []
+
+
+def test_expand_product_with_exclusion() -> None:
+    result = expand_product({"product": [["a", "b"], ["x", "y"]], "exclude": ["a-y", "b-x"]})
+    assert result == ["a-x", "b-y"]
+
+
+def test_expand_product_exclusion_miss_is_ignored() -> None:
+    result = expand_product({"product": [["a"], ["x"]], "exclude": ["nonexistent"]})
+    assert result == ["a-x"]
+
+
+def test_expand_product_not_list() -> None:
+    with pytest.raises(TypeError, match="product value must be a list"):
+        expand_product({"product": "bad"})
+
+
+def test_expand_factor_group_list() -> None:
+    assert _expand_factor_group(["py312", "py313"]) == ["py312", "py313"]
+
+
+def test_expand_factor_group_range_dict() -> None:
+    assert _expand_factor_group({"prefix": "py3", "start": 12, "stop": 14}) == ["py312", "py313", "py314"]
+
+
+def test_expand_factor_group_bad_type() -> None:
+    with pytest.raises(TypeError, match="factor group must be a list of strings or a range dict"):
+        _expand_factor_group(42)
+
+
+def test_expand_factor_group_dict_no_prefix() -> None:
+    with pytest.raises(TypeError, match="factor group must be a list of strings or a range dict"):
+        _expand_factor_group({"start": 1, "stop": 3})
+
+
+def test_expand_range_closed() -> None:
+    assert _expand_range({"prefix": "py3", "start": 12, "stop": 14}) == ["py312", "py313", "py314"]
+
+
+def test_expand_range_open_stop() -> None:
+    result = _expand_range({"prefix": "py3", "start": 12})
+    assert result == [f"py3{i}" for i in range(12, LATEST_PYTHON_MINOR_MAX + 1)]
+
+
+def test_expand_range_open_start() -> None:
+    result = _expand_range({"prefix": "py3", "stop": 13})
+    assert result == [f"py3{i}" for i in range(LATEST_PYTHON_MINOR_MIN, 14)]
+
+
+def test_expand_range_no_bounds() -> None:
+    with pytest.raises(TypeError, match="range must have at least 'start' or 'stop'"):
+        _expand_range({"prefix": "py3"})
+
+
+def test_expand_range_start_not_int() -> None:
+    with pytest.raises(TypeError, match="range 'start' must be an integer"):
+        _expand_range({"prefix": "py3", "start": "12", "stop": 14})
+
+
+def test_expand_range_stop_not_int() -> None:
+    with pytest.raises(TypeError, match="range 'stop' must be an integer"):
+        _expand_range({"prefix": "py3", "start": 12, "stop": "14"})
+
+
+def test_expand_product_mixed_list_and_range() -> None:
+    result = expand_product({
+        "product": [
+            {"prefix": "py3", "start": 12, "stop": 13},
+            ["django42", "django50"],
+        ],
+    })
+    assert result == ["py312-django42", "py312-django50", "py313-django42", "py313-django50"]
+
+
+def test_product_envs_listed(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                { product = [["py312", "py313"], ["django42", "django50"]] },
+            ]
+
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("l")
+    result.assert_success()
+    for env in ("py312-django42", "py312-django50", "py313-django42", "py313-django50"):
+        assert env in result.out
+
+
+def test_product_mixed_with_literals(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                "lint",
+                { product = [["py312", "py313"], ["django42"]] },
+                "docs",
+            ]
+
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("l")
+    result.assert_success()
+    for env in ("lint", "py312-django42", "py313-django42", "docs"):
+        assert env in result.out
+
+
+def test_product_with_range(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                { product = [{ prefix = "py3", start = 12, stop = 13 }, ["django42"]] },
+            ]
+
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("l")
+    result.assert_success()
+    assert "py312-django42" in result.out
+    assert "py313-django42" in result.out
+
+
+def test_product_with_exclusion(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                { product = [["py312", "py313"], ["django42", "django50"]], exclude = ["py312-django50"] },
+            ]
+
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("l")
+    result.assert_success()
+    assert "py312-django42" in result.out
+    assert "py313-django42" in result.out
+    assert "py313-django50" in result.out
+    assert "py312-django50" not in result.out
+
+
+def test_product_multiple_in_env_list(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                { product = [["py312"], ["django42"]] },
+                { product = [["py313"], ["flask20"]] },
+            ]
+
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("l")
+    result.assert_success()
+    assert "py312-django42" in result.out
+    assert "py313-flask20" in result.out
+
+
+def test_product_deduplication(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                "py312-django42",
+                { product = [["py312"], ["django42"]] },
+            ]
+
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("l")
+    result.assert_success()
+    assert result.out.count("py312-django42") == 1


### PR DESCRIPTION
TOML users have had to manually enumerate every environment in `env_list` when they need a test matrix, while INI users could write concise expressions like `py3{12,13}-django{42,50}`. This gap made TOML configuration verbose and error-prone for projects with large matrices, and was one of the most visible feature disparities between the two formats.

✨ This introduces a TOML-native `product` dict syntax that leverages TOML's type system instead of mimicking INI's string-based brace expansion. Factor groups are expressed as arrays of strings or range dicts, and tox computes the Cartesian product joining combinations with `-`. Range dicts (`{ prefix = "py3", start = 12, stop = 14 }`) generate sequential factors, with open-ended bounds matching INI's `py3{10-}` behavior. An `exclude` key allows skipping specific combinations — a capability not available in INI at all.

```toml
env_list = [
    "lint",
    { product = [
        { prefix = "py3", start = 12, stop = 14 },
        ["django42", "django50"],
    ] },
]
```

Documentation has been updated across all four Diataxis dimensions (tutorial, how-to, reference, explanation) with TOML shown first in all tab pairs. The "TOML feature gaps" section has been renamed to "Format comparison" since generative `env_list` was the last major functional gap — only generative section names remain INI-exclusive. The JSON schema has been extended to validate `product` dicts with their factor groups and optional `exclude` arrays.