### PR TITLE
✨ feat(config): add --format json/toml and -o to config command

### DIFF
--- a/docs/changelog/3854.feature.rst
+++ b/docs/changelog/3854.feature.rst
@@ -1,0 +1,3 @@
+Add ``--format`` flag (``ini``, ``json``, ``toml``) and ``-o``/``--output-file`` to the ``config`` command for
+machine-readable output with native types. JSON and TOML use the same key structure as ``tox.toml`` (``env.<name>`` for
+environments, ``tox`` for core) and get syntax-highlighted on stdout - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -705,12 +705,36 @@ To detect misplaced keys:
 
 - Run ``tox run -v`` — unused keys are printed as warnings before the final report.
 - Run ``tox config`` — unused keys appear as ``# !!! unused:`` comments per section.
+- Run ``tox config --format json`` or ``--format toml`` — unused keys appear in an ``"unused"`` array per section.
 
-For example, putting ``ignore_base_python_conflict`` in ``[testenv]`` instead of ``[tox]`` produces:
+For example, putting ``ignore_base_python_conflict`` in ``[testenv]`` instead of ``[tox]``:
 
-.. code-block:: text
+.. tab:: INI
 
-    [testenv:py] unused config key(s): ignore_base_python_conflict
+    .. code-block:: text
+
+        [testenv:py]
+        ...
+        # !!! unused: ignore_base_python_conflict
+
+.. tab:: JSON
+
+    .. code-block:: json
+
+        {
+          "env": {
+            "py": {
+              "unused": ["ignore_base_python_conflict"]
+            }
+          }
+        }
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+        [env.py]
+        unused = ["ignore_base_python_conflict"]
 
 See the :ref:`Core <conf-core>` and :ref:`tox environment <conf-testenv>` reference sections for which options belong
 where.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -1292,6 +1292,61 @@ When an environment fails, use these techniques to investigate:
        tox run -v
        tox config -e 3.13
 
+7. **Extract configuration in different formats.** Use ``--format`` to choose between ``ini`` (default), ``json``, or
+   ``toml``. Write to a file with ``-o`` instead of stdout:
+
+   .. code-block:: bash
+
+       tox config -e py -k deps commands                          # INI (default)
+       tox config -e py -k deps commands --format json             # JSON to stdout
+       tox config -e py -k deps commands --format toml -o out.toml # TOML to file
+
+   Given a ``tox.ini`` with ``deps = pytest`` and ``commands = pytest {posargs}``, the output looks like:
+
+   .. tab:: INI
+
+       .. code-block:: ini
+
+           [testenv:py]
+           deps = pytest
+           commands = pytest
+
+   .. tab:: JSON
+
+       .. code-block:: json
+
+           {
+             "env": {
+               "py": {
+                 "deps": [
+                   "pytest"
+                 ],
+                 "commands": [
+                   "pytest"
+                 ]
+               }
+             }
+           }
+
+   .. tab:: TOML
+
+       .. code-block:: toml
+
+           [env.py]
+           deps = ["pytest"]
+           commands = ["pytest"]
+
+   The JSON and TOML formats preserve native types (booleans, integers, floats, arrays, dicts) and use the same key
+   structure as ``tox.toml`` (``env.<name>`` for environments, ``tox`` for core settings). The ``-o`` flag always writes
+   without color codes.
+
+   To get the list of environments programmatically, query ``-k type`` — the ``env`` keys in the output are the
+   environment names:
+
+   .. code-block:: bash
+
+       tox config -k type --format json | python -c "import json,sys; print(*json.load(sys.stdin)['env'])"
+
 .. _skip-env-install:
 
 **************************************

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -306,7 +306,14 @@ View the resolved configuration for an environment:
 
     tox config -e 3.13 -k deps commands
 
-This is useful for debugging configuration issues.
+The output format can be changed with ``--format`` and written to a file with ``-o``:
+
+.. code-block:: bash
+
+    tox config -e 3.13 --format json -o config.json
+    tox config -e 3.13 --format toml -o config.toml
+
+This is useful for debugging configuration issues and for programmatic consumption.
 
 ************
  Next steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
   "pluggy>=1.6",
   "pyproject-api>=1.10",
   "tomli>=2.4; python_version<'3.11'",
