### PR TITLE
📝 docs(infra): integrate sphinxcontrib-towncrier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /.*_cache
 /build
 /dist
-/docs/_draft.rst
 /src/tox/version.py
 /toxfile.py
 /Dockerfile

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
  Release History
 #################
 
-.. include:: _draft.rst
+.. towncrier-draft-entries::
 
 .. towncrier release notes start
 

--- a/docs/changelog/3201.doc.rst
+++ b/docs/changelog/3201.doc.rst
@@ -1,0 +1,2 @@
+Integrate ``sphinxcontrib-towncrier`` to render draft changelog entries directly in Sphinx, replacing the manual
+towncrier draft script - by :user:`gaborbernat`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 import re
-import subprocess
-import sys
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
-from subprocess import check_output
 from typing import TYPE_CHECKING, Any
 
 from sphinx.domains.python import PythonDomain
@@ -50,12 +47,13 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_issues",  # :user: and similar roles
     "sphinxcontrib.mermaid",
+    "sphinxcontrib.towncrier.ext",
 ]
 mermaid_output_format = "raw"
 mermaid_d3_zoom = True
 mermaid_height = "auto"
 
-exclude_patterns = ["_build", "changelog/*", "_draft.rst"]
+exclude_patterns = ["_build", "changelog/*"]
 autoclass_content, autodoc_member_order, autodoc_typehints = "class", "bysource", "none"
 autodoc_default_options = {
     "member-order": "bysource",
@@ -93,6 +91,10 @@ issues_github_path = f"{company}/{name}"  # `sphinx-issues` ext
 man_pages = [("man/tox.1", "tox", "virtualenv-based automation of test activities", ["tox-dev"], 1)]
 man_show_urls = True
 
+towncrier_draft_autoversion_mode = "draft"
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = Path(__file__).parent.parent
+
 
 def process_signature(  # noqa: PLR0913
     app: Sphinx,  # noqa: ARG001
@@ -111,13 +113,6 @@ def process_signature(  # noqa: PLR0913
 
 def setup(app: Sphinx) -> None:
     here = Path(__file__).parent
-    # 1. run towncrier
-    root, exe = here.parent, Path(sys.executable)
-    towncrier = exe.with_name(f"towncrier{exe.suffix}")
-    cmd = [str(towncrier), "build", "--draft", "--version", "NEXT"]
-    new = check_output(cmd, cwd=root, text=True, stderr=subprocess.DEVNULL)
-    draft = "" if "No significant changes" in new else new
-    (root / "docs" / "_draft.rst").write_text(draft if draft.endswith("\n") else f"{draft}\n")
 
     class PatchedPythonDomain(PythonDomain):
         def resolve_xref(  # noqa: PLR0913


### PR DESCRIPTION
The `sphinxcontrib-towncrier` package was listed as a docs dependency but never actually wired into the Sphinx configuration. Instead, the `setup()` function in `docs/conf.py` shelled out to `towncrier build --draft`, wrote a generated `_draft.rst` file, and included it via `.. include::`. This required a `.gitignore` entry and an `exclude_patterns` entry to manage the generated file.

This replaces that approach with the `sphinxcontrib.towncrier.ext` extension, which renders draft changelog entries natively via the `towncrier-draft-entries` directive. The draft section only appears in non-release builds (via Sphinx's `.. only:: not is_release` conditional), matching the pattern used by yarl and other aio-libs projects.

**Changes:**
- Added `sphinxcontrib.towncrier.ext` to Sphinx extensions with `towncrier_draft_*` config
- Replaced `.. include:: _draft.rst` in `changelog.rst` with `.. towncrier-draft-entries::` directive
- Removed the manual `towncrier build --draft` script from `setup()` and its unused imports
- Removed `_draft.rst` from `.gitignore` and `exclude_patterns`

Fixes #3201