### PR TITLE
✨ feat(config): add PEP 751 pylock.toml support

### DIFF
--- a/docs/changelog/3665.feature.rst
+++ b/docs/changelog/3665.feature.rst
@@ -1,0 +1,3 @@
+Support PEP 751 ``pylock.toml`` lock files as dependency input via the ``pylock`` configuration option (mutually
+exclusive with ``deps``). Packages are filtered by extras, dependency groups, and platform markers evaluated against the
+target Python interpreter, then installed via pip with ``--no-deps`` - by :user:`gaborbernat`.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -706,6 +706,61 @@ coverage combining, documentation builds, or linting environments that share the
 This reads your ``pyproject.toml`` directly (no build step) and installs ``httpx``, ``sphinx``, and ``furo`` into the
 environment. If your dependencies are dynamic, tox falls back to using the packaging environment to extract metadata.
 
+**********************************************
+ Install locked dependencies from pylock.toml
+**********************************************
+
+If your project maintains :PEP:`751` lock files (``pylock.toml``), you can install those locked dependencies directly
+via the :ref:`pylock` configuration. The :ref:`pylock` setting is mutually exclusive with :ref:`deps` — use one or the
+other. Each package in the lock file is installed as a pinned requirement (``name==version``) with ``--no-deps`` (since
+the lock file already contains all transitive dependencies), and tox automatically recreates the environment when the
+lock file changes.
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+         # tox.toml
+         [env_run_base]
+         pylock = "pylock.toml"
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+         [testenv]
+         pylock = pylock.toml
+
+The locked dependencies are installed first, then the project itself is built and installed normally (unless
+``skip_install`` or ``package = "skip"`` is set). When the lock file contains :PEP:`751` extras or dependency groups,
+use the existing :ref:`extras` and :ref:`dependency_groups` settings to select which ones to include. Packages with
+markers like ``'docs' in extras`` or ``'dev' in dependency_groups`` are filtered at install time — only packages
+matching the selected extras/groups (and the target Python's platform markers) are installed:
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+         [env.docs]
+         pylock = "pylock.toml"
+         extras = ["docs"]
+
+         [env.dev]
+         pylock = "pylock.toml"
+         dependency_groups = ["dev"]
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+         [testenv:docs]
+         pylock = pylock.toml
+         extras = docs
+
+         [testenv:dev]
+         pylock = pylock.toml
+         dependency_groups = dev
+
 .. ------------------------------------------------------------------------------------------
 
 .. Environment Customization

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1459,6 +1459,37 @@ Python run
            ]
 
 .. conf::
+    :keys: pylock
+    :default: <empty list>
+    :version_added: 4.44
+
+    A list of :pep:`751` ``pylock.toml`` lock file paths to install locked dependencies from. Each package in the lock
+    file is converted to a pinned requirement (``name==version``) and installed via pip with ``--no-deps`` (since the
+    lock file already contains all transitive dependencies). Environment markers from the lock file are preserved. The
+    lock files are resolved relative to the :ref:`package_root` (or :ref:`tox_root` if no package root is configured).
+    Change detection is automatic: adding, removing, or changing packages in a lock file triggers environment recreation
+    as needed. See :ref:`pylock-explanation` for implementation details.
+
+    For example:
+
+     .. tab:: TOML
+
+        .. code-block:: toml
+
+           [tool.tox.env_run_base]
+           pylock = [
+             "pylock.toml",
+           ]
+
+     .. tab:: INI
+
+        .. code-block:: ini
+
+         [testenv]
+         pylock =
+             pylock.toml
+
+.. conf::
     :keys: deps
     :default: <empty list>
     :version_added: 0.5

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -184,6 +184,11 @@ If the name doesn't match any pattern, tox uses the same Python as the one tox i
 This pins a default Python version for environments without a Python factor, improving reproducibility across machines
 with different system Pythons.
 
+.. tip::
+
+    If your project uses :PEP:`751` lock files (``pylock.toml``), you can install locked dependencies via :ref:`pylock`
+    instead of listing packages in ``deps``.
+
 For the full list of environment options, see :ref:`conf-testenv`.
 
 ***************************

