### PR TITLE
Replace archived 31z4/tox Docker image with build-your-own guide

### DIFF
--- a/docs/changelog/3855.doc.rst
+++ b/docs/changelog/3855.doc.rst
@@ -1,1 +1,2 @@
-Replace archived ``31z4/tox`` Docker image recommendation with instructions for building your own image using the official Python base image and ``uv`` - by :user:`rahuldevikar`.
+Replace archived ``31z4/tox`` Docker image recommendation with instructions for building your own image using the
+official Python base image and ``uv`` - by :user:`rahuldevikar`.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -1157,9 +1157,9 @@ up dependency installation.
 
 .. _howto-docker:
 
-***************************************
+***********************************
  Run tox inside a Docker container
-***************************************
+***********************************
 
 Build a lightweight Docker image that contains tox and your target Python versions. Using `uv
 <https://docs.astral.sh/uv/>`__ keeps the image small and installation fast:
@@ -1214,9 +1214,9 @@ To test against multiple Python versions in the same image, start from a base im
 
 .. note::
 
-    The previously recommended `31z4/tox <https://hub.docker.com/r/31z4/tox>`_ Docker image has been
-    `archived <https://github.com/31z4/tox-docker>`_ and is no longer maintained. The image is still available on
-    Docker Hub but may not receive updates. Building your own image as shown above is the recommended approach.
+    The previously recommended `31z4/tox <https://hub.docker.com/r/31z4/tox>`_ Docker image has been `archived
+    <https://github.com/31z4/tox-docker>`_ and is no longer maintained. The image is still available on Docker Hub but
+    may not receive updates. Building your own image as shown above is the recommended approach.
 
 .. ------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Resolves #3855 