### PR TITLE
🐛 fix(pip): pass config_settings to pip for sdist install

### DIFF
--- a/docs/changelog/3125.bugfix.rst
+++ b/docs/changelog/3125.bugfix.rst
@@ -1,0 +1,2 @@
+Pass ``config_settings_build_wheel`` to pip as ``--config-settings`` when installing sdist packages, ensuring the build
+backend receives config settings during pip's internal wheel build - by :user:`gaborbernat`.

--- a/src/tox/tox_env/python/package.py
+++ b/src/tox/tox_env/python/package.py
@@ -41,6 +41,10 @@ class WheelPackage(PythonPathPackageWithDeps):
 class SdistPackage(PythonPathPackageWithDeps):
     """sdist package."""
 
+    def __init__(self, path: Path, deps: Sequence[Requirement], config_settings: dict[str, str] | None = None) -> None:
+        super().__init__(path=path, deps=deps)
+        self.config_settings = config_settings
+
 
 class EditableLegacyPackage(PythonPathPackageWithDeps):
     """legacy editable package."""

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -199,7 +199,7 @@ class Pip(PythonInstallerListDependencies):
         msg = f"changed {of_type}{removed}{added}"
         raise Recreate(msg)
 
-    def _install_list_of_deps(  # noqa: C901
+    def _install_list_of_deps(  # noqa: C901, PLR0912
         self,
         arguments: Sequence[
             Requirement | WheelPackage | SdistPackage | EditableLegacyPackage | EditablePackage | PathPackage
@@ -208,12 +208,15 @@ class Pip(PythonInstallerListDependencies):
         of_type: str,
     ) -> None:
         groups: dict[str, list[str]] = defaultdict(list)
+        config_settings: dict[str, str] = {}
         for arg in arguments:
             if isinstance(arg, Requirement):
                 groups["req"].append(str(arg))
             elif isinstance(arg, (WheelPackage, SdistPackage, EditablePackage)):
                 groups["req"].extend(self._apply_force_deps(arg.deps))
                 groups["pkg"].append(str(arg.path))
+                if isinstance(arg, SdistPackage) and arg.config_settings:
+                    config_settings.update(arg.config_settings)
             elif isinstance(arg, EditableLegacyPackage):
                 groups["req"].extend(self._apply_force_deps(arg.deps))
                 groups["dev_pkg"].append(str(arg.path))
@@ -234,10 +237,11 @@ class Pip(PythonInstallerListDependencies):
                     new_deps.extend(self.constraints.as_root_args)
                     self._execute_installer(new_deps, req_of_type)
         install_args = ["--force-reinstall", "--no-deps"]
+        cs_args = [f"--config-settings={k}={v}" for k, v in config_settings.items()]
         if groups["pkg"]:
             # we intentionally ignore constraints when installing the package itself
             # https://github.com/tox-dev/tox/issues/3550
-            self._execute_installer(install_args + groups["pkg"], of_type)
+            self._execute_installer(install_args + cs_args + groups["pkg"], of_type)
         if groups["dev_pkg"]:
             for entry in groups["dev_pkg"]:
                 install_args.extend(("-e", str(entry)))

--- a/src/tox/tox_env/python/virtual_env/package/pyproject.py
+++ b/src/tox/tox_env/python/virtual_env/package/pyproject.py
@@ -280,7 +280,7 @@ class Pep517VenvPackager(PythonPackageToxEnv, ABC):
                 sdist = self._frontend.build_sdist(sdist_directory=self.pkg_dir, config_settings=config_settings).sdist
                 sdist = create_session_view(sdist, self._package_temp_path)
                 self._package_paths.add(sdist)
-                package = SdistPackage(sdist, deps)
+                package = SdistPackage(sdist, deps, config_settings=self.conf["config_settings_build_wheel"])
         elif of_type == "sdist-wheel":
             wheel = create_session_view(self._build_wheel_via_sdist(for_env), self._package_temp_path)
             self._package_paths.add(wheel)


### PR DESCRIPTION
When `package = sdist`, tox builds an sdist via PEP-517 and then hands it to pip for installation. Pip internally builds a wheel from that sdist, but `config_settings_build_wheel` was never forwarded as `--config-settings` flags. This meant build backends couldn't honor wheel-build config settings during pip's internal build phase, silently ignoring user configuration. The `sdist-wheel` package type wasn't affected since tox builds the wheel directly with config settings in that flow.

The fix threads `config_settings_build_wheel` from the `.pkg` environment through `SdistPackage` and into the pip install command as `--config-settings=KEY=VALUE` flags. This keeps the data flow explicit — config settings travel with the package object rather than requiring the installer to reach back into the package environment's configuration.

Fixes #3125