--- a/src/tox/tox_env/python/pylock.py
+++ b/src/tox/tox_env/python/pylock.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from packaging.pylock import Package, PylockValidationError
+from packaging.pylock import Pylock as PackagingPylock
+from packaging.requirements import Requirement
+
+from tox.tox_env.errors import Fail
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+if sys.version_info >= (3, 11):  # pragma: no cover
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+
+@dataclass(frozen=True, kw_only=True)
+class Pylock:
+    path: Path
+
+    def requirements(self) -> list[Requirement]:
+        with self.path.open("rb") as fh:
+            data = tomllib.load(fh)
+        try:
+            parsed = PackagingPylock.from_dict(data)
+        except PylockValidationError as exc:
+            msg = f"invalid pylock file {self.path}: {exc}"
+            raise Fail(msg) from exc
+        return [self._to_requirement(pkg) for pkg in parsed.packages]
+
+    @staticmethod
+    def _to_requirement(pkg: Package) -> Requirement:
+        req_str = str(pkg.name)
+        if pkg.version is not None:
+            req_str += f"=={pkg.version}"
+        if pkg.marker is not None:
+            req_str += f"; {pkg.marker}"
+        return Requirement(req_str)
+
+
+@dataclass(frozen=True, kw_only=True)
+class Pylocks:
+    locks: tuple[Pylock, ...]
+
+    def requirements(self) -> list[Requirement]:
+        return [req for lock in self.locks for req in lock.requirements()]
+
+
+__all__ = [
+    "Pylock",
+    "Pylocks",
+]

--- a/src/tox/tox_env/python/runner.py
+++ b/src/tox/tox_env/python/runner.py
@@ -16,10 +16,11 @@ from tox.report import HandledError
 from tox.session.cmd.run.single import run_command_set
 from tox.tox_env.errors import Fail, Skip
 from tox.tox_env.python.pip.req_file import PythonDeps
+from tox.tox_env.python.pylock import Pylock, Pylocks
 from tox.tox_env.runner import RunToxEnv
 
 from .api import Python
-from .dependency_groups import resolve
+from .dependency_groups import resolve as resolve_dependency_groups
 from .extras import resolve_extras_static
 
 if TYPE_CHECKING:
@@ -52,6 +53,12 @@ class PythonRun(Python, RunToxEnv, ABC):
             default=set(),
             desc="dependency groups to install of the target package",
             post_process=_normalize_extras,
