### PR TITLE
Add fail_fast to config reference docs

### DIFF
--- a/docs/changelog/578.doc.rst
+++ b/docs/changelog/578.doc.rst
@@ -1,0 +1,1 @@
+Add ``fail_fast`` to the configuration reference documentation - by :user:`rahuldevikar`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1278,6 +1278,15 @@ Run
     If set to true a failing result of this test environment will not make tox fail (instead just warn).
 
 .. conf::
+    :keys: fail_fast
+    :default: False
+    :version_added: 4.36.0
+
+    If set to true, tox will stop executing remaining environments when this environment fails. This can also be
+    enabled globally via the ``--fail-fast`` (``-x``) CLI flag. The behavior respects :ref:`ignore_outcome` --
+    environments with ``ignore_outcome = true`` will not trigger fail-fast even if they fail.
+
+.. conf::
     :keys: skip_install
     :default: False
     :version_added: 1.9


### PR DESCRIPTION
Add fail_fast to config reference docs

Ref: https://github.com/tox-dev/tox/issues/578#issuecomment-3996935117
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
