### PR TITLE
flatten list results from TOML conditional replacements

### DIFF
--- a/src/tox/config/loader/toml/_replace.py
+++ b/src/tox/config/loader/toml/_replace.py
@@ -72,7 +72,7 @@ class Unroll:
             res_list: list[TomlTypes] = []
             for val in value:  # apply replacement for every entry
                 got = self(val, depth, skip_str=skip_str)
-                if isinstance(val, dict) and val.get("replace") and val.get("extend"):
+                if isinstance(val, dict) and val.get("replace") and (isinstance(got, list) or val.get("extend")):
                     res_list.extend(cast("list[Any]", got))
                 else:
                     res_list.append(got)


### PR DESCRIPTION
Flatten the result when the replacement returns a list, regardless of whether extend is explicitly set. 
The extend flag is still respected for non-list iterables (like sets from ref replacements), so nothing else breaks.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
