### PR TITLE
Add .mailmap to consolidate author identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,46 @@
+# .mailmap - Consolidate git author identities
+# See: https://git-scm.com/docs/gitmailmap
+#
+# Format: Canonical Name <canonical@email.com> Old Name <old@email.com>
+
+# Bernát Gábor
+Bernát Gábor <bgabor8@bloomberg.net> Bernát Gábor <gaborjbernat@gmail.com>
+Bernát Gábor <bgabor8@bloomberg.net> Bernat Gabor <bgabor8@bloomberg.net>
+Bernát Gábor <bgabor8@bloomberg.net> bgabor8 <bgabor8@bloomberg.net>
+Bernát Gábor <bgabor8@bloomberg.net> gaborbernat <gaborbernat@users.noreply.github.com>
+
+# Eric L
+Eric L <ewl+git@lavar.de> <ericzolf@users.noreply.github.com>
+
+# Hugo van Kemenade
+Hugo van Kemenade <1324225+hugovk@users.noreply.github.com> <hugovk@users.noreply.github.com>
+
+# James Williams
+James Williams <jamwil@gmail.com> <james@kananlabs.org>
+
+# Jürgen Gmach
+Jürgen Gmach <juergen.gmach@googlemail.com> <juergen.gmach@canonical.com>
+
+# Matt Bogosian
+Matt Bogosian <matt@bogosian.net> <eb3f73+github+com@yaymail.com>
+
+# Robsdedude (Rouven Bauer)
+Robsdedude <dev@rouvenbauer.de> <rouven.bauer@neo4j.com>
+
+# seyidaniels
+seyidaniels <seyidaniels@gmail.com> <odaniel8@bloomberg.net>
+
+# Sorin Sbarnea
+Sorin Sbarnea <sorin.sbarnea@gmail.com> <ssbarnea@redhat.com>
+
+# Stefano Rivera
+Stefano Rivera <stefano@rivera.za.net> <github@rivera.za.net>
+
+# Stephen Finucane
+Stephen Finucane <stephen@that.guru> <stephenfinucane@hotmail.com>
+
+# Sviatoslav Sydorenko
+Sviatoslav Sydorenko <wk@sydorenko.org.ua> Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>
+Sviatoslav Sydorenko <wk@sydorenko.org.ua> Sviatoslav Sydorenko (Святослав Сидоренко) <wk@sydorenko.org.ua>
+Sviatoslav Sydorenko <wk@sydorenko.org.ua> 🇺🇦 Sviatoslav Sydorenko (Святослав Сидоренко) <wk@sydorenko.org.ua>
+Sviatoslav Sydorenko <wk@sydorenko.org.ua> 🇺🇦 Sviatoslav Sydorenko (Святослав Сидоренко) <webknjaz@redhat.com>


### PR DESCRIPTION
## Summary

- Add `.mailmap` to consolidate 17 duplicate author entries across 12 contributors
- Reduces unique author count from 138 to 121
- Improves `git shortlog` output and contributor statistics

## Consolidated identities

| Contributor | Entries | Canonical |
|---|---|---|
| Bernát Gábor | 5 → 1 | `<bgabor8@bloomberg.net>` |
| Sviatoslav Sydorenko | 4 → 1 | `<wk@sydorenko.org.ua>` |
| Jürgen Gmach | 2 → 1 | `<juergen.gmach@googlemail.com>` |
| Sorin Sbarnea | 2 → 1 | `<sorin.sbarnea@gmail.com>` |
| Hugo van Kemenade | 2 → 1 | `<1324225+hugovk@users.noreply.github.com>` |
| Stephen Finucane | 2 → 1 | `<stephen@that.guru>` |
| Stefano Rivera | 2 → 1 | `<stefano@rivera.za.net>` |
| Robsdedude | 2 → 1 | `<dev@rouvenbauer.de>` |
| Matt Bogosian | 2 → 1 | `<matt@bogosian.net>` |
| Eric L | 2 → 1 | `<ewl+git@lavar.de>` |
| seyidaniels | 2 → 1 | `<seyidaniels@gmail.com>` |
| James Williams | 2 → 1 | `<jamwil@gmail.com>` |

<details>
<summary>
Before / after `git log --format='%aN <%aE>' | sort | uniq -c | sort -rn`
</summary> 

