### PR TITLE
🐛 fix(ci): resolve ty type-check failures

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -84,7 +84,7 @@ jobs:
           - ubuntu-24.04
           - windows-2025
         exclude:
-          - { os: windows-latest, tox_env: docs }
+          - { os: windows-2025, tox_env: docs }
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/changelog/3837.bugfix.rst
+++ b/docs/changelog/3837.bugfix.rst
@@ -1,0 +1,3 @@
+Fix type errors flagged by ``ty`` for ``virtualenv`` API changes (``system_executable`` nullability and
+``cached_py_info.PythonInfo`` removal), and correct the CI workflow matrix exclude for ``windows-2025`` - by
+:user:`gaborbernat`.

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -108,6 +108,7 @@ def test_result_json_sequential(
         log_report = json.load(file_handler)
 
     py_info = PythonInfo.current_system()
+    assert py_info.system_executable is not None
     host_python = {
         "executable": str(Path(py_info.system_executable).resolve()),
         "extra_version_info": None,


### PR DESCRIPTION
The `type` and `type-min` CI jobs have been failing across all platforms because the ty type checker correctly identified that `system_executable` on virtualenv's `PythonInfo` is typed as `str | None`, which cannot be passed directly to `Path()`. Additionally, `cached_py_info.PythonInfo` was never a public attribute of that module — it needs to be imported from `virtualenv.discovery.py_info` instead, and `from_exe` returns `PythonInfo | None` rather than `PythonInfo`.

The fix narrows the `None` case with a walrus-operator guard in `_get_python` (returning `None` early, which the method already supports), moves the `cached_py_info` and `PythonInfo` imports into `get_virtualenv_py_info` where they're actually used, and raises a clear `RuntimeError` when `from_exe` returns `None`. 🔧 The test is narrowed with an assert.

Also fixes the `check.yaml` workflow matrix exclude which still referenced the stale `windows-latest` alias instead of `windows-2025`, so the `docs` job was unintentionally running on Windows.