### PR TITLE
✨ feat(config): add PEP 751 pylock.toml support

### DIFF
--- a/docs/changelog/3665.feature.rst
+++ b/docs/changelog/3665.feature.rst
@@ -1,0 +1,3 @@
+Support PEP 751 ``pylock.toml`` lock files as dependency input via the ``pylock`` configuration option (mutually
+exclusive with ``deps``). Packages are filtered by extras, dependency groups, and platform markers evaluated against the
+target Python interpreter, then installed via pip with ``--no-deps`` - by :user:`gaborbernat`.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -706,6 +706,61 @@ coverage combining, documentation builds, or linting environments that share the
 This reads your ``pyproject.toml`` directly (no build step) and installs ``httpx``, ``sphinx``, and ``furo`` into the
 environment. If your dependencies are dynamic, tox falls back to using the packaging environment to extract metadata.
 
+**********************************************
+ Install locked dependencies from pylock.toml
+**********************************************
+
+If your project maintains :PEP:`751` lock files (``pylock.toml``), you can install those locked dependencies directly
+via the :ref:`pylock` configuration. The :ref:`pylock` setting is mutually exclusive with :ref:`deps` — use one or the
+other. Each package in the lock file is installed as a pinned requirement (``name==version``) with ``--no-deps`` (since
+the lock file already contains all transitive dependencies), and tox automatically recreates the environment when the
+lock file changes.
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+         # tox.toml
+         [env_run_base]
+         pylock = "pylock.toml"
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+         [testenv]
+         pylock = pylock.toml
+
+The locked dependencies are installed first, then the project itself is built and installed normally (unless
+``skip_install`` or ``package = "skip"`` is set). When the lock file contains :PEP:`751` extras or dependency groups,
+use the existing :ref:`extras` and :ref:`dependency_groups` settings to select which ones to include. Packages with
+markers like ``'docs' in extras`` or ``'dev' in dependency_groups`` are filtered at install time — only packages
+matching the selected extras/groups (and the target Python's platform markers) are installed:
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+         [env.docs]
+         pylock = "pylock.toml"
+         extras = ["docs"]
+
+         [env.dev]
+         pylock = "pylock.toml"
+         dependency_groups = ["dev"]
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+         [testenv:docs]
+         pylock = pylock.toml
+         extras = docs
+
+         [testenv:dev]
+         pylock = pylock.toml
+         dependency_groups = dev
+
 .. ------------------------------------------------------------------------------------------
 
 .. Environment Customization

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1459,6 +1459,34 @@ Python run
            ]
 
 .. conf::
+    :keys: pylock
+    :default: <empty string>
+    :version_added: 4.44
+
+    Path to a :pep:`751` ``pylock.toml`` lock file to install locked dependencies from. Mutually exclusive with
+    :ref:`deps`. Each package in the lock file is filtered by evaluating its environment markers against the target
+    Python interpreter and the configured :ref:`extras` and :ref:`dependency_groups`, then converted to a pinned
+    requirement (``name==version``) and installed via pip with ``--no-deps``. The path is resolved relative to the
+    :ref:`package_root` (or :ref:`tox_root` if no package root is configured). Change detection is automatic: adding,
+    removing, or changing packages triggers environment recreation as needed. See :ref:`pylock-explanation` for details.
+
+    For example:
+
+     .. tab:: TOML
+
+        .. code-block:: toml
+
+           [tool.tox.env_run_base]
+           pylock = "pylock.toml"
+
+     .. tab:: INI
+
+        .. code-block:: ini
+
+         [testenv]
+         pylock = pylock.toml
+
+.. conf::
     :keys: deps
     :default: <empty list>
     :version_added: 0.5

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -184,6 +184,11 @@ If the name doesn't match any pattern, tox uses the same Python as the one tox i
 This pins a default Python version for environments without a Python factor, improving reproducibility across machines
 with different system Pythons.
 
+.. tip::
+
+    If your project uses :PEP:`751` lock files (``pylock.toml``), you can install locked dependencies via :ref:`pylock`
+    instead of listing packages in ``deps``.
+
 For the full list of environment options, see :ref:`conf-testenv`.
 
 ***************************

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -18,6 +18,7 @@ from tox.tox_env.installer import Installer
 from tox.tox_env.python.api import Python
 from tox.tox_env.python.package import EditableLegacyPackage, EditablePackage, SdistPackage, WheelPackage
 from tox.tox_env.python.pip.req_file import PythonConstraints, PythonDeps