+  "tomli-w>=1.1",
   "typing-extensions>=4.15; python_version<'3.11'",
   "virtualenv>=20.39",
 ]

--- a/src/tox/config/loader/native.py
+++ b/src/tox/config/loader/native.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from tox.config.set_env import SetEnv
+from tox.config.types import Command, EnvList
+from tox.tox_env.python.pip.req_file import PythonDeps
+
+
+def to_native(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float, str)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    return _to_native_complex(value)
+
+
+def _to_native_complex(value: Any) -> Any:
+    if isinstance(value, SetEnv):
+        return {k: to_native(value.load(k)) for k in sorted(value)}
+    if isinstance(value, PythonDeps):
+        return to_native(value.lines())
+    if isinstance(value, EnvList):
+        return value.envs
+    if isinstance(value, Command):
+        return value.shell
+    return _to_native_collection(value)
+
+
+def _to_native_collection(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(k): to_native(v) for k, v in value.items()}
+    if isinstance(value, set):
+        return sorted(str(i) for i in value)
+    if isinstance(value, Sequence):
+        return [to_native(i) for i in value]
+    return str(value)
+
+
+__all__ = ("to_native",)

--- a/src/tox/config/loader/section.py
+++ b/src/tox/config/loader/section.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import sys
 
-    if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+    if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
         from typing import Self
-    else:  # pragma: no cover (<py311)
+    else:  # pragma: <3.11 cover
         from typing_extensions import Self
 
 

--- a/src/tox/config/source/legacy_toml.py
+++ b/src/tox/config/source/legacy_toml.py
@@ -4,9 +4,9 @@ import sys
 
 from tox.config.types import MissingRequiredConfigKeyError
 
-if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
-else:  # pragma: no cover (py311+)
+else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 

--- a/src/tox/config/source/toml_pyproject.py
+++ b/src/tox/config/source/toml_pyproject.py
@@ -15,9 +15,9 @@ from tox.report import HandledError
 
 from .api import Source
 
-if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
-else:  # pragma: no cover (py311+)
+else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 if TYPE_CHECKING:

--- a/src/tox/execute/local_sub_process/read_via_thread.py
+++ b/src/tox/execute/local_sub_process/read_via_thread.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from types import TracebackType
 
-    if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+    if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
         from typing import Self
-    else:  # pragma: no cover (<py311)
+    else:  # pragma: <3.11 cover
         from typing_extensions import Self
 
 

--- a/src/tox/execute/stream.py
+++ b/src/tox/execute/stream.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from types import TracebackType
 
-    if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+    if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
         from typing import Self
-    else:  # pragma: no cover (<py311)
+    else:  # pragma: <3.11 cover
         from typing_extensions import Self
 
 

