### PR TITLE
🐛 fix(config): restore factor conditional continuations

### DIFF
--- a/docs/changelog/3796.bugfix.rst
+++ b/docs/changelog/3796.bugfix.rst
@@ -1,0 +1,3 @@
+Fix factor-conditional continuation lines (e.g. ``cov: coverage run \`` / ``!cov: python \`` / ``somefile.py``) where
+different factor prefixes on consecutive continuation lines caused prefixes to be passed as literal command arguments
+instead of being filtered - by :user:`gaborbernat`.

--- a/src/tox/config/loader/ini/__init__.py
+++ b/src/tox/config/loader/ini/__init__.py
@@ -52,14 +52,14 @@ class IniLoader(StrConvert, Loader[str]):
             if not line.startswith("#"):
                 part = _COMMENTS.sub("", line)
                 elements.append(part.replace("\\#", "#"))
-        strip_comments = "\n".join(elements).replace("\r", "").replace("\\\n", "")  # collapse continuation lines
+        strip_comments = "\n".join(elements).replace("\r", "")
         if conf is None:  # conf is None when we're loading the global tox configuration file for the CLI
             factor_filtered = strip_comments  # we don't support factor and replace functionality there
         else:
             factor_filtered = filter_for_env(strip_comments, env_name)  # select matching factors
             if not factor_filtered and strip_comments.strip():
                 raise KeyError(value)
-        return factor_filtered
+        return factor_filtered.replace("\\\n", "")
 
     def build(  # noqa: PLR0913
         self,

--- a/tests/config/loader/ini/test_factor.py
+++ b/tests/config/loader/ini/test_factor.py
@@ -321,6 +321,30 @@ def test_ini_loader_factor_multiline_command(
     assert outcome == result
 
 
+@pytest.mark.parametrize(
+    ("env", "result"),
+    [
+        ("py-cov", "coverage run somefile.py"),
+        ("py-no_cov", "python somefile.py"),
+    ],
+)
+def test_ini_loader_factor_conditional_continuation(
+    mk_ini_conf: Callable[[str], ConfigParser],
+    env: str,
+    result: str,
+    empty_config: Config,
+) -> None:
+    commands = "cov: coverage run \\\n    !cov: python \\\n        somefile.py"
+    loader = IniLoader(
+        section=IniSection(None, "testenv"),
+        parser=mk_ini_conf(f"[tox]\nenvlist=py-cov,py-no_cov\n[testenv]\ncommands={commands}"),
+        overrides=[],
+        core_section=IniSection(None, "tox"),
+    )
+    outcome = loader.load_raw(key="commands", conf=empty_config, env_name=env)
+    assert outcome == result
+
+
 def test_generative_ranges_in_deps(tox_ini_conf: ToxIniCreator) -> None:
     config = tox_ini_conf(
         """


### PR DESCRIPTION
Commit 78eb3948 (#3787) moved continuation line collapsing (`\`) before factor filtering to fix #2912, where factor-specific multiline commands leaked continuation lines into non-matching environments. However, this broke the common pattern of using different factor prefixes on consecutive continuation lines — the collapsed single line caused prefixes like `!cov:` to be passed as literal command arguments instead of being filtered.

```ini
commands =
    cov: coverage run \
    !cov: python \
        somefile.py
```

Running `tox -e py-cov` produced `coverage run '!cov:' python somefile.py` instead of `coverage run somefile.py`.

The fix restores the original order (factor filter first, collapse `\` after) and makes `filter_for_env` continuation-aware. Two flags track whether a kept line has an active backslash chain (`active_continuation`) and whether a filtered-out line's continuation should be skipped (`pending_skip`). An unfactored continuation line is only dropped when it is exclusively reachable through removed factored lines, preserving the fix for #2912 while restoring the conditional continuation pattern from #3796.

Fixes #3796.