+from tox.tox_env.python.pylock import Pylock
 
 if TYPE_CHECKING:
     from tox.config.main import Config
@@ -114,6 +115,8 @@ class Pip(PythonInstallerListDependencies):
     def install(self, arguments: Any, section: str, of_type: str) -> None:
         if isinstance(arguments, PythonDeps):
             self._install_requirement_file(arguments, section, of_type)
+        elif isinstance(arguments, Pylock):
+            self._install_pylock(arguments, section, of_type)
         elif isinstance(arguments, Sequence):
             self._install_list_of_deps(arguments, section, of_type)
         else:
@@ -198,6 +201,19 @@ class Pip(PythonInstallerListDependencies):
         added = f" added {', '.join(sorted(fmt(i) for i in added_opts))}" if added_opts else ""
         msg = f"changed {of_type}{removed}{added}"
         raise Recreate(msg)
+
+    def _install_pylock(self, pylock: Pylock, section: str, of_type: str) -> None:
+        requirements = pylock.requirements()
+        new_reqs = sorted(str(r) for r in requirements)
+        with self._env.cache.compare(new_reqs, section, of_type) as (eq, old):
+            if not eq:
+                if old is not None and (missing := sorted(set(old) - set(new_reqs))):
+                    msg = f"pylock dependencies removed: {' '.join(missing)}"
+                    raise Recreate(msg)
+                if new_deps := sorted(set(new_reqs) - set(old or [])):
+                    req_file = Path(self._env.env_dir) / "pylock.txt"
+                    req_file.write_text("\n".join(new_deps))
+                    self._execute_installer(["--no-deps", "-r", str(req_file)], of_type)
 
     def _install_list_of_deps(  # noqa: C901, PLR0912
         self,

--- a/src/tox/tox_env/python/pylock.py
+++ b/src/tox/tox_env/python/pylock.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from packaging.pylock import Package, PylockValidationError
+from packaging.pylock import Pylock as PackagingPylock
+from packaging.requirements import Requirement
+
+from tox.tox_env.errors import Fail
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+if sys.version_info >= (3, 11):  # pragma: no cover
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+
+@dataclass(frozen=True, kw_only=True)
+class Pylock:
+    path: Path
+    extras: frozenset[str] = frozenset()
+    groups: frozenset[str] = frozenset()
+    marker_env: dict[str, str] = field(default_factory=dict)
+
+    def requirements(self) -> list[Requirement]:
+        with self.path.open("rb") as fh:
+            data = tomllib.load(fh)
+        try:
+            parsed = PackagingPylock.from_dict(data)
+        except PylockValidationError as exc:
+            msg = f"invalid pylock file {self.path}: {exc}"
+            raise Fail(msg) from exc
+        env: dict[str, str | frozenset[str]] = {**self.marker_env}
+        if self.extras:
+            env["extras"] = self.extras
+        if self.groups:
+            env["dependency_groups"] = self.groups
+        return [
+            self._to_requirement(pkg)
+            for pkg in parsed.packages
+            if pkg.marker is None or pkg.marker.evaluate(env, context="lock_file")
+        ]
+
+    @staticmethod
+    def _to_requirement(pkg: Package) -> Requirement:
+        req_str = str(pkg.name)
+        if pkg.version is not None:
+            req_str += f"=={pkg.version}"
+        return Requirement(req_str)
+
+
+__all__ = [
+    "Pylock",
+]

--- a/tests/tox_env/python/test_pylock.py
+++ b/tests/tox_env/python/test_pylock.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import sys
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tox.tox_env.errors import Fail
+from tox.tox_env.python.pylock import Pylock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tox.pytest import ToxProjectCreator
+
+PYLOCK_TOML = dedent("""\
+    lock-version = "1.0"
+    created-by = "test-tool"
+
+    [[packages]]
+    name = "alpha"
+    version = "1.0.0"
+
+    [[packages.wheels]]
+    url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+    [packages.wheels.hashes]
+    sha256 = "abc123"
+
+    [[packages]]
+    name = "beta"
+    version = "2.0.0"
+
+    [packages.sdist]
+    url = "https://files.example.com/beta-2.0.0.tar.gz"
+
+    [packages.sdist.hashes]
+    sha256 = "def456"
+""")
+
+
+def test_pylock_install(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = "pylock.toml"
+            """,
+            "pylock.toml": PYLOCK_TOML,
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+
+    req_file = str(project.path / ".tox" / "py" / "pylock.txt")
+    found_calls = [(i[0][0].conf.name, i[0][3].run_id, i[0][3].cmd) for i in execute_calls.call_args_list]
+    assert found_calls == [
+        ("py", "install_pylock", ["python", "-I", "-m", "pip", "install", "--no-deps", "-r", req_file]),
+    ]
+    assert (project.path / ".tox" / "py" / "pylock.txt").read_text() == "alpha==1.0.0\nbeta==2.0.0"
+
+
+def test_pylock_empty(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            """,
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+    assert not execute_calls.call_args_list
+
+
+def test_pylock_not_found(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = "missing.toml"
+            """,
+        },
+    )
+    result = project.run("r", "-e", "py")
+
+    result.assert_failed()
+    assert "pylock file 'missing.toml' not found" in result.out
+
+
+def test_pylock_invalid_toml(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = "pylock.toml"
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+                packages = "not-a-list"
+            """),
+        },
+    )
+    result = project.run("r", "-e", "py")
+
+    result.assert_failed()
+    assert "invalid pylock file" in result.out
+
+
+def test_pylock_mutually_exclusive_with_deps(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            deps = ["pytest"]
+            pylock = "pylock.toml"
+            """,
+            "pylock.toml": PYLOCK_TOML,
+        },
+    )
+    result = project.run("r", "-e", "py")
+
+    result.assert_failed()
+    assert "cannot use both 'deps' and 'pylock'" in result.out
+
+
+def test_pylock_recreate_on_change(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = "pylock.toml"
+            """,
+            "pylock.toml": PYLOCK_TOML,
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+    result.assert_success()
+
+    (project.path / "pylock.toml").write_text(
+        dedent("""\
+            lock-version = "1.0"
+            created-by = "test-tool"
+
+            [[packages]]
+            name = "alpha"
+            version = "1.0.0"
+
+            [[packages.wheels]]
+            url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+            [packages.wheels.hashes]
+            sha256 = "abc123"
+        """),
+    )
+    execute_calls.reset_mock()
+    result_second = project.run("r", "-e", "py")
+    result_second.assert_success()
+    assert "py: recreate env because" in result_second.out
+
+
+def test_pylock_no_reinstall_on_rerun(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = "pylock.toml"
+            """,
+            "pylock.toml": PYLOCK_TOML,
+        },
+    )
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+    result.assert_success()
+    assert len(execute_calls.call_args_list) == 1
+
+    execute_calls.reset_mock()
+    result_second = project.run("r", "-e", "py")
+    result_second.assert_success()
+    assert not execute_calls.call_args_list
+
+
+def test_pylock_filters_by_extras(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = "pylock.toml"
+            extras = ["docs"]
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+                extras = ["docs", "test"]
+
+                [[packages]]
+                name = "alpha"
+                version = "1.0.0"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "abc"
+
+                [[packages]]
+                name = "sphinx"
+                version = "7.0.0"
+                marker = "'docs' in extras"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/sphinx-7.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "def"
+
+                [[packages]]
+                name = "pytest"
+                version = "8.0.0"
+                marker = "'test' in extras"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/pytest-8.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "ghi"
+            """),
+        },
+    )
+    project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+    assert (project.path / ".tox" / "py" / "pylock.txt").read_text() == "alpha==1.0.0\nsphinx==7.0.0"
+
+
+def test_pylock_filters_by_dependency_groups(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = "pylock.toml"
+            dependency_groups = ["dev"]
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+                dependency-groups = ["dev", "ci"]
+
+                [[packages]]
+                name = "alpha"
+                version = "1.0.0"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "abc"
+
+                [[packages]]
+                name = "ruff"
+                version = "0.5.0"
+                marker = "'dev' in dependency_groups"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/ruff-0.5.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "def"
+
+                [[packages]]
+                name = "coverage"
+                version = "7.0.0"
+                marker = "'ci' in dependency_groups"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/coverage-7.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "ghi"
+            """),
+        },
+    )
+    project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+    assert (project.path / ".tox" / "py" / "pylock.txt").read_text() == "alpha==1.0.0\nruff==0.5.0"
+
+
+def test_pylock_filters_by_platform_marker(tox_project: ToxProjectCreator) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = "pylock.toml"
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "alpha"
+                version = "1.0.0"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "abc"
+
+                [[packages]]
+                name = "linuxonly"
+                version = "1.0.0"
+                marker = "sys_platform == 'linux'"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/linuxonly-1.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "def"
+
+                [[packages]]
+                name = "winonly"
+                version = "1.0.0"
+                marker = "sys_platform == 'win32'"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/winonly-1.0.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "ghi"
+            """),
+        },
+    )
+    project.patch_execute()
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+    content = (project.path / ".tox" / "py" / "pylock.txt").read_text()
+    assert "alpha==1.0.0" in content
+    if sys.platform == "win32":
+        assert "winonly==1.0.0" in content
+        assert "linuxonly" not in content
+    elif sys.platform == "linux":
+        assert "linuxonly==1.0.0" in content
+        assert "winonly" not in content
+    else:
+        assert "linuxonly" not in content
+        assert "winonly" not in content
+
+
+def test_pylock_requirements(tmp_path: Path) -> None:
+    lock_file = tmp_path / "pylock.toml"
+    lock_file.write_text(PYLOCK_TOML)
+    pylock = Pylock(path=lock_file)
+
+    result = [str(r) for r in pylock.requirements()]
+
+    assert result == ["alpha==1.0.0", "beta==2.0.0"]
+
+
+def test_pylock_requirements_filters_extras(tmp_path: Path) -> None:
+    lock_file = tmp_path / "pylock.toml"
+    lock_file.write_text(
+        dedent("""\
+        lock-version = "1.0"
+        created-by = "test-tool"
+        extras = ["docs"]
+
+        [[packages]]
+        name = "alpha"
+        version = "1.0.0"
+
+        [[packages.wheels]]
+        url = "https://files.example.com/alpha-1.0.0-py3-none-any.whl"
+
+        [packages.wheels.hashes]
+        sha256 = "abc"
+
+        [[packages]]
+        name = "sphinx"
+        version = "7.0.0"
+        marker = "'docs' in extras"
+
+        [[packages.wheels]]
+        url = "https://files.example.com/sphinx-7.0.0-py3-none-any.whl"
+
+        [packages.wheels.hashes]
+        sha256 = "def"
+    """),
+    )
+
+    with_extras = [str(r) for r in Pylock(path=lock_file, extras=frozenset({"docs"})).requirements()]
+    assert with_extras == ["alpha==1.0.0", "sphinx==7.0.0"]
+
+    without_extras = [str(r) for r in Pylock(path=lock_file).requirements()]
+    assert without_extras == ["alpha==1.0.0"]
+
+
+def test_pylock_requirements_invalid(tmp_path: Path) -> None:
+    lock_file = tmp_path / "pylock.toml"
+    lock_file.write_text(
+        dedent("""\
+        lock-version = "1.0"
+        created-by = "test-tool"
+        packages = "not-a-list"
+    """),
+    )
+    pylock = Pylock(path=lock_file)
+
+    with pytest.raises(Fail, match="invalid pylock file"):
+        pylock.requirements()
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_pylock_install_integration(
+    tox_project: ToxProjectCreator,
+    enable_pip_pypi_access: str | None,  # noqa: ARG001
+) -> None:
+    project = tox_project(
+        {
+            "tox.toml": """
+            [env_run_base]
+            skip_install = true
+            pylock = "pylock.toml"
+            commands = [["python", "-c", "import six; print(six.__version__)"]]
+            """,
+            "pylock.toml": dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "six"
+                version = "1.17.0"
+
+                [[packages.wheels]]
+                url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30f4c7e48bb4cb87/six-1.17.0-py2.py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8ez91c67d35ad282f3"
+            """),
+        },
+    )
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+    assert "1.17.0" in result.out


### PR DESCRIPTION
Projects using PEP 751 lock files had no way to feed those locked dependencies into tox environments — users had to manually extract requirements or maintain parallel `deps` lists, defeating the purpose of a lock file.

The new `pylock` config option accepts a path to a `pylock.toml` file and installs its packages as pinned requirements (`name==version`) with `--no-deps`. It is mutually exclusive with `deps` since a lock file already contains all transitive dependencies. 🔒 When the lock file declares extras or dependency groups, the existing `extras` and `dependency_groups` settings select which ones to include — package markers like `'docs' in extras` are evaluated against the **target** Python interpreter's platform and version, not the host running tox. The project itself is still built and installed normally after locked dependencies are in place.

The `Pylock` dataclass is passed through the `tox_on_install` plugin hook, so installer plugins can inspect it via `isinstance(arguments, Pylock)` and handle lock files natively (e.g. `uv pip install --pylock`) instead of relying on the pip transpile path. ✨ When pip gains native `pylock.toml` support, the transpile step can be swapped out with no user-facing config changes. The system overview diagram and lifecycle docs have been updated to reflect the new dependency installation branch.

Fixes #3665