```patch
--- before
+++ after
@@ -1,36 +1,33 @@
-    356 Bernát Gábor <bgabor8@bloomberg.net>
-    279 Bernát Gábor <gaborjbernat@gmail.com>
+    659 Bernát Gábor <bgabor8@bloomberg.net>
      96 pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-     44 Jürgen Gmach <juergen.gmach@googlemail.com>
+     46 Jürgen Gmach <juergen.gmach@googlemail.com>
      40 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
      19 rahuldevikar <rahuldevikar5512@gmail.com>
-     18 gaborbernat <gaborbernat@users.noreply.github.com>
+     18 Sorin Sbarnea <sorin.sbarnea@gmail.com>
      18 Masen Furer <m_github@0x26.net>
-     15 Sorin Sbarnea <ssbarnea@redhat.com>
      11 Miro Hrončok <miro@hroncok.cz>
      10 Miroslav Šedivý <6774676+eumiro@users.noreply.github.com>
+      9 Sviatoslav Sydorenko <wk@sydorenko.org.ua>
       9 Kurt McKee <contactme@kurtmckee.org>
       9 Curt J. Sampson <cjs@cynic.net>
       8 q0w <43147888+q0w@users.noreply.github.com>
+      7 Stephen Finucane <stephen@that.guru>
       7 Fridayai700 <aifriday700@gmail.com>
-      6 Stephen Finucane <stephen@that.guru>
-      5 🇺🇦 Sviatoslav Sydorenko (Святослав Сидоренко) <wk@sydorenko.org.ua>
-      5 bgabor8 <bgabor8@bloomberg.net>
       5 Vlastimil Zíma <ziima@users.noreply.github.com>
+      5 Robsdedude <dev@rouvenbauer.de>
       5 Gleb Nikonorov <gleb.i.nikonorov@gmail.com>
       5 Andrey Bienkowski <hexagonrecursion@gmail.com>
-      4 Robsdedude <rouven.bauer@neo4j.com>
+      4 Stefano Rivera <stefano@rivera.za.net>
       4 Michał Górny <mgorny@gentoo.org>
+      4 Hugo van Kemenade <1324225+hugovk@users.noreply.github.com>
       4 Faidon Liambotis <paravoid@debian.org>
       4 Alexander Clausen <alex@gc-web.de>
       3 Teejay <tbruno25@gmail.com>
       3 Stephen Rosen <sirosen@globus.org>
-      3 Stefano Rivera <stefano@rivera.za.net>
-      3 Sorin Sbarnea <sorin.sbarnea@gmail.com>
       3 James Braza <jamesbraza@gmail.com>
       3 Antoine Musso <hashar@free.fr>
       3 Adam Johnson <me@adamj.eu>
-      2 🇺🇦 Sviatoslav Sydorenko (Святослав Сидоренко) <webknjaz@redhat.com>
+      2 seyidaniels <seyidaniels@gmail.com>
       2 Vytautas Liuolia <vytautas.liuolia@gmail.com>
       2 Ville Skyttä <ville.skytta@iki.fi>
       2 Tushar Sadhwani <tushar.sadhwani000@gmail.com>
@@ -38,22 +35,20 @@
       2 Ross Patterson <me@rpatterson.net>
       2 Patrick Decat <pdecat@gmail.com>
       2 Oliver Bestwalter <oliver@bestwalter.de>
+      2 Matt Bogosian <matt@bogosian.net>
       2 Martin Imre <mimre25@users.noreply.github.com>
       2 Marius Gedminas <marius@gedmin.as>
-      2 Jürgen Gmach <juergen.gmach@canonical.com>
-      2 Hugo van Kemenade <hugovk@users.noreply.github.com>
-      2 Hugo van Kemenade <1324225+hugovk@users.noreply.github.com>
+      2 James Williams <jamwil@gmail.com>
       2 Grzegorz Bokota <bokota+github@gmail.com>
       2 Ganden Schaffner <gschaffner@pm.me>
       2 Frank Dana <ferdnyc@gmail.com>
+      2 Eric L <ewl+git@lavar.de>
       2 Elisey Zanko <elisey.zanko@gmail.com>
       2 Christian Clauss <cclauss@me.com>
       2 Anthony Sottile <asottile@umich.edu>
       1 zhanpon <pon.zhan@gmail.com>
       1 wooshaun53 <wooshaun53@gmail.com>
       1 srenfo <14216995+srenfo@users.noreply.github.com>
-      1 seyidaniels <seyidaniels@gmail.com>
-      1 seyidaniels <odaniel8@bloomberg.net>
       1 realitycheck <realitycheck@users.noreply.github.com>
       1 kdestin <101366538+kdestin@users.noreply.github.com>
       1 graingert-coef <151018808+graingert-coef@users.noreply.github.com>
@@ -74,13 +69,8 @@
       1 Tim Burke <tim.burke@gmail.com>
       1 Tibor Takacs <takacs84@gmail.com>
       1 Takashi Kajinami <kajinamit@users.noreply.github.com>
-      1 Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>
-      1 Sviatoslav Sydorenko (Святослав Сидоренко) <wk@sydorenko.org.ua>
-      1 Stephen Finucane <stephenfinucane@hotmail.com>
       1 Stein Magnus Jodal <stein.magnus@jodal.no>
-      1 Stefano Rivera <github@rivera.za.net>
       1 Santiago Castro <bryant1410@gmail.com>
-      1 Robsdedude <dev@rouvenbauer.de>
       1 Reinout van Rees <reinout@vanrees.org>
       1 PreistlyPython <134371693+PreistlyPython@users.noreply.github.com>
       1 Pichot <pichot.fabien@gmail.com>
@@ -93,8 +83,6 @@
       1 Nathan Tsai <natesigh@gmail.com>
       1 Michael van Bracht <mbra@users.noreply.github.com>
       1 Max Droy <maxime_droy@ultimatesoftware.com>
-      1 Matt Bogosian <matt@bogosian.net>
-      1 Matt Bogosian <eb3f73+github+com@yaymail.com>
       1 Marcos Boger <50413997+marcosboger@users.noreply.github.com>
       1 Marcin Konowalczyk <marcin.konow@lczyk.xyz>
       1 Marcel Johannesmann <mj0nez@fn.de>
@@ -104,8 +92,6 @@
       1 Kemal Zebari <60799661+kemzeb@users.noreply.github.com>
       1 Judit Novak <judit.novak@gmail.com>
       1 Jim Brännlund <jimbrannlund@fastmail.com>
-      1 James Williams <jamwil@gmail.com>
-      1 James Williams <james@kananlabs.org>
       1 James Falcon <therealfalcon@gmail.com>
       1 JJLLWW <70631023+JJLLWW@users.noreply.github.com>
       1 Ionel Cristian Mărieș <contact@ionelmc.ro>
@@ -114,8 +100,6 @@
       1 Florian Bruhin <me@the-compiler.org>
       1 Fabian P. Schmidt <kerel@mailbox.org>
       1 Evgeni Golov <evgeni@golov.de>
-      1 Eric L <ewl+git@lavar.de>
-      1 Eric L <ericzolf@users.noreply.github.com>
       1 ElBe <90863907+ElBe-Plaq@users.noreply.github.com>
       1 Edgar Ramírez Mondragón <edgarrm358@gmail.com>
       1 Dmitrii Sutiagin <f3flight@gmail.com>
@@ -128,7 +112,6 @@
       1 Chris Lamb <chris@chris-lamb.co.uk>
       1 Carlton Gibson <carlton@noumenal.es>
       1 Caleb P. Burns <2126043+cpburnz@users.noreply.github.com>
-      1 Bernat Gabor <bgabor8@bloomberg.net>
       1 Asger Gitz-Johansen <sillydan1@users.noreply.github.com>
       1 Arik Mitschang <arik.mitschang@gmail.com>
       1 Antoine Dechaume <AntoineD@users.noreply.github.com>
```

