### PR TITLE
🧪 test(docs): validate doc config examples to prevent regressions

### DIFF
--- a/docs/changelog/3875.doc.rst
+++ b/docs/changelog/3875.doc.rst
@@ -1,0 +1,2 @@
+Fix broken TOML examples missing ``extend = true`` on conditional replacements inside lists, fix incorrect ``ref of``
+path in raw reference docs, and add a test that validates all doc config examples - by :user:`gaborbernat`

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -299,13 +299,13 @@ platform without encoding the platform name in the environment:
          [env_run_base]
          deps = [
              "pytest",
-             { replace = "if", condition = "factor.linux or factor.darwin", then = ["platformdirs>=3"] },
-             { replace = "if", condition = "factor.win32", then = ["platformdirs>=2"] },
+             { replace = "if", condition = "factor.linux or factor.darwin", then = ["platformdirs>=3"], extend = true },
+             { replace = "if", condition = "factor.win32", then = ["platformdirs>=2"], extend = true },
          ]
          commands = [
-             { replace = "if", condition = "factor.linux", then = [["python", "-c", "print('Running on Linux')"]] },
-             { replace = "if", condition = "factor.darwin", then = [["python", "-c", "print('Running on macOS')"]] },
-             { replace = "if", condition = "factor.win32", then = [["python", "-c", "print('Running on Windows')"]] },
+             { replace = "if", condition = "factor.linux", then = [["python", "-c", "print('Running on Linux')"]], extend = true },
+             { replace = "if", condition = "factor.darwin", then = [["python", "-c", "print('Running on macOS')"]], extend = true },
+             { replace = "if", condition = "factor.win32", then = [["python", "-c", "print('Running on Windows')"]], extend = true },
              ["python", "-m", "pytest"],
          ]
 
