### PR TITLE
Fix outdated min version of virtualenv

### DIFF
--- a/docs/changelog/3829.bugfix.rst
+++ b/docs/changelog/3829.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the minimum version of virtualenv, to avoid incompatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "pyproject-api>=1.10",
   "tomli>=2.4; python_version<'3.11'",
   "typing-extensions>=4.15; python_version<'3.11'",
-  "virtualenv>=20.38",
+  "virtualenv>=20.39",
 ]
 optional-dependencies.completion = [
   "argcomplete>=3.6.3",


### PR DESCRIPTION
The recent 4.46.0 release introduced the feature[1] which requires virtualenv>=20.39.0 .

[1] https://github.com/tox-dev/tox/pull/3815

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