--- a/src/tox/session/cmd/show_config/__init__.py
+++ b/src/tox/session/cmd/show_config/__init__.py
@@ -1,0 +1,65 @@
+"""Show materialized configuration of tox environments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, get_args
+
+from tox.plugin import impl
+from tox.session.cmd.run.common import env_run_create_flags
+from tox.session.env_select import CliEnv, register_env_select_flags
+
+if TYPE_CHECKING:
+    from tox.config.cli.parser import ToxParser
+    from tox.session.state import State
+
+ConfigFormat = Literal["ini", "json", "toml"]
+
+
+@impl
+def tox_add_option(parser: ToxParser) -> None:
+    our = parser.add_command("config", ["c"], "show tox configuration", show_config)
+    our.add_argument(
+        "-k",
+        nargs="+",
+        help="list just configuration keys specified",
+        dest="list_keys_only",
+        default=[],
+        metavar="key",
+    )
+    our.add_argument(
+        "--core",
+        action="store_true",
+        help="show core options (by default is hidden unless -e ALL is passed)",
+        dest="show_core",
+    )
+    our.add_argument(
+        "--format",
+        choices=get_args(ConfigFormat),
+        default="ini",
+        help="output format (default: %(default)s)",
+        dest="config_format",
+    )
+    our.add_argument(
+        "-o",
+        "--output-file",
+        of_type=Path,
+        default=None,
+        help="write output to file instead of stdout",
+        dest="output_file",
+    )
+    register_env_select_flags(our, default=CliEnv())
+    env_run_create_flags(our, mode="config")
+
+
+def show_config(state: State) -> int:
+    from .ini import show_config_ini  # noqa: PLC0415
+    from .json_format import show_config_json  # noqa: PLC0415
+    from .toml_format import show_config_toml  # noqa: PLC0415
+
+    fmt: ConfigFormat = state.conf.options.config_format
+    if fmt == "json":
+        return show_config_json(state)
+    if fmt == "toml":
+        return show_config_toml(state)
+    return show_config_ini(state)

--- a/src/tox/session/cmd/show_config/common.py
+++ b/src/tox/session/cmd/show_config/common.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from tox.config.loader.native import to_native
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from tox.config.sets import ConfigSet
+    from tox.session.state import State
+
+
+def build_structured_result(state: State) -> tuple[dict[str, Any], bool]:
+    keys: list[str] = state.conf.options.list_keys_only
+    show_everything = state.conf.options.env.is_all
+    has_exception = False
+    result: dict[str, Any] = {}
+
+    envs: dict[str, Any] = {}
+    for name in state.envs.iter(package=True):
+        tox_env = state.envs[name]
+        env_data, exc = _collect_conf(tox_env.conf, keys)
+        if not keys:
+            env_data = {"type": type(tox_env).__name__, **env_data}
+        if exc:
+            has_exception = True
+        envs[tox_env.conf.name] = env_data
+    result["env"] = envs
+
+    if show_everything or state.conf.options.show_core:
+        tox_data, exc = _collect_conf(state.conf.core, keys)
+        has_exception = has_exception or exc
+        result["tox"] = tox_data
+
+    return result, has_exception
+
+
+def write_output(
+    output: str,
+    output_file: Path | None,
+    is_colored: bool,  # noqa: FBT001
+    colorize: Callable[[str], str],
+) -> None:
+    if output_file is not None:
+        Path(output_file).write_text(output + "\n", encoding="utf-8")
+    else:
+        print(colorize(output) if is_colored else output)  # noqa: T201
+
+
+def _collect_conf(conf: ConfigSet, keys: list[str]) -> tuple[dict[str, Any], bool]:
+    data: dict[str, Any] = {}
+    has_exception = False
+    for key in keys or conf:
+        if key not in conf:
+            continue
+        key = conf.primary_key(key)  # noqa: PLW2901
+        try:
+            data[key] = to_native(conf[key])
+        except Exception as exception:
+            if os.environ.get("_TOX_SHOW_CONFIG_RAISE"):  # pragma: no branch
+                raise  # pragma: no cover
+            data[key] = {"error": repr(exception)}
+            has_exception = True
+    if (unused := conf.unused()) and not keys:
+        data["unused"] = sorted(unused)
+    return data, has_exception

--- a/src/tox/session/cmd/show_config/ini.py
+++ b/src/tox/session/cmd/show_config/ini.py
@@ -1,5 +1,3 @@
-"""Show materialized configuration of tox environments."""
-
 from __future__ import annotations
 
 import os
@@ -9,41 +7,16 @@ from typing import TYPE_CHECKING
 from colorama import Fore
 
 from tox.config.loader.stringify import stringify
-from tox.plugin import impl
-from tox.session.cmd.run.common import env_run_create_flags
-from tox.session.env_select import CliEnv, register_env_select_flags
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from tox.config.cli.parser import ToxParser
     from tox.config.sets import ConfigSet
     from tox.session.state import State
     from tox.tox_env.api import ToxEnv
 
 
-@impl
-def tox_add_option(parser: ToxParser) -> None:
-    our = parser.add_command("config", ["c"], "show tox configuration", show_config)
-    our.add_argument(
-        "-k",
-        nargs="+",
-        help="list just configuration keys specified",
-        dest="list_keys_only",
-        default=[],
-        metavar="key",
-    )
-    our.add_argument(
-        "--core",
-        action="store_true",
-        help="show core options (by default is hidden unless -e ALL is passed)",
-        dest="show_core",
-    )
-    register_env_select_flags(our, default=CliEnv())
-    env_run_create_flags(our, mode="config")
-
-
-def show_config(state: State) -> int:
+def show_config_ini(state: State) -> int:
     is_colored = state.conf.options.is_colored
     keys: list[str] = state.conf.options.list_keys_only
     is_first = True
@@ -55,23 +28,22 @@ def show_config(state: State) -> int:
             is_first = False
         else:
             print()  # noqa: T201
-        print_section_header(is_colored, f"[testenv:{tox_env.conf.name}]")
+        _print_section_header(is_colored, f"[testenv:{tox_env.conf.name}]")
         if not keys:
-            print_key_value(is_colored, "type", type(tox_env).__name__)
-        if print_conf(is_colored, tox_env.conf, keys):
+            _print_key_value(is_colored, "type", type(tox_env).__name__)
+        if _print_conf(is_colored, tox_env.conf, keys):
             has_exception = True
 
     show_everything = state.conf.options.env.is_all
     done: set[str] = set()
-    for name in state.envs.iter(package=True):  # now go through selected ones
+    for name in state.envs.iter(package=True):
         done.add(name)
         _print_env(state.envs[name])
 
-    # environments may define core configuration flags, so we must exhaust first the environments to tell the core part
     if show_everything or state.conf.options.show_core:
         print()  # noqa: T201
-        print_section_header(is_colored, "[tox]")
-        if print_conf(is_colored, state.conf.core, keys):
+        _print_section_header(is_colored, "[tox]")
+        if _print_conf(is_colored, state.conf.core, keys):
             has_exception = True
     return -1 if has_exception else 0
 
@@ -80,15 +52,15 @@ def _colored(is_colored: bool, color: int, msg: str) -> str:  # noqa: FBT001
     return f"{color}{msg}{Fore.RESET}" if is_colored else msg
 
 
-def print_section_header(is_colored: bool, name: str) -> None:  # noqa: FBT001
+def _print_section_header(is_colored: bool, name: str) -> None:  # noqa: FBT001
     print(_colored(is_colored, Fore.YELLOW, name))  # noqa: T201
 
 
-def print_comment(is_colored: bool, comment: str) -> None:  # noqa: FBT001
+def _print_comment(is_colored: bool, comment: str) -> None:  # noqa: FBT001
     print(_colored(is_colored, Fore.CYAN, comment))  # noqa: T201
 
 
-def print_key_value(is_colored: bool, key: str, value: str, multi_line: bool = False) -> None:  # noqa: FBT001, FBT002
+def _print_key_value(is_colored: bool, key: str, value: str, multi_line: bool = False) -> None:  # noqa: FBT001, FBT002
     print(_colored(is_colored, Fore.GREEN, key), end="")  # noqa: T201
     print(" =", end="")  # noqa: T201
     if multi_line:
@@ -100,7 +72,7 @@ def print_key_value(is_colored: bool, key: str, value: str, multi_line: bool = F
     print(value_str)  # noqa: T201
 
 
-def print_conf(is_colored: bool, conf: ConfigSet, keys: Iterable[str]) -> bool:  # noqa: FBT001
+def _print_conf(is_colored: bool, conf: ConfigSet, keys: Iterable[str]) -> bool:  # noqa: FBT001
     has_exception = False
     for key in keys or conf:
         if key not in conf:
@@ -116,8 +88,8 @@ def print_conf(is_colored: bool, conf: ConfigSet, keys: Iterable[str]) -> bool: 
             has_exception = True
         if multi_line and "\n" not in as_str:
             multi_line = False
-        print_key_value(is_colored, key, as_str, multi_line=multi_line)
+        _print_key_value(is_colored, key, as_str, multi_line=multi_line)
     unused = conf.unused()
     if unused and not keys:
-        print_comment(is_colored, f"# !!! unused: {', '.join(unused)}")
+        _print_comment(is_colored, f"# !!! unused: {', '.join(unused)}")
     return has_exception

--- a/src/tox/session/cmd/show_config/json_format.py
+++ b/src/tox/session/cmd/show_config/json_format.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+from colorama import Fore
+
+from .common import build_structured_result, write_output
+
+if TYPE_CHECKING:
+    from tox.session.state import State
+
+_KEY_RE = re.compile(
+    r"""
+    ^ ([ ]*)        # leading indentation
+    " ([^"]+) "     # quoted key name
+    :               # colon separator
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+
+
+def show_config_json(state: State) -> int:
+    result, has_exception = build_structured_result(state)
+    output = json.dumps(result, indent=2)
+    write_output(output, state.conf.options.output_file, state.conf.options.is_colored, colorize)
+    return -1 if has_exception else 0
+
+
+def colorize(text: str) -> str:
+    return _KEY_RE.sub(rf"\1{Fore.GREEN}\2{Fore.RESET}:", text)

