### PR TITLE
🐛 fix(cli): allow --help with invalid config

### DIFF
--- a/docs/changelog/3819.bugfix.rst
+++ b/docs/changelog/3819.bugfix.rst
@@ -1,0 +1,1 @@
+Allow ``--help`` to render even when the configuration file is malformed or missing - by :user:`gaborbernat`.

--- a/tests/config/source/test_discover.py
+++ b/tests/config/source/test_discover.py
@@ -50,6 +50,13 @@ def test_bad_src_content(tox_project: ToxProjectCreator, tmp_path: Path) -> None
     assert outcome.out == f"ROOT: HandledError| config file {tmp_path / 'setup.cfg'} does not exist\n"
 
 
+def test_malformed_config_does_not_prevent_help(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.toml": "deps =\n    mypy\n"})
+    outcome = project.run("--help")
+    outcome.assert_success()
+    assert "usage: tox" in outcome.out
+
+
 def test_malformed_toml_in_dir_reports_error(tox_project: ToxProjectCreator) -> None:
     """Config discovery in a directory should report TOML parse errors instead of silently ignoring them."""
     project = tox_project({})


### PR DESCRIPTION
Config discovery errors were preventing `--help` from rendering because `_get_base()` calls `discover_source()` which raises `HandledError` on malformed config files. This propagates before argparse can display help output in `_get_all()`. Fixes #3819.

When `--help` is requested and config loading fails, tox now falls back to an empty source so users can still access help output regardless of config state. This only applies when `-h` or `--help` is in the arguments — all other invocations still raise the config error as before.