### PR TITLE
support multiple values in --override via \n separator

### DIFF
--- a/docs/changelog/3859.feature.rst
+++ b/docs/changelog/3859.feature.rst
@@ -1,0 +1,2 @@
+Support multiple values in ``--override`` for list configs like ``deps`` by using ``\n`` as a line separator - e.g.,
+``-x "testenv.deps=pytest\npytest-repeat"`` - by :user:`rahuldevikar`.

--- a/src/tox/config/loader/api.py
+++ b/src/tox/config/loader/api.py
@@ -157,7 +157,8 @@ class Loader(Convert[T]):
                 raise KeyError(key)
 
         for override in overrides:
-            converted_override = _STR_CONVERT.to(override.value, of_type, factory)
+            override_value = resolve_override_value(override.value)
+            converted_override = _STR_CONVERT.to(override_value, of_type, factory)
             if override.append and converted is not None:
                 if isinstance(converted, list) and isinstance(converted_override, list):
                     converted += converted_override
@@ -212,3 +213,30 @@ def tox_add_option(parser: ToxParser) -> None:
 
 
 _STR_CONVERT = StrConvert()
+
+
+def resolve_override_value(value: str) -> str:
+    r"""Resolve escape sequences in override values.
+
+    Allows specifying multi-value overrides on the CLI by using ``\n`` as a line separator. For example: ``-x
+    "testenv.deps=pytest\npytest-repeat"`` provides two dependencies.
+
+    Supports ``\\`` to produce a literal backslash.
+
+    """
+    result: list[str] = []
+    i = 0
+    while i < len(value):
+        if value[i] == "\\" and i + 1 < len(value):
+            nxt = value[i + 1]
+            if nxt == "n":
+                result.append("\n")
+                i += 2
+                continue
+            if nxt == "\\":
+                result.append("\\")
+                i += 2
+                continue
+        result.append(value[i])
+        i += 1
+    return "".join(result)

--- a/tests/config/test_main.py
+++ b/tests/config/test_main.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from tox.config.loader.api import Override
+from tox.config.loader.api import Override, resolve_override_value
 from tox.config.loader.memory import MemoryLoader
 from tox.config.sets import ConfigSet
 from tox.tox_env.python.pip.req_file import PythonDeps
@@ -216,6 +216,75 @@ def test_config_override_cannot_append(tox_ini_conf: ToxIniCreator) -> None:
     conf.add_config("foo", of_type=int, default=0, desc="desc")
     with pytest.raises(ValueError, match="Only able to append to lists and dicts"):
         conf["foo"]
+
+
+def test_config_override_multivalue_pythondeps(tox_ini_conf: ToxIniCreator, tmp_path: Path) -> None:
+    example = """
+    [testenv]
+    """
+    conf = tox_ini_conf(example, override=[Override("testenv.deps=pytest\\npytest-repeat")]).get_env("testenv")
+    conf.add_config(
+        "deps",
+        of_type=PythonDeps,
+        factory=partial(PythonDeps.factory, tmp_path),
+        default=PythonDeps("", root=tmp_path),
+        desc="desc",
+    )
+    assert conf["deps"].lines() == ["pytest", "pytest-repeat"]
+
+
+def test_config_override_multivalue_pythondeps_append(tox_ini_conf: ToxIniCreator, tmp_path: Path) -> None:
+    example = """
+    [testenv]
+    deps = foo
+    """
+    conf = tox_ini_conf(example, override=[Override("testenv.deps+=bar\\nbaz")]).get_env("testenv")
+    conf.add_config(
+        "deps",
+        of_type=PythonDeps,
+        factory=partial(PythonDeps.factory, tmp_path),
+        default=PythonDeps("", root=tmp_path),
+        desc="desc",
+    )
+    assert conf["deps"].lines() == ["foo", "bar", "baz"]
+
+
+def test_config_override_multivalue_list(tox_ini_conf: ToxIniCreator) -> None:
+    example = """
+    [testenv]
+    passenv = FOO
+    """
+    conf = tox_ini_conf(example, override=[Override("testenv.passenv=BAR\\nBAZ")]).get_env("testenv")
+    conf.add_config("passenv", of_type=list[str], default=[], desc="desc")
+    assert conf["passenv"] == ["BAR", "BAZ"]
+
+
+def test_config_override_escape_literal_backslash(tox_ini_conf: ToxIniCreator) -> None:
+    conf = tox_ini_conf("[testenv]", override=[Override("testenv.c=a\\\\b")]).get_env("py")
+    conf.add_config("c", of_type=str, default="d", desc="desc")
+    assert conf["c"] == "a\\b"
+
+
+def test_config_override_escape_backslash_n(tox_ini_conf: ToxIniCreator) -> None:
+    conf = tox_ini_conf("[testenv]", override=[Override("testenv.c=a\\\\nb")]).get_env("py")
+    conf.add_config("c", of_type=str, default="d", desc="desc")
+    assert conf["c"] == "a\\nb"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("simple", "simple", id="no_escapes"),
+        pytest.param("a\\nb", "a\nb", id="newline"),
+        pytest.param("a\\\\b", "a\\b", id="backslash"),
+        pytest.param("a\\\\nb", "a\\nb", id="backslash_then_n"),
+        pytest.param("a\\n\\nb", "a\n\nb", id="two_newlines"),
+        pytest.param("\\n", "\n", id="only_newline"),
+        pytest.param("trailing\\", "trailing\\", id="trailing_backslash"),
+    ],
+)
+def test_resolve_override_value(raw: str, expected: str) -> None:
+    assert resolve_override_value(raw) == expected
 
 
 def test_args_are_paths_when_disabled(tox_project: ToxProjectCreator) -> None:


### PR DESCRIPTION
Added a small helper function `_resolve_override_value()` that processes the override value before it's converted to the target type. It interprets the literal two-character sequence `\n` as an actual newline.

tox will see that as two separate lines — `pytest` and `pytest-repeat` — which get correctly installed as two separate packages.

It also supports `\\` to produce a literal backslash, so there's no ambiguity if you actually need a backslash in a value. This works for all list-type configs (deps, passenv, setenv, etc.), not just deps.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
