### PR TITLE
🐛 fix(config): resolve base_python from new-style version factors

### DIFF
--- a/docs/changelog/3845.bugfix.rst
+++ b/docs/changelog/3845.bugfix.rst
@@ -1,0 +1,1 @@
+New-style version factors (e.g., ``3.10-tests``) now correctly set ``base_python`` - by :user:`gaborbernat`.

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -67,7 +67,7 @@ PY_FACTORS_RE_EXPLICIT_VERSION = re.compile(
     r"""
     ^
     ( (?P<impl> cpython | pypy ) - )?   # optional interpreter prefix with dash
-    (?P<version> [2-9] \. [0-9]+ )      # explicit major.minor version
+    (?P<version> [23] \. [0-9]+ )        # explicit major.minor version (Python 2.x or 3.x)
     (?P<threaded> t? )                   # optional free-threaded suffix
     $
     """,
@@ -180,15 +180,18 @@ class Python(ToxEnv, ABC):
     @classmethod
     def extract_base_python(cls, env_name: str) -> str | None:
         candidates: list[str] = []
-        match = PY_FACTORS_RE_EXPLICIT_VERSION.match(env_name)
-        if match:
+        if match := PY_FACTORS_RE_EXPLICIT_VERSION.match(env_name):
             found = match.groupdict()
             candidates.append(f"{'pypy' if found['impl'] == 'pypy' else ''}{found['version']}{found['threaded']}")
         else:
             for factor in env_name.split("-"):
-                match = PY_FACTORS_RE.match(factor)
-                if match:
+                if match := PY_FACTORS_RE.match(factor):
                     candidates.append(factor)
+                elif match := PY_FACTORS_RE_EXPLICIT_VERSION.match(factor):
+                    found = match.groupdict()
+                    candidates.append(
+                        f"{'pypy' if found['impl'] == 'pypy' else ''}{found['version']}{found['threaded']}"
+                    )
         if candidates:
             if len(candidates) > 1:
                 msg = f"conflicting factors {', '.join(candidates)} in {env_name}"

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -45,6 +45,16 @@ def test_conflicting_base_python_factor() -> None:
         Python.extract_base_python(name)
 
 
+def test_conflicting_base_python_factor_explicit_version() -> None:
+    with pytest.raises(ValueError, match=r"conflicting factors 3\.10, 3\.11 in 3\.10-3\.11"):
+        Python.extract_base_python("3.10-3.11")
+
+
+def test_conflicting_base_python_factor_mixed_style() -> None:
+    with pytest.raises(ValueError, match=r"conflicting factors py310, 3\.11 in py310-3\.11"):
+        Python.extract_base_python("py310-3.11")
+
+
 def test_build_wheel_in_non_base_pkg_env(
     tox_project: ToxProjectCreator,
     patch_prev_py: Callable[[bool], tuple[str, str]],
@@ -142,6 +152,11 @@ def test_diff_msg_no_diff() -> None:
         ("2.7t", "2.7t"),
         ("pypy-3.10", "pypy3.10"),
         ("pypy-3.10t", "pypy3.10t"),
+        ("3.10-tests", "3.10"),
+        ("3.10t-tests", "3.10t"),
+        ("tests-3.10", "3.10"),
+        ("tests-3.10t", "3.10t"),
+        ("foo-3.14-bar", "3.14"),
     ],
     ids=lambda a: "|".join(a) if isinstance(a, list) else str(a),
 )


### PR DESCRIPTION
Multi-factor environment names using new-style version numbers like `3.10-tests` or `3.14-django` didn't set `base_python`, causing all environments to run with the default interpreter. 🐛 This happened because `extract_base_python` only matched `PY_FACTORS_RE_EXPLICIT_VERSION` against the entire env name — when that failed for multi-factor names, the fallback factor loop only checked `PY_FACTORS_RE`, which requires an impl prefix (e.g., `py`). Bare version factors like `3.10` were silently ignored.

The fix checks individual factors against `PY_FACTORS_RE_EXPLICIT_VERSION` in the fallback loop, so `3.10-tests` now correctly resolves `base_python` to `3.10`. The regex major version range was also tightened from `[2-9]` to `[23]` to prevent false positives — without this, env names like `eslint-8.3` would incorrectly match `8.3` as a Python version.

Fixes #3845