### PR TITLE
🐛 fix(schema): add additionalProperties to partial-tox.json

### DIFF
--- a/.github/workflows/update-schemastore.yaml
+++ b/.github/workflows/update-schemastore.yaml
@@ -29,11 +29,23 @@ jobs:
           with open('/tmp/schemastore/src/schemas/json/tox.json', 'w') as f:
               json.dump(schema, f, indent=2)
               f.write('\n')
+          partial = {
+              '\$schema': 'http://json-schema.org/draft-07/schema#',
+              '\$id': 'https://json.schemastore.org/partial-tox.json',
+              'title': 'Tox configuration in pyproject.toml',
+              'description': 'Schema for the [tool.tox] section in pyproject.toml',
+              'type': 'object',
+              'allOf': [{'\$ref': 'https://json.schemastore.org/tox.json'}],
+              'additionalProperties': True,
+          }
+          with open('/tmp/schemastore/src/schemas/json/partial-tox.json', 'w') as f:
+              json.dump(partial, f, indent=2)
+              f.write('\n')
           "
       - name: Check for changes
         id: diff
         run: |
-          git add src/schemas/json/tox.json
+          git add src/schemas/json/tox.json src/schemas/json/partial-tox.json
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/docs/changelog/3823.bugfix.rst
+++ b/docs/changelog/3823.bugfix.rst
@@ -1,0 +1,2 @@
+Fix false positive schema validation errors with tombi by adding ``additionalProperties: true`` to ``partial-tox.json``
+on SchemaStore - by :user:`gaborbernat`.

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import pytest
 
 if TYPE_CHECKING:
     from tox.pytest import MonkeyPatch, ToxProjectCreator
 
-SCHEMA_PATH = Path(__file__).parents[3] / "src" / "tox" / "tox.schema.json"
+ROOT = Path(__file__).parents[3]
+SCHEMA_PATH = ROOT / "src" / "tox" / "tox.schema.json"
 
 
 def test_show_schema_empty_dir(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
@@ -32,3 +37,38 @@ def test_schema_freshness(tox_project: ToxProjectCreator, monkeypatch: MonkeyPat
     assert generated == committed, (
         "tox.schema.json is out of date — regenerate with: tox schema > src/tox/tox.schema.json"
     )
+
+
+@pytest.mark.parametrize(
+    ("filename", "tombi_cfg", "content"),
+    [
+        pytest.param(
+            "tox.toml",
+            '[[schemas]]\npath = "tox.schema.json"\ninclude = ["tox.toml"]\n',
+            (ROOT / "tox.toml").read_text(),
+            id="tox.toml",
+        ),
+        pytest.param(
+            "pyproject.toml",
+            '[[schemas]]\nroot = "tool.tox"\npath = "tox.schema.json"\ninclude = ["pyproject.toml"]\n',
+            "[tool.tox]\nrequires = ['tox>=4']\nenv_list = ['py']\nskip_missing_interpreters = true\n\n"
+            "[tool.tox.env_run_base]\ncommands = [['pytest']]\ndeps = 'pytest'\n\n"
+            "[tool.tox.env.lint]\ncommands = [['ruff', 'check', '.']]\n",
+            id="pyproject.toml",
+        ),
+    ],
+)
+def test_schema_tombi_lint(tmp_path: Path, filename: str, tombi_cfg: str, content: str) -> None:
+    if not (tombi := shutil.which("tombi")):
+        pytest.skip("tombi not installed")
+    shutil.copy2(SCHEMA_PATH, tmp_path / "tox.schema.json")
+    (tmp_path / filename).write_text(content)
+    (tmp_path / "tombi.toml").write_text(tombi_cfg)
+    result = subprocess.run(
+        [tombi, "lint", "--error-on-warnings", "--offline", filename],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,8 @@
+[[schemas]]
+path = "src/tox/tox.schema.json"
+include = ["tox.toml"]
+
+[[schemas]]
+root = "tool.tox"
+path = "src/tox/tox.schema.json"
+include = ["pyproject.toml"]


### PR DESCRIPTION
Tools like tombi that validate `pyproject.toml` against SchemaStore schemas in strict mode reject valid `[tool.tox]` keys such as `env_list`, `requires`, `env`, and `env_run_base`. 🔍 The root cause is that SchemaStore's `partial-tox.json` wrapper references `tox.json` via `allOf` but lacks explicit `additionalProperties: true`, and tombi's strict mode treats missing `additionalProperties` as `false`.

The release workflow now generates and pushes `partial-tox.json` alongside `tox.json` to SchemaStore, ensuring the partial schema always includes `additionalProperties: true`. A `tombi.toml` configures local schema validation against the repo's own `tox.schema.json`, so both `tox.toml` and `pyproject.toml` with `[tool.tox]` sections are validated with tombi lint using the local schema rather than depending on SchemaStore being correct.

Fixes #3823