</details>

<details>
<summary>Interesting difference for shortlog which "tripped" me to place PR back into draft:</summary> 

I took PR into draft since saw something which didn't align with my memory of seeing on master

```shell
❯ git shortlog -sn | head
   635	Bernát Gábor
    96	pre-commit-ci[bot]
    46	Jürgen Gmach
    40	dependabot[bot]
    19	rahuldevikar
    18	Masen Furer
    18	Sorin Sbarnea
    18	gaborbernat
    11	Miro Hrončok
    10	Miroslav Šedivý
```

which differs from what was shown in the `git log` diff

```shell
❯ git log --format='%aN <%aE>' | sort | uniq -c | sort -rn | head
    356 Bernát Gábor <bgabor8@bloomberg.net>
    279 Bernát Gábor <gaborjbernat@gmail.com>
     96 pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
     44 Jürgen Gmach <juergen.gmach@googlemail.com>
     40 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
     19 rahuldevikar <rahuldevikar5512@gmail.com>
     18 Masen Furer <m_github@0x26.net>
     18 gaborbernat <gaborbernat@users.noreply.github.com>
     15 Sorin Sbarnea <ssbarnea@redhat.com>
     11 Miro Hrončok <miro@hroncok.cz>
```

since it also included the emails. And without emails -- match fine

```shell
❯ git log --format='%aN' | sort | uniq -c | sort -rn | head
    635 Bernát Gábor
     96 pre-commit-ci[bot]
     46 Jürgen Gmach
     40 dependabot[bot]
     19 rahuldevikar
     18 Sorin Sbarnea
     18 Masen Furer
     18 gaborbernat
     11 Miro Hrončok
     10 Miroslav Šedivý
```

and after introducing `.mailmap`, git log also starts mapping emails uniformly

```shell
❯ git co introduce-mailmap
Switched to branch 'introduce-mailmap'
Your branch is up to date with 'gh-yarikoptic/introduce-mailmap'.
❯ git log --format='%aN <%aE>' | sort | uniq -c | sort -rn | head
    659 Bernát Gábor <bgabor8@bloomberg.net>
     96 pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
     46 Jürgen Gmach <juergen.gmach@googlemail.com>
     40 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
     19 rahuldevikar <rahuldevikar5512@gmail.com>
     18 Sorin Sbarnea <sorin.sbarnea@gmail.com>
     18 Masen Furer <m_github@0x26.net>
     11 Miro Hrončok <miro@hroncok.cz>
     10 Miroslav Šedivý <6774676+eumiro@users.noreply.github.com>
      9 Sviatoslav Sydorenko <wk@sydorenko.org.ua>
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

TODOs
- [x] rerun CI after github comes to good health again. 