### PR TITLE
🐛 fix(exec): pass stdin through to executed command

### DIFF
--- a/docs/changelog/3841.bugfix.rst
+++ b/docs/changelog/3841.bugfix.rst
@@ -1,0 +1,2 @@
+Pass stdin through to commands executed via ``tox exec`` so that piped input (e.g., ``echo "foo" | tox exec -- python -c
+'import sys; print(sys.stdin.read())'``) reaches the subprocess instead of being discarded - by :user:`gaborbernat`.

--- a/src/tox/session/cmd/run/single.py
+++ b/src/tox/session/cmd/run/single.py
@@ -118,7 +118,7 @@ def run_command_set(  # noqa: PLR0913
             current_outcome = tox_env.execute(
                 cmd.args,
                 cwd=cwd,
-                stdin=StdinSource.user_only(),
+                stdin=StdinSource.USER if getattr(tox_env.options, "no_capture", False) else StdinSource.user_only(),
                 show=True,
                 run_id=f"{key}[{at}]",
             )


### PR DESCRIPTION
Running commands via `tox exec` with piped stdin silently discards the input data. For example, `echo "foo" | tox exec -- python -c 'import sys; print(sys.stdin.read())'` produces an empty output instead of printing `foo`. This happens because `StdinSource.user_only()` returns `OFF` when `sys.stdin.isatty()` is `False`, mapping to `DEVNULL` in the subprocess `Popen` call.

When `no_capture` is enabled (which `tox exec` always sets), the subprocess should inherit the parent's stdin directly via `StdinSource.USER` rather than going through the tty check. This preserves the existing behavior for `tox run` while allowing `tox exec` to work naturally with pipes and redirections.

Fixes #3841