### PR TITLE
📝 docs: add redirects for old URLs (#3806)

### DIFF
--- a/docs/changelog/3806.bugfix.rst
+++ b/docs/changelog/3806.bugfix.rst
@@ -1,0 +1,3 @@
+Add redirects for old documentation URLs that broke after the Diataxis restructure (e.g. ``/config.html`` ->
+``/reference/config.html``, ``/example/general.html`` -> ``/index.html``) using ``sphinx-reredirects`` - by
+:user:`gaborbernat`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx_issues",  # :user: and similar roles
     "sphinxcontrib.mermaid",
     "sphinxcontrib.towncrier.ext",
+    "sphinx_reredirects",
 ]
 mermaid_output_format = "raw"
 mermaid_d3_zoom = True
@@ -90,6 +91,34 @@ issues_github_path = f"{company}/{name}"  # `sphinx-issues` ext
 # Man page configuration
 man_pages = [("man/tox.1", "tox", "virtualenv-based automation of test activities", ["tox-dev"], 1)]
 man_show_urls = True
+
+redirects = {
+    "config": "reference/config.html",
+    "cli_interface": "reference/cli.html",
+    "user_guide": "explanation.html",
+    "installation": "how-to/install.html",
+    "howto": "how-to/usage.html",
+    "getting_started": "tutorial/getting-started.html",
+    "plugins": "plugin/index.html",
+    "plugins_api": "plugin/api.html",
+    "plugins/index": "plugin/index.html",
+    "plugins/api": "plugin/api.html",
+    "plugins/getting_started": "plugin/getting_started.html",
+    "plugins/howto": "plugin/howto.html",
+    "upgrading": "index.html",
+    "faq": "index.html",
+    "example/general": "index.html",
+    "example/basic": "index.html",
+    "example/devenv": "index.html",
+    "example/documentation": "index.html",
+    "example/jenkins": "index.html",
+    "example/nose": "index.html",
+    "example/package": "index.html",
+    "example/platform": "index.html",
+    "example/pytest": "index.html",
+    "example/result": "index.html",
+    "example/unittest": "index.html",
+}
 
 towncrier_draft_autoversion_mode = "draft"
 towncrier_draft_include_empty = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ docs = [
   "sphinx-copybutton>=0.5.2",
   "sphinx-inline-tabs>=2025.12.21.14",
   "sphinx-issues>=5.0.1",
+  "sphinx-reredirects>=0.2.1",
   "sphinxcontrib-mermaid>=2",
   "sphinxcontrib-towncrier>=0.2.1a0",
   "towncrier>=25.8",


### PR DESCRIPTION
The Diataxis restructure moved documentation pages into subdirectories (e.g. `config.html` to `reference/config.html`, `cli_interface.html` to `reference/cli.html`) and removed several pages entirely (`upgrading.html`, `faq.html`, all `example/*.html` pages from tox 3). External links from Stack Overflow and other sites now return 404.

This adds `sphinx-reredirects` to generate HTML redirect pages at build time, keeping the configuration version-controlled alongside the docs. Pages that moved get redirected to their new location, and removed pages redirect to the landing page. URL fragments are preserved so links like `config.html#conf-description` still resolve correctly.

Fixes #3806