### PR TITLE
Fix SchemaStore workflow creating empty PRs

### DIFF
--- a/.github/workflows/update-schemastore.yaml
+++ b/.github/workflows/update-schemastore.yaml
@@ -21,45 +21,29 @@ jobs:
           git fetch upstream master
           git switch -C "$BRANCH" upstream/master
         working-directory: /tmp/schemastore
-      - name: Copy schema with SchemaStore $id
-        run: |
-          python3 -c "
-          import json
-          with open('${{ github.workspace }}/src/tox/tox.schema.json') as f:
-              schema = json.load(f)
-          schema['\$id'] = 'https://json.schemastore.org/tox.json'
-          with open('/tmp/schemastore/src/schemas/json/tox.json', 'w') as f:
-              json.dump(schema, f, indent=2)
-              f.write('\n')
-          partial = {
-              '\$schema': 'http://json-schema.org/draft-07/schema#',
-              '\$id': 'https://json.schemastore.org/partial-tox.json',
-              'title': 'Tox configuration in pyproject.toml',
-              'description': 'Schema for the [tool.tox] section in pyproject.toml',
-              'type': 'object',
-              'allOf': [{'\$ref': 'https://json.schemastore.org/tox.json'}],
-              'additionalProperties': True,
-          }
-          with open('/tmp/schemastore/src/schemas/json/partial-tox.json', 'w') as f:
-              json.dump(partial, f, indent=2)
-              f.write('\n')
-          "
-      - name: Check for changes
+      - name: Update schema and check for changes
         id: diff
         run: |
-          git add src/schemas/json/tox.json src/schemas/json/partial-tox.json
-          if git diff --cached --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-        working-directory: /tmp/schemastore
+          python3 -c "
+          import json, sys
+          with open('${{ github.workspace }}/src/tox/tox.schema.json') as f:
+              new = json.load(f)
+          new['\$id'] = 'https://json.schemastore.org/tox.json'
+          with open('/tmp/schemastore/src/schemas/json/tox.json') as f:
+              old = json.load(f)
+          if new == old:
+              sys.exit(1)
+          with open('/tmp/schemastore/src/schemas/json/tox.json', 'w') as f:
+              json.dump(new, f, indent=2)
+              f.write('\n')
+          " && echo "changed=true" >> "$GITHUB_OUTPUT" || echo "changed=false" >> "$GITHUB_OUTPUT"
       - name: Commit and push
         if: steps.diff.outputs.changed == 'true'
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/schemas/json/tox.json
           git commit -m "Update tox JSON Schema to ${{ github.ref_name }}"
           git push --force origin "$BRANCH"
         working-directory: /tmp/schemastore


### PR DESCRIPTION
The `update-schemastore.yaml` workflow used `git diff --cached` to detect schema changes, but `json.dump` formatting differs from SchemaStore's prettier formatting. This caused every release to open a PR with formatting-only diffs and no actual schema content changes (e.g. #5434).

Replace file-level diff with parsed JSON comparison — only writes the file and proceeds when the schema content actually differs.