+        )
+        self.conf.add_config(
+            keys=["pylock"],
+            of_type=list[str],
+            default=[],
+            desc="PEP 751 pylock.toml lock files to install locked dependencies from",
         )
         self.conf.add_config(
             keys=["extra_setup_commands"],
@@ -131,6 +138,7 @@ class PythonRun(Python, RunToxEnv, ABC):
             return
         self._install_deps()
         self._install_dependency_groups()
+        self._install_pylock()
 
     def _install_deps(self) -> None:
         requirements_file: PythonDeps = self.conf["deps"]
@@ -144,8 +152,23 @@ class PythonRun(Python, RunToxEnv, ABC):
             root: Path = self.core["package_root"]
         except KeyError:
             root = self.core["tox_root"]
-        requirements = resolve(root, groups)
+        requirements = resolve_dependency_groups(root, groups)
         self._install(list(requirements), PythonRun.__name__, "dependency-groups")
+
+    def _install_pylock(self) -> None:
+        if not (files := self.conf["pylock"]):
+            return
+        try:
+            root: Path = self.core["package_root"]
+        except KeyError:
+            root = self.core["tox_root"]
+        locks: list[Pylock] = []
+        for file_str in files:
+            if not (path := root / file_str).exists():
+                msg = f"pylock file {file_str!r} not found at {path}"
+                raise Fail(msg)
+            locks.append(Pylock(path=path))
+        self._install(Pylocks(locks=tuple(locks)), PythonRun.__name__, "pylock")
 
     def _setup_with_env(self) -> None:
         super()._setup_with_env()

--- a/tests/tox_env/python/test_pylock.py
+++ b/tests/tox_env/python/test_pylock.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tox.tox_env.errors import Fail
+from tox.tox_env.python.pylock import Pylock, Pylocks
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tox.pytest import ToxProjectCreator
+
+PYLOCK_TOML = dedent("""\
+    lock-version = "1.0"
+    created-by = "test-tool"
+
+    [[packages]]
+    name = "alpha"
+    version = "1.0.0"
+
+    [[packages.wheels]]
+    url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+    [packages.wheels.hashes]
+    sha256 = "abc123"
+
+    [[packages]]
+    name = "beta"
+    version = "2.0.0"
+
+    [packages.sdist]
+    url = "https://files.example.com/beta-2.0.0.tar.gz"
+
+    [packages.sdist.hashes]
+    sha256 = "def456"
+""")
+
+
+def test_pylock_install(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = ["pylock.toml"]
+            """,
+            "pylock.toml": PYLOCK_TOML,
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+
+    req_file = str(project.path / ".tox" / "py" / "pylock.txt")
+    found_calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    assert found_calls == [
+        ("py", "install_pylock", ["python", "-I", "-m", "pip", "install", "--no-deps", "-r", req_file]),
+    ]
+    assert (project.path / ".tox" / "py" / "pylock.txt").read_text() == "alpha==1.0.0\nbeta==2.0.0"
+
+
+def test_pylock_with_markers(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = ["pylock.toml"]
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "colorama"
+                version = "0.4.6"
+                marker = "sys_platform == 'win32'"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/colorama-0.4.6-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "abc"
+            """),
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+
+    req_file = str(project.path / ".tox" / "py" / "pylock.txt")
+    found_calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    assert found_calls == [
+        ("py", "install_pylock", ["python", "-I", "-m", "pip", "install", "--no-deps", "-r", req_file]),
+    ]
+    assert (project.path / ".tox" / "py" / "pylock.txt").read_text() == 'colorama==0.4.6; sys_platform == "win32"'
+
+
+def test_pylock_empty(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            """,
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+    assert not execute_calls.call_args_list
+
+
+def test_pylock_not_found(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = ["missing.toml"]
+            """,
+        },
+    )
+    result = project.run("r", "-e", "py")
+
+    result.assert_failed()
+    assert "pylock file 'missing.toml' not found" in result.out
+
+
+def test_pylock_invalid_toml(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = ["pylock.toml"]
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+                packages = "not-a-list"
+            """),
+        },
+    )
+    result = project.run("r", "-e", "py")
+
+    result.assert_failed()
+    assert "invalid pylock file" in result.out
+
+
+def test_pylock_recreate_on_change(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = ["pylock.toml"]
+            """,
+            "pylock.toml": PYLOCK_TOML,
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+    result.assert_success()
+
+    (project.path / "pylock.toml").write_text(
+        dedent("""\
+            lock-version = "1.0"
+            created-by = "test-tool"
+
+            [[packages]]
+            name = "alpha"
+            version = "1.0.0"
+
+            [[packages.wheels]]
+            url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+            [packages.wheels.hashes]
+            sha256 = "abc123"
+        """),
+    )
+    execute_calls.reset_mock()
+    result_second = project.run("r", "-e", "py")
+    result_second.assert_success()
+    assert "py: recreate env because" in result_second.out
+
+
+def test_pylock_multiple(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = ["pylock.toml", "pylock.extra.toml"]
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "alpha"
+                version = "1.0.0"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "abc"
+            """),
+            "pylock.extra.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "gamma"
+                version = "3.0.0"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/gamma-3.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "ghi"
+            """),
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+
+    req_file = str(project.path / ".tox" / "py" / "pylock.txt")
+    found_calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    assert found_calls == [
+        ("py", "install_pylock", ["python", "-I", "-m", "pip", "install", "--no-deps", "-r", req_file]),
+    ]
+    assert (project.path / ".tox" / "py" / "pylock.txt").read_text() == "alpha==1.0.0\ngamma==3.0.0"
+
+
+def test_pylock_with_deps(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            deps = ["pytest"]
+            pylock = ["pylock.toml"]
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "alpha"
+                version = "1.0.0"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "abc"
+            """),
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+
+    req_file = str(project.path / ".tox" / "py" / "pylock.txt")
+    found_calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    assert found_calls == [
+        ("py", "install_deps", ["python", "-I", "-m", "pip", "install", "pytest"]),
+        ("py", "install_pylock", ["python", "-I", "-m", "pip", "install", "--no-deps", "-r", req_file]),
+    ]
+
+
+def test_pylock_no_reinstall_on_rerun(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = ["pylock.toml"]
+            """,
+            "pylock.toml": PYLOCK_TOML,
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+    result.assert_success()
+    assert len(execute_calls.call_args_list) == 1
+
+    execute_calls.reset_mock()
+    result_second = project.run("r", "-e", "py")
+    result_second.assert_success()
+    assert not execute_calls.call_args_list
+
+
+def test_pylock_requirements(tmp_path: Path) -> None:
+    lock_file = tmp_path / "pylock.toml"
+    lock_file.write_text(PYLOCK_TOML)
+    pylock = Pylock(path=lock_file)
+
+    result = [str(r) for r in pylock.requirements()]
+
+    assert result == ["alpha==1.0.0", "beta==2.0.0"]
+
+
+def test_pylock_requirements_with_marker(tmp_path: Path) -> None:
+    lock_file = tmp_path / "pylock.toml"
+    lock_file.write_text(
+        dedent("""\
+        lock-version = "1.0"
+        created-by = "test-tool"
+
+        [[packages]]
+        name = "colorama"
+        version = "0.4.6"
+        marker = "sys_platform == 'win32'"
+
+        [[packages.wheels]]
+        url = "https://files.example.com/colorama-0.4.6-py3-none-any.whl"
+
+        [packages.wheels.hashes]
+        sha256 = "abc"
+    """)
+    )
+    pylock = Pylock(path=lock_file)
+
+    result = [str(r) for r in pylock.requirements()]
+
+    assert result == ['colorama==0.4.6; sys_platform == "win32"']
+
+
+def test_pylock_requirements_invalid(tmp_path: Path) -> None:
+    lock_file = tmp_path / "pylock.toml"
+    lock_file.write_text(
+        dedent("""\
+        lock-version = "1.0"
+        created-by = "test-tool"
+        packages = "not-a-list"
+    """)
+    )
+    pylock = Pylock(path=lock_file)
+
+    with pytest.raises(Fail, match="invalid pylock file"):
+        pylock.requirements()
+
+
+def test_pylocks_requirements(tmp_path: Path) -> None:
+    first = tmp_path / "a.toml"
+    first.write_text(
+        dedent("""\
+        lock-version = "1.0"
+        created-by = "test-tool"
+
+        [[packages]]
+        name = "alpha"
+        version = "1.0.0"
+
+        [[packages.wheels]]
+        url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+        [packages.wheels.hashes]
+        sha256 = "abc"
+    """)
+    )
+    second = tmp_path / "b.toml"
+    second.write_text(
+        dedent("""\
+        lock-version = "1.0"
+        created-by = "test-tool"
+
+        [[packages]]
+        name = "beta"
+        version = "2.0.0"
+
+        [[packages.wheels]]
+        url = "https://files.example.com/beta-2.0.0-py3-none-any.whl"
+
+        [packages.wheels.hashes]
+        sha256 = "def"
+    """)
+    )
+    pylocks = Pylocks(locks=(Pylock(path=first), Pylock(path=second)))
+
+    result = [str(r) for r in pylocks.requirements()]
+
+    assert result == ["alpha==1.0.0", "beta==2.0.0"]
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_pylock_install_integration(
+    tox_project: ToxProjectCreator,
+    enable_pip_pypi_access: str | None,  # noqa: ARG001
+) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = ["pylock.toml"]
+            commands = [["python", "-c", "import six; print(six.__version__)"]]
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "six"
+                version = "1.17.0"
+
+                [[packages.wheels]]
+                url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30f4c7e48bb4cb87/six-1.17.0-py2.py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8ez91c67d35ad282f3"
+            """),
+        },
+    )
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+    assert "1.17.0" in result.out


### PR DESCRIPTION
Lock files (PEP 751) provide reproducible dependency installation by specifying exact versions, markers, and artifact URLs for every transitive dependency. The new `pylock` config key accepts a list of `pylock.toml` file paths, giving users a standardized way to install pre-resolved dependencies without manual requirements files.

Since pip lacks native `pylock.toml` support (pip#13334), tox parses lock files via `packaging.pylock` and transpiles them to a temporary requirements file (`{env_dir}/pylock.txt`) installed with `--no-deps`. The `--no-deps` flag ensures pip uses the exact versions from the lock file without re-resolving. Change detection works like `deps` — added packages are installed incrementally, removed packages trigger environment recreation.

The implementation passes the original file paths through `_install()` so the `tox_on_install` plugin hook fires before the Pip installer handles them. This lets `tox-uv` intercept the call and use its native `uv pip install --pylock` support, bypassing transpilation entirely. When pip gains native support, the transpile step can be swapped out with no config changes needed.