### PR TITLE
🐛 fix(type): resolve ty 0.0.17 compatibility

### DIFF
--- a/docs/tox_conf.py
+++ b/docs/tox_conf.py
@@ -10,8 +10,6 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.logging import getLogger
 
 if TYPE_CHECKING:
-    from typing import Final
-
     from docutils.parsers.rst.states import RSTState, RSTStateMachine
     from sphinx.domains.std import StandardDomain
 
@@ -21,7 +19,7 @@ LOGGER = getLogger(__name__)
 class ToxConfig(SphinxDirective):
     name = "conf"
     has_content = True
-    option_spec: Final[ClassVar[dict[str, Any]]] = {
+    option_spec: ClassVar[dict[str, Any]] = {
         "keys": unchanged_required,
         "version_added": unchanged,
         "version_deprecated": unchanged,

--- a/src/tox/config/of_type.py
+++ b/src/tox/config/of_type.py
@@ -58,7 +58,7 @@ class ConfigConstantDefinition(ConfigDefinition[T]):  # noqa: PLW1641
         loaders: list[Loader[T]],  # noqa: ARG002
         args: ConfigLoadArgs,  # noqa: ARG002
     ) -> T:
-        return self.value() if callable(self.value) else self.value
+        return self.value() if callable(self.value) else self.value  # ty: ignore[call-top-callable]
 
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, ConfigConstantDefinition):
@@ -118,7 +118,7 @@ class ConfigDynamicDefinition(ConfigDefinition[T]):  # noqa: PLW1641
                 finally:
                     del args.chain[-1]
             else:
-                value = self.default(conf, args.env_name) if callable(self.default) else self.default
+                value = self.default(conf, args.env_name) if callable(self.default) else self.default  # ty: ignore[call-top-callable]
             if self.post_process is not None:
                 value = self.post_process(value)
             self._cache = value


### PR DESCRIPTION
ty 0.0.17 introduced new diagnostics that cause CI failures. The `redundant-final-classvar` warning flags `Final[ClassVar[...]]` in `docs/tox_conf.py` since `Final` already implies class-level scope, making `ClassVar` redundant. The `call-top-callable` errors in `src/tox/config/of_type.py` arise because `callable()` cannot statically narrow `Callable[[], T] | T` when `T` is an unconstrained type variable — the value could itself be callable, so ty can't determine the call signature.

Removed the redundant `Final` wrapper and added `ty: ignore[call-top-callable]` suppressions for the two `callable()` guards, which are a valid runtime pattern that ty cannot verify statically.