@@ -355,13 +355,13 @@ factors ``py313``, ``django50``, and the current platform:
 
         [env_run_base]
         deps = [
-            { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
-            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
-            { replace = "if", condition = "factor.py312 and factor.linux", then = ["pytest-xdist"] },
-            { replace = "if", condition = "factor.darwin", then = ["pyobjc-framework-Cocoa"] },
+            { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"], extend = true },
+            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"], extend = true },
+            { replace = "if", condition = "factor.py312 and factor.linux", then = ["pytest-xdist"], extend = true },
+            { replace = "if", condition = "factor.darwin", then = ["pyobjc-framework-Cocoa"], extend = true },
         ]
         commands = [
-            { replace = "if", condition = "factor.win32", then = [["python", "-c", "import winreg"]] },
+            { replace = "if", condition = "factor.win32", then = [["python", "-c", "import winreg"]], extend = true },
             ["pytest"],
         ]
 
@@ -390,8 +390,8 @@ Negation also works with platform factors:
 
         [env_run_base]
         deps = [
-            { replace = "if", condition = "not factor.win32", then = ["uvloop"] },
-            { replace = "if", condition = "not factor.darwin", then = ["pyinotify"] },
+            { replace = "if", condition = "not factor.win32", then = ["uvloop"], extend = true },
+            { replace = "if", condition = "not factor.darwin", then = ["pyinotify"], extend = true },
         ]
 
 .. tab:: INI
@@ -416,8 +416,8 @@ There are two ways to handle platform differences:
 
         [env_run_base]
         commands = [
-            { replace = "if", condition = "factor.linux", then = [["pytest", "--numprocesses=auto"]] },
-            { replace = "if", condition = "factor.darwin or factor.win32", then = [["pytest"]] },
+            { replace = "if", condition = "factor.linux", then = [["pytest", "--numprocesses=auto"]], extend = true },
+            { replace = "if", condition = "factor.darwin or factor.win32", then = [["pytest"]], extend = true },
         ]
 
 .. tab:: INI
@@ -545,7 +545,7 @@ Use different dependencies based on environment factors:
     [env_run_base]
     deps = [
         "pytest",
-        { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"], "else" = ["Django>=4.2,<4.3"] },
+        { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"], "else" = ["Django>=4.2,<4.3"], extend = true },
     ]
 
 Combine multiple conditions (environment variables and factors):
@@ -942,8 +942,8 @@ factor group is an array of strings or a range dict. Combinations are joined wit
          package = "skip"
          deps = [
              "pytest",
-             { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
-             { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
+             { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"], extend = true },
+             { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"], extend = true },
          ]
          commands = [["pytest"]]
 
@@ -993,8 +993,8 @@ Cartesian product of factor groups, and each generated environment inherits all 
     package = "skip"
     deps = [
         "pytest",
-        { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
-        { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
+        { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"], extend = true },
+        { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"], extend = true },
     ]
     commands = [["pytest"]]
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -78,14 +78,14 @@ factor.
         [env_run_base]
         deps = [
             "pytest",
-            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
-            { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
-            { replace = "if", condition = "not factor.lint", then = ["coverage"] },
+            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"], extend = true },
+            { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"], extend = true },
+            { replace = "if", condition = "not factor.lint", then = ["coverage"], extend = true },
         ]
         commands = [
-            { replace = "if", condition = "factor.linux", then = [["python", "-c", "print('on linux')"]] },
-            { replace = "if", condition = "factor.darwin", then = [["python", "-c", "print('on mac')"]] },
-            { replace = "if", condition = "factor.win32", then = [["python", "-c", "print('on windows')"]] },
+            { replace = "if", condition = "factor.linux", then = [["python", "-c", "print('on linux')"]], extend = true },
+            { replace = "if", condition = "factor.darwin", then = [["python", "-c", "print('on mac')"]], extend = true },
+            { replace = "if", condition = "factor.win32", then = [["python", "-c", "print('on windows')"]], extend = true },
         ]
 
     Use ``replace = "if"`` with ``factor.NAME`` conditions. Supports boolean operations (``and``, ``or``, ``not``) and
@@ -184,8 +184,8 @@ This generates ``test-3.13`` and ``test-3.14``. For multi-dimensional matrices:
     factors = [["py312", "py313"], ["django42", "django50"]]
     deps = [
         "pytest",
-        { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
-        { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
+        { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"], extend = true },
+        { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"], extend = true },
     ]
     commands = [["pytest"]]
 
@@ -2214,7 +2214,7 @@ You can reference other configurations via the ``ref`` replacement. This can eit
           [env.src]
           extras = ["A", "{env_name}"]
           [env.dest]
-          extras = [{ replace = "ref", of = ["env", "extras"], extend = true }, "B"]
+          extras = [{ replace = "ref", of = ["env", "src", "extras"], extend = true }, "B"]
 
   In this case ``dest`` environments ``extras`` will be ``A``, ``dest``, ``B``.
 
@@ -2415,7 +2415,7 @@ If ``TAG_NAME`` is set and non-empty, ``MATURITY`` becomes ``production``, other
     [env_run_base]
     deps = [
         "pytest",
-        { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
+        { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"], extend = true },
     ]
 
 If the environment name contains ``django50`` (e.g., ``py313-django50``), the Django dependency is added.
@@ -2426,8 +2426,8 @@ If the environment name contains ``django50`` (e.g., ``py313-django50``), the Dj
 
     [env_run_base]
     commands = [
-        { replace = "if", condition = "factor.linux", then = [["pytest", "--numprocesses=auto"]] },
-        { replace = "if", condition = "not factor.linux", then = [["pytest"]] },
+        { replace = "if", condition = "factor.linux", then = [["pytest", "--numprocesses=auto"]], extend = true },
+        { replace = "if", condition = "not factor.linux", then = [["pytest"]], extend = true },
     ]
 
 The current platform (``sys.platform`` value like ``linux``, ``darwin``, ``win32``) is automatically available as a
@@ -2585,11 +2585,11 @@ and conditional settings to express that in a concise form:
 
         [env_run_base]
         deps = [
-            { replace = "if", condition = "factor.django41", then = ["Django>=4.1,<4.2"] },
-            { replace = "if", condition = "factor.django40", then = ["Django>=4.0,<4.1"] },
-            { replace = "if", condition = "factor.py311 and factor.mysql", then = ["PyMySQL"] },
-            { replace = "if", condition = "factor.py311 or factor.py310", then = ["urllib3"] },
-            { replace = "if", condition = "(factor.py311 or factor.py310) and factor.sqlite", then = ["mock"] },
+            { replace = "if", condition = "factor.django41", then = ["Django>=4.1,<4.2"], extend = true },
+            { replace = "if", condition = "factor.django40", then = ["Django>=4.0,<4.1"], extend = true },
+            { replace = "if", condition = "factor.py311 and factor.mysql", then = ["PyMySQL"], extend = true },
+            { replace = "if", condition = "factor.py311 or factor.py310", then = ["urllib3"], extend = true },
+            { replace = "if", condition = "(factor.py311 or factor.py310) and factor.sqlite", then = ["mock"], extend = true },
         ]
 
 .. tab:: INI

--- a/src/tox/config/loader/toml/_product.py
+++ b/src/tox/config/loader/toml/_product.py
@@ -51,7 +51,7 @@ def expand_factor_group(group: Any) -> list[str]:
 
 def extract_label(group: Any) -> str | None:
     if isinstance(group, dict) and "prefix" not in group and len(group) == 1:
-        return next(iter(group))
+        return str(next(iter(group)))
     return None
 
 

--- a/src/tox/execute/local_sub_process/__init__.py
+++ b/src/tox/execute/local_sub_process/__init__.py
@@ -308,21 +308,21 @@ def _pty(key: str) -> tuple[int, int] | None:
         return None  # cannot proceed on platforms without pty support
 
     try:
-        main, child = pty.openpty()  # ty: ignore[possibly-missing-attribute] # Unix-only
+        main, child = pty.openpty()  # Unix-only
     except OSError:  # could not open a tty
         return None  # pragma: no cover
 
     try:
-        mode = termios.tcgetattr(stream)  # ty: ignore[possibly-missing-attribute] # Unix-only
-        termios.tcsetattr(child, termios.TCSANOW, mode)  # ty: ignore[possibly-missing-attribute] # Unix-only
-    except (termios.error, OSError):  # could not inherit traits  # ty: ignore[possibly-missing-attribute]
+        mode = termios.tcgetattr(stream)  # Unix-only
+        termios.tcsetattr(child, termios.TCSANOW, mode)  # Unix-only
+    except (termios.error, OSError):  # could not inherit traits
         return None  # pragma: no cover
 
     # adjust sub-process terminal size
     columns, lines = shutil.get_terminal_size(fallback=(-1, -1))
     if columns != -1 and lines != -1:
         size = struct.pack("HHHH", lines, columns, 0, 0)
-        fcntl.ioctl(child, termios.TIOCSWINSZ, size)  # ty: ignore[possibly-missing-attribute] # Unix-only
+        fcntl.ioctl(child, termios.TIOCSWINSZ, size)  # Unix-only
 
     return main, child
 

--- a/src/tox/tox_env/python/dependency_groups.py
+++ b/src/tox/tox_env/python/dependency_groups.py
@@ -149,7 +149,7 @@ def _resolve_dependency_group(
                 msg = f"{item!r} is not valid requirement due to {exc}"
                 raise Fail(msg) from exc
         elif isinstance(item, dict) and tuple(item.keys()) == ("include-group",):
-            include_group = canonicalize_name(next(iter(item.values())))
+            include_group = canonicalize_name(str(next(iter(item.values()))))
             result = result.union(
                 _resolve_dependency_group(
                     dependency_groups, include_group, original_names_lookup, (*past_groups, group)

--- a/src/tox/tox_env/python/virtual_env/package/util.py
+++ b/src/tox/tox_env/python/virtual_env/package/util.py
@@ -44,7 +44,7 @@ def dependencies_with_extras_from_markers(
             raise Fail(msg)
     result: list[Requirement] = []
     found: set[str] = set()
-    todo: set[str | None] = normalized_extras | {None}  # ty: ignore[invalid-assignment]
+    todo: set[str | None] = normalized_extras | {None}
     visited: set[str | None] = set()
     while todo:
         new_extras: set[str | None] = set()
@@ -95,7 +95,7 @@ def _extract_extra_markers(req: Requirement) -> tuple[Requirement, set[str | Non
         cast("Marker", req.marker)._markers = new_markers  # noqa: SLF001
     else:
         req.marker = None
-    return req, cast("set[str | None]", extra_markers) or {None}  # ty: ignore[invalid-return-type]
+    return req, cast("set[str | None]", extra_markers) or {None}
 
 
 def _get_extra(

--- a/src/tox/util/spinner.py
+++ b/src/tox/util/spinner.py
@@ -164,10 +164,10 @@ class Spinner:
         if self.stream.isatty():
             if sys.platform == "win32":  # pragma: win32 cover
                 ci = _CursorInfo()
-                handle = ctypes.windll.kernel32.GetStdHandle(-11)  # ty: ignore[possibly-missing-attribute] # Windows-only
-                ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(ci))  # ty: ignore[possibly-missing-attribute] # Windows-only
+                handle = ctypes.windll.kernel32.GetStdHandle(-11)  # Windows-only
+                ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(ci))  # Windows-only
                 ci.visible = False
-                ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))  # ty: ignore[possibly-missing-attribute] # Windows-only
+                ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))  # Windows-only
             else:
                 self.stream.write("\033[?25l")
 
@@ -175,10 +175,10 @@ class Spinner:
         if self.stream.isatty():
             if sys.platform == "win32":  # pragma: win32 cover
                 ci = _CursorInfo()
-                handle = ctypes.windll.kernel32.GetStdHandle(-11)  # ty: ignore[possibly-missing-attribute] # Windows-only
-                ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(ci))  # ty: ignore[possibly-missing-attribute] # Windows-only
+                handle = ctypes.windll.kernel32.GetStdHandle(-11)  # Windows-only
+                ctypes.windll.kernel32.GetConsoleCursorInfo(handle, ctypes.byref(ci))  # Windows-only
                 ci.visible = True
-                ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))  # ty: ignore[possibly-missing-attribute] # Windows-only
+                ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))  # Windows-only
             else:
                 self.stream.write("\033[?25h")
 

--- a/tests/docs/test_doc_config_examples.py
+++ b/tests/docs/test_doc_config_examples.py
@@ -32,103 +32,17 @@ _BASE_PYTHON_UNAVAILABLE_RE = re.compile(
 _VIRTUALENV_SPEC_RE = re.compile(r"""virtualenv_spec\s*=""", re.MULTILINE)
 _COMMANDS_FLAT_LIST_RE = re.compile(r"""^commands\s*=\s*\["[^["]""", re.MULTILINE)
 
-
-def _extract_config_blocks() -> list[tuple[str, int, str, str]]:
-    results: list[tuple[str, int, str, str]] = []
-    for rst_path in sorted(_DOCS_DIR.rglob("*.rst")):
-        lines = rst_path.read_text(encoding="utf-8").splitlines()
-        i = 0
-        while i < len(lines):
-            if m := _CODE_BLOCK_RE.match(lines[i]):
-                directive_indent = len(m.group(1)) + len(m.group(2)) + 2  # ".. " prefix
-                lang = m.group(3)
-                line_no = i + 1
-                i += 1
-                while i < len(lines) and not lines[i].strip():
-                    i += 1
-                content_lines: list[str] = []
-                while i < len(lines):
-                    line = lines[i]
-                    if not line.strip():
-                        content_lines.append("")
-                        i += 1
-                        continue
-                    current_indent = len(line) - len(line.lstrip())
-                    if current_indent > directive_indent:
-                        content_lines.append(line)
-                        i += 1
-                    else:
-                        break
-                while content_lines and not content_lines[-1].strip():
-                    content_lines.pop()
-                if content_lines:
-                    content = textwrap.dedent("\n".join(content_lines))
-                    rel = rst_path.relative_to(_DOCS_DIR.parent)
-                    results.append((str(rel), line_no, lang, content))
-            else:
-                i += 1
-    return results
-
-
-def _is_tox_config(lang: str, content: str) -> bool:
-    if lang == "ini":
-        return bool(
-            re.search(r"^\[tox(?::tox)?\]", content, re.MULTILINE)
-            or re.search(r"^\[testenv", content, re.MULTILINE)
-            or re.search(r"^\[pkgenv", content, re.MULTILINE)
-            or re.search(r"^\[base\]", content, re.MULTILINE)
-        )
-    first_section = re.search(r"^\[([^\]]+)\]", content, re.MULTILINE)
-    if first_section:
-        section = first_section.group(1).split(".")[0].strip('"').strip("'")
-        if section in _SKIP_TOML_SECTIONS:
-            return False
-    return bool(
-        "legacy_tox_ini" in content
-        or re.search(r"^\[tool\.tox", content, re.MULTILINE)
-        or re.search(r"^\[(env|env_run_base|env_pkg_base|env_base)\b", content, re.MULTILINE)
-        or re.search(r"^env_list\s*=", content, re.MULTILINE)
-        or re.search(r"^(requires|no_package)\s*=", content, re.MULTILINE)
-        or (re.search(r"^\w+\s*=", content, re.MULTILINE) and not first_section)
-    )
-
-
-def _should_skip(content: str) -> str | None:
-    if _REQUIRES_PROVISION_RE.search(content):
-        return "triggers auto-provisioning"
-    if _BASE_PYTHON_UNAVAILABLE_RE.search(content):
-        return "references unavailable Python interpreter"
-    if _VIRTUALENV_SPEC_RE.search(content):
-        return "requires specific virtualenv version"
-    if _COMMANDS_FLAT_LIST_RE.search(content):
-        return "tox output format, not input config"
-    return None
-
-
-def _classify_ini(content: str) -> tuple[str, str]:
-    if re.search(r"^\[tox:tox\]", content, re.MULTILINE):
-        return "setup.cfg", content
-    has_section = (
-        re.search(r"^\[tox\]", content, re.MULTILINE)
-        or re.search(r"^\[testenv", content, re.MULTILINE)
-        or re.search(r"^\[pkgenv", content, re.MULTILINE)
-        or re.search(r"^\[base\]", content, re.MULTILINE)
-    )
-    return ("tox.ini", content) if has_section else ("tox.ini", f"[testenv]\n{content}")
-
-
-def _classify(lang: str, content: str) -> tuple[str, str]:
-    if lang == "ini":
-        return _classify_ini(content)
-    if "legacy_tox_ini" in content:
-        if not re.search(r"^\[tool\.tox\]", content, re.MULTILINE):
-            return "pyproject.toml", f"[tool.tox]\n{content}"
-        return "pyproject.toml", content
-    if re.search(r"^\[tool\.tox", content, re.MULTILINE):
-        return "pyproject.toml", content
-    if re.search(r"^\[dependency-groups\]", content, re.MULTILINE):
-        return "pyproject.toml", _wrap_tox_toml_in_pyproject(content)
-    return "tox.toml", content
+_DOC_ENV_VARS: dict[str, str] = {
+    "CI": "1",
+    "TAG_NAME": "v1.0",
+    "VERBOSE": "1",
+    "DEBUG": "1",
+    "DEPLOY": "1",
+    "LOCAL": "1",
+    "L": "1",
+    "X": "1",
+    "MODE": "dev",
+}
 
 
 def _wrap_tox_toml_in_pyproject(content: str) -> str:
@@ -166,18 +80,120 @@ def _wrap_tox_toml_in_pyproject(content: str) -> str:
     return result
 
 
+def _classify_ini(content: str) -> tuple[str, str]:
+    if re.search(r"^\[tox:tox\]", content, re.MULTILINE):
+        return "setup.cfg", content
+    return (
+        ("tox.ini", content)
+        if (
+            re.search(r"^\[tox\]", content, re.MULTILINE)
+            or re.search(r"^\[testenv", content, re.MULTILINE)
+            or re.search(r"^\[pkgenv", content, re.MULTILINE)
+            or re.search(r"^\[base\]", content, re.MULTILINE)
+        )
+        else ("tox.ini", f"[testenv]\n{content}")
+    )
+
+
+def _classify(lang: str, content: str) -> tuple[str, str]:
+    if lang == "ini":
+        return _classify_ini(content)
+    if "legacy_tox_ini" in content:
+        if not re.search(r"^\[tool\.tox\]", content, re.MULTILINE):
+            return "pyproject.toml", f"[tool.tox]\n{content}"
+        return "pyproject.toml", content
+    if re.search(r"^\[tool\.tox", content, re.MULTILINE):
+        return "pyproject.toml", content
+    if re.search(r"^\[dependency-groups\]", content, re.MULTILINE):
+        return "pyproject.toml", _wrap_tox_toml_in_pyproject(content)
+    return "tox.toml", content
+
+
+def _extract_config_blocks() -> list[tuple[str, int, str, str]]:
+    results: list[tuple[str, int, str, str]] = []
+    for rst_path in sorted(_DOCS_DIR.rglob("*.rst")):
+        lines = rst_path.read_text(encoding="utf-8").splitlines()
+        idx = 0
+        while idx < len(lines):
+            if match := _CODE_BLOCK_RE.match(lines[idx]):
+                directive_indent = len(match.group(1)) + len(match.group(2)) + 2
+                lang = match.group(3)
+                line_no = idx + 1
+                idx += 1
+                while idx < len(lines) and not lines[idx].strip():
+                    idx += 1
+                content_lines: list[str] = []
+                while idx < len(lines):
+                    line = lines[idx]
+                    if not line.strip():
+                        content_lines.append("")
+                        idx += 1
+                        continue
+                    current_indent = len(line) - len(line.lstrip())
+                    if current_indent > directive_indent:
+                        content_lines.append(line)
+                        idx += 1
+                    else:
+                        break
+                while content_lines and not content_lines[-1].strip():
+                    content_lines.pop()
+                if content_lines:
+                    results.append((
+                        str(rst_path.relative_to(_DOCS_DIR.parent)),
+                        line_no,
+                        lang,
+                        textwrap.dedent("\n".join(content_lines)),
+                    ))
+            else:
+                idx += 1
+    return results
+
+
+def _is_tox_config(lang: str, content: str) -> bool:
+    if lang == "ini":
+        return bool(
+            re.search(r"^\[tox(?::tox)?\]", content, re.MULTILINE)
+            or re.search(r"^\[testenv", content, re.MULTILINE)
+            or re.search(r"^\[pkgenv", content, re.MULTILINE)
+            or re.search(r"^\[base\]", content, re.MULTILINE)
+        )
+    first_section = re.search(r"^\[([^\]]+)\]", content, re.MULTILINE)
+    if first_section and first_section.group(1).split(".")[0].strip('"').strip("'") in _SKIP_TOML_SECTIONS:
+        return False
+    return bool(
+        "legacy_tox_ini" in content
+        or re.search(r"^\[tool\.tox", content, re.MULTILINE)
+        or re.search(r"^\[(env|env_run_base|env_pkg_base|env_base)\b", content, re.MULTILINE)
+        or re.search(r"^env_list\s*=", content, re.MULTILINE)
+        or re.search(r"^(requires|no_package)\s*=", content, re.MULTILINE)
+        or (re.search(r"^\w+\s*=", content, re.MULTILINE) and not first_section)
+    )
+
+
+def _should_skip(content: str) -> str | None:
+    if _REQUIRES_PROVISION_RE.search(content):
+        return "triggers auto-provisioning"
+    if _BASE_PYTHON_UNAVAILABLE_RE.search(content):
+        return "references unavailable Python interpreter"
+    if _VIRTUALENV_SPEC_RE.search(content):
+        return "requires specific virtualenv version"
+    if _COMMANDS_FLAT_LIST_RE.search(content):
+        return "tox output format, not input config"
+    return None
+
+
 def _find_env_names(filename: str, content: str) -> list[str]:
     envs: list[str] = []
     if filename in {"tox.toml", "pyproject.toml"}:
         if re.search(r"\[(?:tool\.tox\.)?env_base\.", content):
             return ["__env_base__"]
-        for m in re.finditer(r"\[(?:tool\.tox\.)?env\.([^\]]+)\]", content):
-            name = m.group(1).strip('"').strip("'")
+        for match in re.finditer(r"\[(?:tool\.tox\.)?env\.([^\]]+)\]", content):
+            name = match.group(1).strip('"').strip("'")
             if name not in envs:
                 envs.append(name)
     elif filename in {"tox.ini", "setup.cfg"}:
-        for m in re.finditer(r"\[testenv:([^\]]+)\]", content):
-            raw = m.group(1)
+        for match in re.finditer(r"\[testenv:([^\]]+)\]", content):
+            raw = match.group(1)
             if "{" not in raw and raw not in envs:
                 envs.append(raw)
     return envs or ["py"]
@@ -190,25 +206,11 @@ def _collect_params() -> list[pytest.param]:  # type: ignore[type-arg]
             continue
         filename, classified_content = _classify(lang, content)
         env_names = _find_env_names(filename, classified_content)
-        param_id = f"{rel_file}:{line_no}"
         marks: list[pytest.MarkDecorator] = []
         if skip_reason := _should_skip(classified_content):
             marks.append(pytest.mark.skip(reason=skip_reason))
-        params.append(pytest.param(filename, classified_content, env_names, id=param_id, marks=marks))
+        params.append(pytest.param(filename, classified_content, env_names, id=f"{rel_file}:{line_no}", marks=marks))
     return params
-
-
-_DOC_ENV_VARS: dict[str, str] = {
-    "CI": "1",
-    "TAG_NAME": "v1.0",
-    "VERBOSE": "1",
-    "DEBUG": "1",
-    "DEPLOY": "1",
-    "LOCAL": "1",
-    "L": "1",
-    "X": "1",
-    "MODE": "dev",
-}
 
 
 @pytest.mark.parametrize(("filename", "content", "env_names"), _collect_params())
@@ -219,8 +221,8 @@ def test_doc_config_valid(
     content: str,
     env_names: list[str],
 ) -> None:
-    for k, v in _DOC_ENV_VARS.items():
-        monkeypatch.setenv(k, v)
+    for key, value in _DOC_ENV_VARS.items():
+        monkeypatch.setenv(key, value)
     project = tox_project({filename: content})
     if env_names == ["__env_base__"]:
         outcome = project.run("l")

--- a/tests/docs/test_doc_config_examples.py
+++ b/tests/docs/test_doc_config_examples.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import sys
 import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -10,39 +11,189 @@ import pytest
 if TYPE_CHECKING:
     from tox.pytest import ToxProjectCreator
 
-_DOCS_DIR = Path(__file__).parents[2] / "docs"
 
-_CODE_BLOCK_RE = re.compile(r"^(\s*)\.\.(\s+)code-block::\s+(toml|ini)\s*$")
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "filename" in metafunc.fixturenames:
+        params = []
+        for rel_file, line_no, lang, content in _extract_config_blocks():
+            if not _is_tox_config(lang, content):
+                continue
+            filename, classified_content = _classify(lang, content)
+            env_names = _find_env_names(filename, classified_content)
+            marks: list[pytest.MarkDecorator] = []
+            if skip_reason := _should_skip(classified_content):
+                marks.append(pytest.mark.skip(reason=skip_reason))
+            params.append(
+                pytest.param(filename, classified_content, env_names, id=f"{rel_file}:{line_no}", marks=marks)
+            )
+        metafunc.parametrize(("filename", "content", "env_names"), params)
 
-_SKIP_TOML_SECTIONS = frozenset({
-    "build-system",
-    "project",
-    "project.entry-points.tox",
-    "project.optional-dependencies",
-})
 
-_REQUIRES_PROVISION_RE = re.compile(
-    r"""requires\s*=\s*\[?[^\]]*(?:tox-uv|virtualenv[<>=!])""",
-    re.MULTILINE,
-)
-_BASE_PYTHON_UNAVAILABLE_RE = re.compile(
-    r"""base_python\s*=\s*\[?\s*"?(?:python3\.[0-9]\b|python3\.1[5-9]\b|cpython3\.\d+-\d+-(?:arm64|x86_64))""",
-    re.MULTILINE,
-)
-_VIRTUALENV_SPEC_RE = re.compile(r"""virtualenv_spec\s*=""", re.MULTILINE)
-_COMMANDS_FLAT_LIST_RE = re.compile(r"""^commands\s*=\s*\["[^["]""", re.MULTILINE)
+def test_doc_config_valid(
+    tox_project: ToxProjectCreator,
+    monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    content: str,
+    env_names: list[str],
+) -> None:
+    for key, value in {
+        "CI": "1",
+        "TAG_NAME": "v1.0",
+        "VERBOSE": "1",
+        "DEBUG": "1",
+        "DEPLOY": "1",
+        "LOCAL": "1",
+        "L": "1",
+        "X": "1",
+        "MODE": "dev",
+    }.items():
+        monkeypatch.setenv(key, value)
+    project = tox_project({filename: content})
+    if env_names == ["__env_base__"]:
+        outcome = project.run("l")
+        outcome.assert_success()
+        return
+    for env in env_names:
+        outcome = project.run("c", "-e", env)
+        outcome.assert_success()
+        assert "# Exception:" not in outcome.out, f"Exception in {env}:\n{outcome.out}"
 
-_DOC_ENV_VARS: dict[str, str] = {
-    "CI": "1",
-    "TAG_NAME": "v1.0",
-    "VERBOSE": "1",
-    "DEBUG": "1",
-    "DEPLOY": "1",
-    "LOCAL": "1",
-    "L": "1",
-    "X": "1",
-    "MODE": "dev",
-}
+
+def _extract_config_blocks() -> list[tuple[str, int, str, str]]:
+    results: list[tuple[str, int, str, str]] = []
+    docs_dir = Path(__file__).parents[2] / "docs"
+    code_block_re = re.compile(
+        r"""
+        ^(?P<indent>\s*)        # leading whitespace
+        \.\.(?P<space>\s+)      # RST directive marker
+        code-block::\s+         # code-block directive
+        (?P<lang>toml|ini)      # language
+        \s*$
+        """,
+        re.VERBOSE,
+    )
+    for rst_path in sorted(docs_dir.rglob("*.rst")):
+        lines = rst_path.read_text(encoding="utf-8").splitlines()
+        idx = 0
+        while idx < len(lines):
+            if match := code_block_re.match(lines[idx]):
+                directive_indent = len(match.group("indent")) + len(match.group("space")) + 2
+                lang = match.group("lang")
+                line_no = idx + 1
+                idx += 1
+                while idx < len(lines) and not lines[idx].strip():
+                    idx += 1
+                content_lines: list[str] = []
+                while idx < len(lines):
+                    line = lines[idx]
+                    if not line.strip():
+                        content_lines.append("")
+                        idx += 1
+                        continue
+                    current_indent = len(line) - len(line.lstrip())
+                    if current_indent > directive_indent:
+                        content_lines.append(line)
+                        idx += 1
+                    else:
+                        break
+                while content_lines and not content_lines[-1].strip():
+                    content_lines.pop()
+                if content_lines:
+                    results.append((
+                        str(rst_path.relative_to(docs_dir.parent)),
+                        line_no,
+                        lang,
+                        textwrap.dedent("\n".join(content_lines)),
+                    ))
+            else:
+                idx += 1
+    return results
+
+
+def _is_tox_config(lang: str, content: str) -> bool:
+    if lang == "ini":
+        return bool(
+            re.search(r"^\[tox(?::tox)?\]", content, re.MULTILINE)
+            or re.search(r"^\[testenv", content, re.MULTILINE)
+            or re.search(r"^\[pkgenv", content, re.MULTILINE)
+            or re.search(r"^\[base\]", content, re.MULTILINE)
+        )
+    first_section = re.search(r"^\[(?P<section>[^\]]+)\]", content, re.MULTILINE)
+    if first_section and first_section.group("section").split(".")[0].strip('"').strip("'") in {
+        "build-system",
+        "project",
+        "project.entry-points.tox",
+        "project.optional-dependencies",
+    }:
+        return False
+    return bool(
+        "legacy_tox_ini" in content
+        or re.search(r"^\[tool\.tox", content, re.MULTILINE)
+        or re.search(r"^\[(env|env_run_base|env_pkg_base|env_base)\b", content, re.MULTILINE)
+        or re.search(r"^env_list\s*=", content, re.MULTILINE)
+        or re.search(r"^(requires|no_package)\s*=", content, re.MULTILINE)
+        or (re.search(r"^\w+\s*=", content, re.MULTILINE) and not first_section)
+    )
+
+
+def _replace_python_versions(content: str) -> str:
+    current_major = sys.version_info.major
+    current_minor = sys.version_info.minor
+    current_version = f"{current_major}.{current_minor}"
+    current_py = f"py{current_major}{current_minor}"
+
+    content = re.sub(r"python3\.\d+", f"python{current_version}", content)
+    content = re.sub(r"py\d{2,3}", current_py, content)
+    content = re.sub(r"cpython3\.\d+", f"cpython{current_version}", content)
+    return re.sub(r"(?<=[\s\[\"',=])3\.\d+", current_version, content)
+
+
+def _classify(lang: str, content: str) -> tuple[str, str]:
+    content = _replace_python_versions(content)
+    if lang == "ini":
+        filename, ini_content = _classify_ini(content)
+        return filename, _inject_skip_missing_interpreters_ini(ini_content)
+    if "legacy_tox_ini" in content:
+        if not re.search(r"^\[tool\.tox\]", content, re.MULTILINE):
+            content = f"[tool.tox]\n{content}"
+        return "pyproject.toml", _inject_skip_missing_interpreters_toml(content, r"(\[tool\.tox\]\n)")
+    if re.search(r"^\[tool\.tox", content, re.MULTILINE):
+        return "pyproject.toml", _inject_skip_missing_interpreters_toml(content, r"(\[tool\.tox\]\n)")
+    if re.search(r"^\[dependency-groups\]", content, re.MULTILINE):
+        wrapped = _wrap_tox_toml_in_pyproject(content)
+        return "pyproject.toml", _inject_skip_missing_interpreters_toml(wrapped, r"(\[tool\.tox\]\n)")
+    return "tox.toml", _inject_skip_missing_interpreters_toml(content, r"^")
+
+
+def _inject_skip_missing_interpreters_ini(content: str) -> str:
+    if r"skip_missing_interpreters" in content:
+        return content
+    if not re.search(r"^\[tox(?::tox)?\]", content, re.MULTILINE):
+        return "[tox]\nskip_missing_interpreters = true\n" + content
+    return re.sub(r"(\[tox(?::tox)?\]\n)", r"\1skip_missing_interpreters = true\n", content)
+
+
+def _inject_skip_missing_interpreters_toml(content: str, section_pattern: str) -> str:
+    if r"skip_missing_interpreters" in content:
+        return content
+    if section_pattern == r"^":
+        return "skip_missing_interpreters = true\n" + content
+    return re.sub(section_pattern, r"\1skip_missing_interpreters = true\n", content)
+
+
+def _classify_ini(content: str) -> tuple[str, str]:
+    if re.search(r"^\[tox:tox\]", content, re.MULTILINE):
+        return "setup.cfg", content
+    return (
+        ("tox.ini", content)
+        if (
+            re.search(r"^\[tox\]", content, re.MULTILINE)
+            or re.search(r"^\[testenv", content, re.MULTILINE)
+            or re.search(r"^\[pkgenv", content, re.MULTILINE)
+            or re.search(r"^\[base\]", content, re.MULTILINE)
+        )
+        else ("tox.ini", f"[testenv]\n{content}")
+    )
 
 
 def _wrap_tox_toml_in_pyproject(content: str) -> str:
@@ -51,8 +202,8 @@ def _wrap_tox_toml_in_pyproject(content: str) -> str:
     in_tox = False
     in_other = False
     for line in content.splitlines():
-        if section_match := re.match(r"^\[([^\]]+)\]", line):
-            section = section_match.group(1)
+        if section_match := re.match(r"^\[(?P<section>[^\]]+)\]", line):
+            section = section_match.group("section")
             if section.startswith(("env", "env_run_base", "env_pkg_base", "env_base")):
                 in_tox, in_other = True, False
                 tox_lines.append(f"[tool.tox.{section}]")
@@ -80,155 +231,51 @@ def _wrap_tox_toml_in_pyproject(content: str) -> str:
     return result
 
 
-def _classify_ini(content: str) -> tuple[str, str]:
-    if re.search(r"^\[tox:tox\]", content, re.MULTILINE):
-        return "setup.cfg", content
-    return (
-        ("tox.ini", content)
-        if (
-            re.search(r"^\[tox\]", content, re.MULTILINE)
-            or re.search(r"^\[testenv", content, re.MULTILINE)
-            or re.search(r"^\[pkgenv", content, re.MULTILINE)
-            or re.search(r"^\[base\]", content, re.MULTILINE)
-        )
-        else ("tox.ini", f"[testenv]\n{content}")
-    )
-
-
-def _classify(lang: str, content: str) -> tuple[str, str]:
-    if lang == "ini":
-        return _classify_ini(content)
-    if "legacy_tox_ini" in content:
-        if not re.search(r"^\[tool\.tox\]", content, re.MULTILINE):
-            return "pyproject.toml", f"[tool.tox]\n{content}"
-        return "pyproject.toml", content
-    if re.search(r"^\[tool\.tox", content, re.MULTILINE):
-        return "pyproject.toml", content
-    if re.search(r"^\[dependency-groups\]", content, re.MULTILINE):
-        return "pyproject.toml", _wrap_tox_toml_in_pyproject(content)
-    return "tox.toml", content
-
-
-def _extract_config_blocks() -> list[tuple[str, int, str, str]]:
-    results: list[tuple[str, int, str, str]] = []
-    for rst_path in sorted(_DOCS_DIR.rglob("*.rst")):
-        lines = rst_path.read_text(encoding="utf-8").splitlines()
-        idx = 0
-        while idx < len(lines):
-            if match := _CODE_BLOCK_RE.match(lines[idx]):
-                directive_indent = len(match.group(1)) + len(match.group(2)) + 2
-                lang = match.group(3)
-                line_no = idx + 1
-                idx += 1
-                while idx < len(lines) and not lines[idx].strip():
-                    idx += 1
-                content_lines: list[str] = []
-                while idx < len(lines):
-                    line = lines[idx]
-                    if not line.strip():
-                        content_lines.append("")
-                        idx += 1
-                        continue
-                    current_indent = len(line) - len(line.lstrip())
-                    if current_indent > directive_indent:
-                        content_lines.append(line)
-                        idx += 1
-                    else:
-                        break
-                while content_lines and not content_lines[-1].strip():
-                    content_lines.pop()
-                if content_lines:
-                    results.append((
-                        str(rst_path.relative_to(_DOCS_DIR.parent)),
-                        line_no,
-                        lang,
-                        textwrap.dedent("\n".join(content_lines)),
-                    ))
-            else:
-                idx += 1
-    return results
-
-
-def _is_tox_config(lang: str, content: str) -> bool:
-    if lang == "ini":
-        return bool(
-            re.search(r"^\[tox(?::tox)?\]", content, re.MULTILINE)
-            or re.search(r"^\[testenv", content, re.MULTILINE)
-            or re.search(r"^\[pkgenv", content, re.MULTILINE)
-            or re.search(r"^\[base\]", content, re.MULTILINE)
-        )
-    first_section = re.search(r"^\[([^\]]+)\]", content, re.MULTILINE)
-    if first_section and first_section.group(1).split(".")[0].strip('"').strip("'") in _SKIP_TOML_SECTIONS:
-        return False
-    return bool(
-        "legacy_tox_ini" in content
-        or re.search(r"^\[tool\.tox", content, re.MULTILINE)
-        or re.search(r"^\[(env|env_run_base|env_pkg_base|env_base)\b", content, re.MULTILINE)
-        or re.search(r"^env_list\s*=", content, re.MULTILINE)
-        or re.search(r"^(requires|no_package)\s*=", content, re.MULTILINE)
-        or (re.search(r"^\w+\s*=", content, re.MULTILINE) and not first_section)
-    )
-
-
-def _should_skip(content: str) -> str | None:
-    if _REQUIRES_PROVISION_RE.search(content):
-        return "triggers auto-provisioning"
-    if _BASE_PYTHON_UNAVAILABLE_RE.search(content):
-        return "references unavailable Python interpreter"
-    if _VIRTUALENV_SPEC_RE.search(content):
-        return "requires specific virtualenv version"
-    if _COMMANDS_FLAT_LIST_RE.search(content):
-        return "tox output format, not input config"
-    return None
-
-
 def _find_env_names(filename: str, content: str) -> list[str]:
     envs: list[str] = []
     if filename in {"tox.toml", "pyproject.toml"}:
         if re.search(r"\[(?:tool\.tox\.)?env_base\.", content):
             return ["__env_base__"]
-        for match in re.finditer(r"\[(?:tool\.tox\.)?env\.([^\]]+)\]", content):
-            name = match.group(1).strip('"').strip("'")
+        for match in re.finditer(r"\[(?:tool\.tox\.)?env\.(?P<name>[^\]]+)\]", content):
+            name = match.group("name").strip('"').strip("'")
             if name not in envs:
                 envs.append(name)
     elif filename in {"tox.ini", "setup.cfg"}:
-        for match in re.finditer(r"\[testenv:([^\]]+)\]", content):
-            raw = match.group(1)
+        for match in re.finditer(r"\[testenv:(?P<name>[^\]]+)\]", content):
+            raw = match.group("name")
             if "{" not in raw and raw not in envs:
                 envs.append(raw)
     return envs or ["py"]
 
 
-def _collect_params() -> list[pytest.param]:  # type: ignore[type-arg]
-    params: list[pytest.param] = []  # type: ignore[type-arg]
-    for rel_file, line_no, lang, content in _extract_config_blocks():
-        if not _is_tox_config(lang, content):
-            continue
-        filename, classified_content = _classify(lang, content)
-        env_names = _find_env_names(filename, classified_content)
-        marks: list[pytest.MarkDecorator] = []
-        if skip_reason := _should_skip(classified_content):
-            marks.append(pytest.mark.skip(reason=skip_reason))
-        params.append(pytest.param(filename, classified_content, env_names, id=f"{rel_file}:{line_no}", marks=marks))
-    return params
-
-
-@pytest.mark.parametrize(("filename", "content", "env_names"), _collect_params())
-def test_doc_config_valid(
-    tox_project: ToxProjectCreator,
-    monkeypatch: pytest.MonkeyPatch,
-    filename: str,
-    content: str,
-    env_names: list[str],
-) -> None:
-    for key, value in _DOC_ENV_VARS.items():
-        monkeypatch.setenv(key, value)
-    project = tox_project({filename: content})
-    if env_names == ["__env_base__"]:
-        outcome = project.run("l")
-        outcome.assert_success()
-        return
-    for env in env_names:
-        outcome = project.run("c", "-e", env)
-        outcome.assert_success()
-        assert "# Exception:" not in outcome.out, f"Exception in {env}:\n{outcome.out}"
+def _should_skip(content: str) -> str | None:
+    if re.search(
+        r"""
+        requires\s*=\s*\[?[^\]]*   # requires key with optional opening bracket
+        (?:tox-uv|virtualenv[<>=!])  # matches tox-uv or virtualenv with version constraint
+        """,
+        content,
+        re.VERBOSE | re.MULTILINE,
+    ):
+        return "triggers auto-provisioning"
+    if re.search(
+        r"""
+        base_python\s*=\s*\[?\s*"?  # base_python key (not default_base_python)
+        cpython3\.\d+-\d+-(?:arm64|x86_64)  # architecture-specific
+        """,
+        content,
+        re.VERBOSE | re.MULTILINE,
+    ):
+        return "references architecture-specific Python"
+    if re.search(r"""virtualenv_spec\s*=""", content, re.MULTILINE):
+        return "requires specific virtualenv version"
+    if re.search(
+        r"""
+        ^commands\s*=\s*\[  # commands key with list
+        "[^["]              # flat string list, not nested
+        """,
+        content,
+        re.VERBOSE | re.MULTILINE,
+    ):
+        return "tox output format, not input config"
+    return None

--- a/tests/docs/test_doc_config_examples.py
+++ b/tests/docs/test_doc_config_examples.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from tox.pytest import ToxProjectCreator
+
+_DOCS_DIR = Path(__file__).parents[2] / "docs"
+
+_CODE_BLOCK_RE = re.compile(r"^(\s*)\.\.(\s+)code-block::\s+(toml|ini)\s*$")
+
+_SKIP_TOML_SECTIONS = frozenset({
+    "build-system",
+    "project",
+    "project.entry-points.tox",
+    "project.optional-dependencies",
+})
+
+_REQUIRES_PROVISION_RE = re.compile(
+    r"""requires\s*=\s*\[?[^\]]*(?:tox-uv|virtualenv[<>=!])""",
+    re.MULTILINE,
+)
+_BASE_PYTHON_UNAVAILABLE_RE = re.compile(
+    r"""base_python\s*=\s*\[?\s*"?(?:python3\.[0-9]\b|python3\.1[5-9]\b|cpython3\.\d+-\d+-(?:arm64|x86_64))""",
+    re.MULTILINE,
+)
+_VIRTUALENV_SPEC_RE = re.compile(r"""virtualenv_spec\s*=""", re.MULTILINE)
+_COMMANDS_FLAT_LIST_RE = re.compile(r"""^commands\s*=\s*\["[^["]""", re.MULTILINE)
+
+
+def _extract_config_blocks() -> list[tuple[str, int, str, str]]:
+    results: list[tuple[str, int, str, str]] = []
+    for rst_path in sorted(_DOCS_DIR.rglob("*.rst")):
+        lines = rst_path.read_text(encoding="utf-8").splitlines()
+        i = 0
+        while i < len(lines):
+            if m := _CODE_BLOCK_RE.match(lines[i]):
+                directive_indent = len(m.group(1)) + len(m.group(2)) + 2  # ".. " prefix
+                lang = m.group(3)
+                line_no = i + 1
+                i += 1
+                while i < len(lines) and not lines[i].strip():
+                    i += 1
+                content_lines: list[str] = []
+                while i < len(lines):
+                    line = lines[i]
+                    if not line.strip():
+                        content_lines.append("")
+                        i += 1
+                        continue
+                    current_indent = len(line) - len(line.lstrip())
+                    if current_indent > directive_indent:
+                        content_lines.append(line)
+                        i += 1
+                    else:
+                        break
+                while content_lines and not content_lines[-1].strip():
+                    content_lines.pop()
+                if content_lines:
+                    content = textwrap.dedent("\n".join(content_lines))
+                    rel = rst_path.relative_to(_DOCS_DIR.parent)
+                    results.append((str(rel), line_no, lang, content))
+            else:
+                i += 1
+    return results
+
+
+def _is_tox_config(lang: str, content: str) -> bool:
+    if lang == "ini":
+        return bool(
+            re.search(r"^\[tox(?::tox)?\]", content, re.MULTILINE)
+            or re.search(r"^\[testenv", content, re.MULTILINE)
+            or re.search(r"^\[pkgenv", content, re.MULTILINE)
+            or re.search(r"^\[base\]", content, re.MULTILINE)
+        )
+    first_section = re.search(r"^\[([^\]]+)\]", content, re.MULTILINE)
+    if first_section:
+        section = first_section.group(1).split(".")[0].strip('"').strip("'")
+        if section in _SKIP_TOML_SECTIONS:
+            return False
+    return bool(
+        "legacy_tox_ini" in content
+        or re.search(r"^\[tool\.tox", content, re.MULTILINE)
+        or re.search(r"^\[(env|env_run_base|env_pkg_base|env_base)\b", content, re.MULTILINE)
+        or re.search(r"^env_list\s*=", content, re.MULTILINE)
+        or re.search(r"^(requires|no_package)\s*=", content, re.MULTILINE)
+        or (re.search(r"^\w+\s*=", content, re.MULTILINE) and not first_section)
+    )
+
+
+def _should_skip(content: str) -> str | None:
+    if _REQUIRES_PROVISION_RE.search(content):
+        return "triggers auto-provisioning"
+    if _BASE_PYTHON_UNAVAILABLE_RE.search(content):
+        return "references unavailable Python interpreter"
+    if _VIRTUALENV_SPEC_RE.search(content):
+        return "requires specific virtualenv version"
+    if _COMMANDS_FLAT_LIST_RE.search(content):
+        return "tox output format, not input config"
+    return None
+
+
+def _classify_ini(content: str) -> tuple[str, str]:
+    if re.search(r"^\[tox:tox\]", content, re.MULTILINE):
+        return "setup.cfg", content
+    has_section = (
+        re.search(r"^\[tox\]", content, re.MULTILINE)
+        or re.search(r"^\[testenv", content, re.MULTILINE)
+        or re.search(r"^\[pkgenv", content, re.MULTILINE)
+        or re.search(r"^\[base\]", content, re.MULTILINE)
+    )
+    return ("tox.ini", content) if has_section else ("tox.ini", f"[testenv]\n{content}")
+
+
+def _classify(lang: str, content: str) -> tuple[str, str]:
+    if lang == "ini":
+        return _classify_ini(content)
+    if "legacy_tox_ini" in content:
+        if not re.search(r"^\[tool\.tox\]", content, re.MULTILINE):
+            return "pyproject.toml", f"[tool.tox]\n{content}"
+        return "pyproject.toml", content
+    if re.search(r"^\[tool\.tox", content, re.MULTILINE):
+        return "pyproject.toml", content
+    if re.search(r"^\[dependency-groups\]", content, re.MULTILINE):
+        return "pyproject.toml", _wrap_tox_toml_in_pyproject(content)
+    return "tox.toml", content
+
+
+def _wrap_tox_toml_in_pyproject(content: str) -> str:
+    tox_lines: list[str] = []
+    other_lines: list[str] = []
+    in_tox = False
+    in_other = False
+    for line in content.splitlines():
+        if section_match := re.match(r"^\[([^\]]+)\]", line):
+            section = section_match.group(1)
+            if section.startswith(("env", "env_run_base", "env_pkg_base", "env_base")):
+                in_tox, in_other = True, False
+                tox_lines.append(f"[tool.tox.{section}]")
+                continue
+            if section == "dependency-groups":
+                in_tox, in_other = False, True
+                other_lines.append(line)
+                continue
+            in_tox, in_other = True, False
+            tox_lines.append(f"[tool.tox.{section}]")
+            continue
+        if in_tox:
+            tox_lines.append(line)
+        elif in_other:
+            other_lines.append(line)
+        elif line.strip() and not line.startswith("#"):
+            tox_lines.append(line)
+        else:
+            other_lines.append(line)
+    result = "[tool.tox]\n"
+    if tox_lines:
+        result += "\n".join(tox_lines) + "\n"
+    if other_lines:
+        result += "\n" + "\n".join(other_lines) + "\n"
+    return result
+
+
+def _find_env_names(filename: str, content: str) -> list[str]:
+    envs: list[str] = []
+    if filename in {"tox.toml", "pyproject.toml"}:
+        if re.search(r"\[(?:tool\.tox\.)?env_base\.", content):
+            return ["__env_base__"]
+        for m in re.finditer(r"\[(?:tool\.tox\.)?env\.([^\]]+)\]", content):
+            name = m.group(1).strip('"').strip("'")
+            if name not in envs:
+                envs.append(name)
+    elif filename in {"tox.ini", "setup.cfg"}:
+        for m in re.finditer(r"\[testenv:([^\]]+)\]", content):
+            raw = m.group(1)
+            if "{" not in raw and raw not in envs:
+                envs.append(raw)
+    return envs or ["py"]
+
+
+def _collect_params() -> list[pytest.param]:  # type: ignore[type-arg]
+    params: list[pytest.param] = []  # type: ignore[type-arg]
+    for rel_file, line_no, lang, content in _extract_config_blocks():
+        if not _is_tox_config(lang, content):
+            continue
+        filename, classified_content = _classify(lang, content)
+        env_names = _find_env_names(filename, classified_content)
+        param_id = f"{rel_file}:{line_no}"
+        marks: list[pytest.MarkDecorator] = []
+        if skip_reason := _should_skip(classified_content):
+            marks.append(pytest.mark.skip(reason=skip_reason))
+        params.append(pytest.param(filename, classified_content, env_names, id=param_id, marks=marks))
+    return params
+
+
+_DOC_ENV_VARS: dict[str, str] = {
+    "CI": "1",
+    "TAG_NAME": "v1.0",
+    "VERBOSE": "1",
+    "DEBUG": "1",
+    "DEPLOY": "1",
+    "LOCAL": "1",
+    "L": "1",
+    "X": "1",
+    "MODE": "dev",
+}
+
+
+@pytest.mark.parametrize(("filename", "content", "env_names"), _collect_params())
+def test_doc_config_valid(
+    tox_project: ToxProjectCreator,
+    monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    content: str,
+    env_names: list[str],
+) -> None:
+    for k, v in _DOC_ENV_VARS.items():
+        monkeypatch.setenv(k, v)
+    project = tox_project({filename: content})
+    if env_names == ["__env_base__"]:
+        outcome = project.run("l")
+        outcome.assert_success()
+        return
+    for env in env_names:
+        outcome = project.run("c", "-e", env)
+        outcome.assert_success()
+        assert "# Exception:" not in outcome.out, f"Exception in {env}:\n{outcome.out}"

--- a/tests/execute/local_subprocess/test_local_subprocess.py
+++ b/tests/execute/local_subprocess/test_local_subprocess.py
@@ -172,7 +172,7 @@ def test_local_execute_terminal_size(os_env: dict[str, str], monkeypatch: Monkey
     import pty  # noqa: PLC0415
 
     terminal_size = os.terminal_size((84, 42))
-    main, child = pty.openpty()  # ty: ignore[possibly-missing-attribute] # Unix-only
+    main, child = pty.openpty()  # Unix-only
 
     # Use ReadViaThreadUnix to help with debugging the test itself.
     pipe_out = ReadViaThreadUnix(main, sys.stdout.buffer.write, name="testout", drain=True)


### PR DESCRIPTION
Discussion #3874 showed that many TOML examples in the documentation were silently broken — `replace = "if"` conditionals inside `deps` and `commands` lists were missing `extend = true`, causing tox to fail with type errors when users copied them. Fixing these by hand is fragile; the examples will drift again with the next doc edit. 📝

This PR adds a parametrized test that dynamically discovers every `.. code-block:: toml` and `.. code-block:: ini` directive across all RST files under `docs/`, classifies each block by config format (`tox.toml`, `pyproject.toml`, `tox.ini`, `setup.cfg`), and runs `tox c` to verify the config parses cleanly. The test currently validates 138 code blocks across 7 RST files. Blocks requiring unavailable infrastructure (specific Python interpreters, auto-provisioning plugins, virtualenv version pinning) are detected at collection time and skipped with clear reasons.

The doc fixes themselves add the missing `extend = true` to ~35 conditional replacement examples and correct a broken `ref of` path in the raw reference documentation (`["env", "extras"]` → `["env", "src", "extras"]`). 🐛 Going forward, any new or edited config example that breaks will be caught by CI before it reaches users.