--- a/src/tox/session/cmd/show_config/toml_format.py
+++ b/src/tox/session/cmd/show_config/toml_format.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import tomli_w
+from colorama import Fore
+
+from .common import build_structured_result, write_output
+
+if TYPE_CHECKING:
+    from tox.session.state import State
+
+_HEADER_RE = re.compile(
+    r"""
+    ^ \[ .* ] $     # section header like [env.py]
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+_KEY_RE = re.compile(
+    r"""
+    ^ ( [a-zA-Z_]       # key starts with letter or underscore
+        [a-zA-Z0-9_-]*  # followed by alphanumerics, underscores, or hyphens
+      )
+    \s* =               # equals sign with optional whitespace
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+
+
+def show_config_toml(state: State) -> int:
+    result, has_exception = build_structured_result(state)
+    output = tomli_w.dumps(result).removesuffix("\n")
+    write_output(output, state.conf.options.output_file, state.conf.options.is_colored, colorize)
+    return -1 if has_exception else 0
+
+
+def colorize(text: str) -> str:
+    text = _HEADER_RE.sub(lambda m: f"{Fore.YELLOW}{m.group()}{Fore.RESET}", text)
+    return _KEY_RE.sub(rf"{Fore.GREEN}\1{Fore.RESET} =", text)

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -27,9 +27,9 @@ if TYPE_CHECKING:
     from argparse import Action, ArgumentParser, Namespace
     from collections.abc import Iterable, Iterator
 
-    if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+    if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
         from typing import Self
-    else:  # pragma: no cover (<py311)
+    else:  # pragma: <3.11 cover
         from typing_extensions import Self
 
     from tox.session.state import State

--- a/src/tox/tox_env/python/dependency_groups.py
+++ b/src/tox/tox_env/python/dependency_groups.py
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
-else:  # pragma: no cover (py311+)
+else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 _IncludeGroup = TypedDict("_IncludeGroup", {"include-group": str})

--- a/src/tox/tox_env/python/extras.py
+++ b/src/tox/tox_env/python/extras.py
@@ -10,9 +10,9 @@ from .virtual_env.package.util import dependencies_with_extras_from_markers
 if TYPE_CHECKING:
     from pathlib import Path
 
-if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
-else:  # pragma: no cover (py311+)
+else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 

--- a/src/tox/tox_env/python/virtual_env/package/pyproject.py
+++ b/src/tox/tox_env/python/virtual_env/package/pyproject.py
@@ -50,9 +50,9 @@ if TYPE_CHECKING:
 
 from importlib.metadata import Distribution, PathDistribution
 
-if sys.version_info >= (3, 11):  # pragma: no cover (py311+)
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
-else:  # pragma: no cover (py311+)
+else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 ConfigSettings = dict[str, Any] | None
@@ -320,13 +320,13 @@ class Pep517VenvPackager(PythonPackageToxEnv, ABC):
             # Step 2: Extract sdist to env_tmp_dir (auto-cleaned by tox lifecycle)
             (extract_dir := self.env_tmp_dir / "sdist-extract").mkdir(parents=True, exist_ok=True)
             with tarfile.open(str(sdist), "r:*") as tar:
-                if sys.version_info >= (3, 12):  # pragma: no cover (py312+)
+                if sys.version_info >= (3, 12):  # pragma: >=3.12 cover
                     try:
                         tar.extractall(path=str(extract_dir), filter="data")
                     except tarfile.OutsideDestinationError as exc:
                         msg = f"tar member {exc.tarinfo.name!r} would extract outside of {extract_dir}"
                         raise Fail(msg) from exc
-                else:  # pragma: no cover (py312+)
+                else:  # pragma: <3.12 cover
                     dest_resolved = extract_dir.resolve()
                     safe_members: list[tarfile.TarInfo] = []
                     for member in tar.getmembers():

--- a/tests/config/loader/test_native.py
+++ b/tests/config/loader/test_native.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from tox.config.loader.native import to_native
+from tox.config.set_env import SetEnv
+from tox.config.types import Command, EnvList
+from tox.tox_env.python.pip.req_file import PythonDeps
+
+
+def test_str() -> None:
+    assert to_native("hello") == "hello"
+
+
+def test_bool_true() -> None:
+    assert to_native(True) is True
+
+
+def test_bool_false() -> None:
+    assert to_native(False) is False
+
+
+def test_bool_before_int() -> None:
+    result = to_native(True)
+    assert result is True
+    assert not isinstance(result, int) or isinstance(result, bool)
+
+
+def test_int() -> None:
+    assert to_native(42) == 42
+
+
+def test_float() -> None:
+    assert to_native(math.pi) == math.pi
+
+
+def test_path(tmp_path: Path) -> None:
+    assert to_native(tmp_path) == str(tmp_path)
+
+
+def test_posix_path() -> None:
+    assert to_native(PurePosixPath("/usr/bin")) == "/usr/bin"
+
+
+def test_dict() -> None:
+    assert to_native({"a": 1, "b": "c"}) == {"a": 1, "b": "c"}
+
+
+def test_nested_dict() -> None:
+    assert to_native({"a": {"b": 1}}) == {"a": {"b": 1}}
+
+
+def test_list() -> None:
+    assert to_native([1, "two", 3.0]) == [1, "two", 3.0]
+
+
+def test_list_of_paths(tmp_path: Path) -> None:
+    p = tmp_path / "a"
+    assert to_native([p]) == [str(p)]
+
+
+def test_set() -> None:
+    result = to_native({"c", "a", "b"})
+    assert result == ["a", "b", "c"]
+
+
+def test_env_list() -> None:
+    assert to_native(EnvList(["py39", "py310", "lint"])) == ["py39", "py310", "lint"]
+
+
+def test_command_simple() -> None:
+    assert to_native(Command(["pytest"])) == "pytest"
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_prefix"),
+    [
+        (["pytest", "-v"], "pytest"),
+        (["-", "cmd"], "cmd"),
+        (["!", "cmd"], "cmd"),
+    ],
+)
+def test_command_variants(args: list[str], expected_prefix: str) -> None:
+    result = to_native(Command(args))
+    assert isinstance(result, str)
+    assert expected_prefix in result
+
+
+def test_set_env(tmp_path: Path) -> None:
+    raw = "A=1\nB=hello"
+    se = SetEnv(raw, "set_env", "py", tmp_path)
+    result = to_native(se)
+    assert result == {"A": "1", "B": "hello"}
+
+
+def test_python_deps(tmp_path: Path) -> None:
+    (tmp_path / "tox.ini").touch()
+    deps = PythonDeps("pytest\nflask>=2.0", tmp_path)
+    result = to_native(deps)
+    assert result == ["pytest", "flask>=2.0"]
+
+
+def test_fallback_unknown_type() -> None:
+    class Custom:
+        def __str__(self) -> str:
+            return "custom-value"
+
+    assert to_native(Custom()) == "custom-value"
+
+
+def test_empty_str() -> None:
+    assert to_native("") is not None
+    assert isinstance(to_native(""), str)
+    assert len(to_native("")) == 0
+
+
+def test_zero() -> None:
+    assert to_native(0) == 0
+    assert isinstance(to_native(0), int)
+
+
+def test_float_zero() -> None:
+    result = to_native(0.0)
+    assert isinstance(result, float)
+    assert result == pytest.approx(0.0)

