### PR TITLE
docs: Update config.rst, add missing extend=true in section "Check for platform factors"

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -2426,8 +2426,8 @@ If the environment name contains ``django50`` (e.g., ``py313-django50``), the Dj
 
     [env_run_base]
     commands = [
-        { replace = "if", condition = "factor.linux", then = [["pytest", "--numprocesses=auto"]] },
-        { replace = "if", condition = "not factor.linux", then = [["pytest"]] },
+        { replace = "if", condition = "factor.linux", then = [["pytest", "--numprocesses=auto"]], extend = true },
+        { replace = "if", condition = "not factor.linux", then = [["pytest"]], extend = true },
     ]
 
 The current platform (``sys.platform`` value like ``linux``, ``darwin``, ``win32``) is automatically available as a


### PR DESCRIPTION
With this change, the sample TOML command list actually works as intended.

Fix based on https://github.com/tox-dev/tox/discussions/3874#discussioncomment-16101158

Verified correctness locally.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation
