### PR TITLE
document {env:TOX_PACKAGE} for referencing built packages in commands

### DIFF
--- a/docs/changelog/3862.doc.rst
+++ b/docs/changelog/3862.doc.rst
@@ -1,0 +1,1 @@
+Document how to reference the built package path in commands via ``TOX_PACKAGE`` - by :user:`rahuldevikar`

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -1682,6 +1682,45 @@ tox automatically detects and uses whatever backend is specified in ``[build-sys
 is needed. For build backends that need extra configuration during the build, use :ref:`config_settings_build_wheel` and
 related options.
 
+.. _howto-reference-built-package:
+
+**********************************************
+ Reference the built package path in commands
+**********************************************
+
+When tox builds an sdist or wheel for your project it stores the path in the ``TOX_PACKAGE`` environment variable (see
+:ref:`injected-environment-variables`). Reference it in ``commands`` (or any other config value) to run post-build
+checks such as ``twine check``, ``check-wheel-contents``, or ``pkginfo`` against the exact artifact that was just built
+and installed.
+
+.. tab:: TOML
+
+    Use the explicit environment variable reference (see :ref:`pyproject-toml-native`):
+
+    .. code-block:: toml
+
+        [env.check]
+        description = "check the built package"
+        deps = ["twine"]
+        commands = [["twine", "check", { replace = "env", name = "TOX_PACKAGE" }]]
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+        [testenv:check]
+        description = check the built package
+        deps = twine
+        commands = twine check {env:TOX_PACKAGE}
+
+``TOX_PACKAGE`` is only set in run environments where a package has been built. If there are multiple artifacts (for
+example both an sdist and a wheel), the paths are joined with ``os.pathsep``.
+
+.. tip::
+
+    If you need a glob-based approach instead (e.g. matching files produced outside of tox), use the ``{glob:PATTERN}``
+    substitution — see :ref:`substitution-reference`.
+
 **********************************
  Migrate from tox.ini to tox.toml
 **********************************

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -995,7 +995,7 @@ always set regardless of the ``pass_env`` or ``set_env`` configuration and canno
         because user site-packages aren't visible. Only set when using ``virtualenv``\-based environments.
     - - ``TOX_PACKAGE``
       - The path(s) to the built package artifact(s), joined by ``os.pathsep`` if there are multiple. Only set in run
-        environments where a package has been built.
+        environments where a package has been built. See :ref:`howto-reference-built-package` for usage examples.
     - - ``VIRTUAL_ENV``
       - The path to the virtual environment directory. Only set when using ``virtualenv``\-based environments (the
         default).


### PR DESCRIPTION
Fixes #3862 requested exposing the built sdist/wheel path for use in commands. The TOX_PACKAGE environment variable already provides this — it is set in RunToxEnv.environment_variables after the package is built during _setup_pkg(), and is available by the time commands are resolved in run_commands(). However, this wasn't documented as a recipe for the common use case of running post-build checks like twine check or check-wheel-contents against the built artifact

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
