### PR TITLE
🐛 fix(config): honor ignore_base_python_conflict for factor conflicts

### DIFF
--- a/docs/changelog/3850.bugfix.rst
+++ b/docs/changelog/3850.bugfix.rst
@@ -1,0 +1,4 @@
+``ignore_base_python_conflict`` now also suppresses errors when an environment name contains multiple conflicting
+version-like factors (e.g., ``unit-py3.10-2.16`` where both ``py3.10`` and ``2.16`` are detected as Python versions).
+Previously this flag only handled conflicts between explicit ``base_python`` settings and the environment name - by
+:user:`gaborbernat`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -521,7 +521,7 @@ Python language core options
 
 .. conf::
     :keys: ignore_base_python_conflict, ignore_basepython_conflict
-    :default: True
+    :default: False
     :version_added: 3.1
 
      .. versionadded:: 3.1.0
@@ -535,6 +535,17 @@ Python language core options
      Furthermore, we allow hard enforcing this rule by setting this flag to ``true``. In such cases we ignore the
      :ref:`base_python` and instead always use the base Python implied from the Python name. This allows you to configure
      :ref:`base_python` in the :ref:`base` section without affecting environments that have implied base Python versions.
+
+     **This flag handles two types of conflicts:**
+
+     1. **Explicit setting vs. environment name**: When :ref:`base_python` is explicitly set but conflicts with the
+        version extracted from the environment name. Setting this to ``true`` uses the version from the environment name.
+
+     2. **Multiple version factors in environment name** (since 4.47.3): When the environment name itself contains
+        multiple factors that look like Python versions (e.g., ``unit-py3.10-2.16`` where both ``py3.10`` and ``2.16``
+        match Python version patterns). Setting this to ``true`` falls back to :ref:`default_base_python` instead of
+        raising an error. To avoid this ambiguity, prefix non-Python version factors (e.g. use ``ac2.16`` instead of
+        ``2.16``).
 
 .. _conf-testenv:
 
@@ -1359,6 +1370,13 @@ Python options
     The preferred naming convention is ``N.M`` (e.g. ``3.14``, ``3.13``) rather than ``pyNMM`` (e.g. ``py314``,
     ``py313``). The dotted form is clearer, avoids ambiguity for Python versions >= 3.10, and reads more naturally in
     environment lists and CI output.
+
+    .. warning::
+
+       Any factor matching the pattern ``2.N`` or ``3.N`` (where N is one or more digits) is treated as a Python
+       version specifier. This means non-Python versions like ``2.16`` in an environment name such as
+       ``unit-py3.10-2.16`` will conflict with the ``py3.10`` factor. To avoid this, prefix non-Python version numbers
+       (e.g. ``ac2.16``), or set :ref:`ignore_base_python_conflict` to ``true``.
 
     .. versionadded:: 4.46
 

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -174,7 +174,13 @@ class Python(ToxEnv, ABC):
         return env
 
     def _base_python_default(self, conf: Config, env_name: str | None) -> list[str]:  # noqa: ARG002
-        base_python = None if env_name is None else self.extract_base_python(env_name)
+        try:
+            base_python = None if env_name is None else self.extract_base_python(env_name)
+        except ValueError:
+            if self.core["ignore_base_python_conflict"]:
+                base_python = None
+            else:
+                raise
         return self.conf["default_base_python"] if base_python is None else [base_python]
 
     @classmethod
@@ -217,7 +223,12 @@ class Python(ToxEnv, ABC):
         base_pythons: list[str],
         ignore_base_python_conflict: bool,  # noqa: FBT001
     ) -> list[str]:
-        env_base_python = cls.extract_base_python(env_name)
+        try:
+            env_base_python = cls.extract_base_python(env_name)
+        except ValueError:
+            if ignore_base_python_conflict:
+                return base_pythons
+            raise
         if env_base_python is not None:
             spec_name = PythonSpec.from_string_spec(env_base_python)
             for base_python in base_pythons:

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -55,6 +55,30 @@ def test_conflicting_base_python_factor_mixed_style() -> None:
         Python.extract_base_python("py310-3.11")
 
 
+def test_conflicting_base_python_factor_ignore(tox_project: ToxProjectCreator) -> None:
+    ini = "[tox]\nenv_list=unit-py3.10-2.16\nignore_base_python_conflict=true\n[testenv]\npackage=skip\n"
+    project = tox_project({"tox.ini": ini})
+    result = project.run("c", "-e", "unit-py3.10-2.16", "-k", "base_python")
+    result.assert_success()
+
+
+def test_conflicting_base_python_factor_no_ignore(tox_project: ToxProjectCreator) -> None:
+    ini = "[tox]\nenv_list=unit-py3.10-2.16\n[testenv]\npackage=skip\n"
+    project = tox_project({"tox.ini": ini})
+    result = project.run("c", "-e", "unit-py3.10-2.16", "-k", "base_python", raise_on_config_fail=False)
+    result.assert_failed(code=-1)
+
+
+def test_validate_base_python_conflicting_factors_ignore() -> None:
+    result = Python._validate_base_python("unit-py3.10-2.16", ["python3"], ignore_base_python_conflict=True)  # noqa: SLF001
+    assert result == ["python3"]
+
+
+def test_validate_base_python_conflicting_factors_no_ignore() -> None:
+    with pytest.raises(ValueError, match=r"conflicting factors py3\.10, 2\.16 in unit-py3\.10-2\.16"):
+        Python._validate_base_python("unit-py3.10-2.16", ["python3"], ignore_base_python_conflict=False)  # noqa: SLF001
+
+
 def test_build_wheel_in_non_base_pkg_env(
     tox_project: ToxProjectCreator,
     patch_prev_py: Callable[[bool], tuple[str, str]],


### PR DESCRIPTION
Environment names containing multiple version-like factors (e.g. `unit-py3.10-2.16` where `2.16` is an Ansible version, not Python) started raising `ValueError` after 4.47.1 introduced bare `N.M` version factor support. The `ignore_base_python_conflict` setting was supposed to suppress this, but the error fired during default value computation in `extract_base_python` — before the flag was ever checked.

**What `ignore_base_python_conflict` did before:**
- Only handled conflicts between an **explicit** `base_python` setting and the version extracted from the environment name
- Example: `base_python = py3.11` in config vs. `py3.10` from env name → flag lets you ignore the explicit setting

**What it does now:**
- ✨ **Also** suppresses errors when the env name **itself** contains multiple conflicting version-like factors
- Example: `unit-py3.10-2.16` contains both `py3.10` and `2.16` (both match Python version patterns) → flag falls back to `default_base_python` instead of crashing

The fix catches the `ValueError` in both the default resolution (`_base_python_default`) and validation (`_validate_base_python`) paths. 📝 Documentation now clearly explains both use cases, warns that any `2.N` or `3.N` factor is treated as a Python version specifier, and corrects the documented default from `true` to `false` to match the code.

Fixes #3850