--- a/tests/session/cmd/test_show_config_json.py
+++ b/tests/session/cmd/test_show_config_json.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from tox.session.cmd.show_config.json_format import colorize as colorize_json
+from tox.session.cmd.show_config.toml_format import colorize as colorize_toml
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    import tomllib
+else:  # pragma: <3.11 cover
+    import tomli as tomllib
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from tox.pytest import ToxProjectCreator
+
+_FORMATS = [
+    pytest.param("json", json.loads, id="json"),
+    pytest.param("toml", tomllib.loads, id="toml"),
+]
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_basic_structure(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true\n[testenv]\ncommands = python -c pass"})
+    result = project.run("c", "-e", "py", "--format", fmt)
+    result.assert_success()
+    env = loader(result.out)["env"]["py"]
+    assert env["type"] == "VirtualEnvRunner"
+    assert env["env_name"] == "py"
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_core_with_flag(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true"})
+    result = project.run("c", "-e", "py", "--core", "--format", fmt)
+    result.assert_success()
+    assert "tox_root" in loader(result.out)["tox"]
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_no_core_by_default(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true"})
+    result = project.run("c", "-e", "py", "--format", fmt)
+    result.assert_success()
+    assert "tox" not in loader(result.out)
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_core_with_all_envs(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true\nenv_list = py"})
+    result = project.run("c", "-e", "ALL", "--format", fmt)
+    result.assert_success()
+    assert "tox" in loader(result.out)
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_key_filtering(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true\n[testenv]\ncommands = python -c pass"})
+    result = project.run("c", "-e", "py", "--format", fmt, "-k", "env_name", "commands")
+    result.assert_success()
+    env = loader(result.out)["env"]["py"]
+    assert "env_name" in env
+    assert "commands" in env
+    assert "type" not in env
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_native_types(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true\n[testenv]\npackage = skip"})
+    result = project.run("c", "-e", "py", "--format", fmt, "-k", "suicide_timeout", "allowlist_externals")
+    result.assert_success()
+    env = loader(result.out)["env"]["py"]
+    assert isinstance(env["suicide_timeout"], float)
+    assert isinstance(env["allowlist_externals"], list)
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_multiple_envs(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true\nenv_list = a,b\n[testenv]\npackage = skip"})
+    result = project.run("c", "-e", "a,b", "--format", fmt)
+    result.assert_success()
+    data = loader(result.out)
+    assert "a" in data["env"]
+    assert "b" in data["env"]
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_unused_keys(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[testenv:py]\nmagical = yes\nmagic = yes"})
+    result = project.run("c", "-e", "py", "--format", fmt)
+    result.assert_success()
+    assert sorted(loader(result.out)["env"]["py"]["unused"]) == ["magic", "magical"]
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_no_unused_with_key_filter(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[testenv:py]\nmagical = yes"})
+    result = project.run("c", "-e", "py", "--format", fmt, "-k", "env_name")
+    result.assert_success()
+    assert "unused" not in loader(result.out)["env"]["py"]
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_output_to_file(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any], tmp_path: Path) -> None:
+    out_file = tmp_path / f"config.{fmt}"
+    project = tox_project({"tox.ini": "[tox]\nno_package = true"})
+    result = project.run("c", "-e", "py", "--format", fmt, "-o", str(out_file))
+    result.assert_success()
+    assert not result.out
+    assert "py" in loader(out_file.read_text())["env"]
+
+
+@pytest.mark.parametrize("fmt", [pytest.param("json", id="json"), pytest.param("toml", id="toml")])
+def test_file_output_no_ansi(tox_project: ToxProjectCreator, fmt: str, tmp_path: Path) -> None:
+    out_file = tmp_path / f"config.{fmt}"
+    project = tox_project({"tox.ini": "[tox]\nno_package = true"})
+    result = project.run("c", "-e", "py", "--format", fmt, "-o", str(out_file))
+    result.assert_success()
+    assert "\x1b[" not in out_file.read_text()
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_set_env(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true\n[testenv]\nset_env =\n    A=1\n    B=hello"})
+    result = project.run("c", "-e", "py", "--format", fmt, "-k", "set_env")
+    result.assert_success()
+    se = loader(result.out)["env"]["py"]["set_env"]
+    assert se["A"] == "1"
+    assert se["B"] == "hello"
+
+
+@pytest.mark.parametrize(("fmt", "loader"), _FORMATS)
+def test_deps(tox_project: ToxProjectCreator, fmt: str, loader: Callable[[str], Any]) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true\n[testenv]\ndeps =\n    pytest\n    flask>=2.0"})
+    result = project.run("c", "-e", "py", "--format", fmt, "-k", "deps")
+    result.assert_success()
+    deps = loader(result.out)["env"]["py"]["deps"]
+    assert isinstance(deps, list)
+    assert "pytest" in deps
+    assert "flask>=2.0" in deps
+
+
+def test_json_exception(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": "[testenv:a]\nbase_python = missing-python"})
+    result = project.run("c", "-e", "a", "--format", "json", "-k", "env_site_packages_dir", raise_on_config_fail=False)
+    result.assert_failed(code=-1)
+    assert "error" in json.loads(result.out)["env"]["a"]["env_site_packages_dir"]
+
+
+def test_json_pass_env(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true\n[testenv]\npass_env = HOME,PATH"})
+    result = project.run("c", "-e", "py", "--format", "json", "-k", "pass_env")
+    result.assert_success()
+    pe = json.loads(result.out)["env"]["py"]["pass_env"]
+    assert isinstance(pe, list)
+    assert "HOME" in pe
+
+
+def test_json_alias_key(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true"})
+    result = project.run("c", "-e", "py", "--format", "json", "-k", "setenv")
+    result.assert_success()
+    assert "set_env" in json.loads(result.out)["env"]["py"]
+
+
+def test_json_valid_output(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true"})
+    result = project.run("c", "-e", "py", "--format", "json")
+    result.assert_success()
+    json.loads(result.out)
+
+
+def test_json_native_types_approx(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true\n[testenv]\npackage = skip"})
+    result = project.run("c", "-e", "py", "--format", "json", "-k", "suicide_timeout")
+    result.assert_success()
+
+
+@pytest.mark.parametrize("fmt", [pytest.param("json", id="json"), pytest.param("toml", id="toml")])
+def test_key_filter_skips_missing(tox_project: ToxProjectCreator, fmt: str) -> None:
+    project = tox_project({"tox.ini": "[tox]\nno_package = true"})
+    result = project.run("c", "-e", "py", "--format", fmt, "-k", "no_such_key")
+    result.assert_success()
+
+
+def test_core_exception_json(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.ini": "[testenv:a]\nbase_python = missing-python"})
+    result = project.run(
+        "c", "-e", "a", "--core", "--format", "json", "-k", "env_site_packages_dir", raise_on_config_fail=False
+    )
+    result.assert_failed(code=-1)
+    data = json.loads(result.out)
+    assert "error" in data["env"]["a"]["env_site_packages_dir"]
+    assert "tox" in data
+
+
+def testcolorize_json() -> None:
+    result = colorize_json('{\n  "key": "val"\n}')
+    assert "\x1b[" in result
+    assert "key" in result
+
+
+def testcolorize_toml() -> None:
+    result = colorize_toml("[env.py]\nname = true")
+    assert "\x1b[" in result
+    assert "env.py" in result

--- a/tox.toml
+++ b/tox.toml
@@ -6,6 +6,7 @@ skip_missing_interpreters = true
 description = "run the tests with pytest under {env_name}"
 package = "wheel"
 wheel_build_env = ".pkg"
+uv_seed = true
 extras = [ "completion" ]
 dependency_groups = [ "test" ]
 pass_env = [ "PYTEST_*", "SSL_CERT_FILE" ]


### PR DESCRIPTION
There is currently no reliable programmatic way to retrieve tox environment configuration. The `tox config` command outputs colored INI-style text that's difficult for tools, scripts, and CI pipelines to consume. This forces users to resort to fragile regex parsing or screen-scraping to extract configuration values. Closes #3854

The `config` command now accepts `--format` (`ini`, `json`, `toml`) and `-o`/`--output-file` flags. ✨ JSON and TOML output preserves native types (booleans, integers, floats, arrays, dicts) and uses the same key structure as `tox.toml` — `env.<name>` for environments, `tox` for core settings — so the output schema feels familiar to anyone already writing tox configuration in TOML. Both structured formats get syntax highlighting on stdout matching the existing INI color behavior, while file output via `-o` is always clean for machine consumption. A new `jsonify()` function in `src/tox/config/loader/jsonify.py` handles the type conversion, parallel to the existing `stringify()`.

📝 Documentation across all three Diataxis dimensions (tutorial, how-to, explanation) has been updated with tabbed examples showing INI, JSON, and TOML output side by side. The `tomli-w` package is added as a dependency for TOML serialization. All existing `-k`, `--core`, and `-e` flags compose naturally with the new format options.