### PR TITLE
👷 ci(schemastore): fix update workflow auth and PR creation

### DIFF
--- a/.github/workflows/update-schemastore.yaml
+++ b/.github/workflows/update-schemastore.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Commit and push
         if: steps.diff.outputs.changed == 'true'
         run: |
+          gh auth setup-git
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "Update tox JSON Schema to ${{ github.ref_name }}"


### PR DESCRIPTION
The update-schemastore workflow fails in two ways when triggered by a release tag. First, `git push` couldn't authenticate because `GH_TOKEN` is only consumed by `gh` CLI, not raw git HTTPS operations. Second, `gh pr create --repo SchemaStore/schemastore` fails with "you must first push the current branch to a remote, or use the --head flag" because it can't infer which fork owns the branch when targeting an upstream repo.

The fix uses `gh auth setup-git` to register `gh` as a git credential helper (bridging the auth gap for `git push`), and dynamically resolves the fork owner via `gh api user` to pass `--head <owner>:<branch>` explicitly to both `gh pr create` and `gh pr view`/`gh pr edit`.