### PR TITLE
✨ feat(run): add interrupt_post_commands for cleanup after Ctrl-C

### DIFF
--- a/docs/changelog/3858.feature.rst
+++ b/docs/changelog/3858.feature.rst
@@ -1,0 +1,1 @@
+Add ``interrupt_post_commands`` option to run cleanup commands even after SIGINT - by :user:`gaborbernat`.

--- a/docs/changelog/3878.bugfix.rst
+++ b/docs/changelog/3878.bugfix.rst
@@ -1,0 +1,2 @@
+Fix multiple manpage issues: remove duplicate header/author/copyright sections, set ``project`` in Sphinx config, and
+compile the manpage to troff format at wheel-build time instead of shipping raw RST source - by :user:`gaborbernat`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from sphinx.ext.autodoc import Options
 
 company, name = "tox-dev", "tox"
+project = name
 release, version = __version__, ".".join(__version__.split(".")[:2])
 copyright = f"{company}"  # noqa: A001
 master_doc = "index"
@@ -89,7 +90,7 @@ extlinks_detect_hardcoded_links = True
 issues_github_path = f"{company}/{name}"  # `sphinx-issues` ext
 
 # Man page configuration
-man_pages = [("man/tox.1", "tox", "virtualenv-based automation of test activities", ["tox-dev"], 1)]
+man_pages = [("man/tox.1", "tox", "virtualenv-based automation of test activities", [], 1)]
 man_show_urls = True
 
 redirects = {

--- a/docs/how-to/install.rst
+++ b/docs/how-to/install.rst
@@ -84,13 +84,7 @@ For Python version compatibility, see :ref:`compatibility-requirements`.
  Man Page Support
 ******************
 
-tox includes a Unix man page that is automatically built when building documentation. The man page provides
-comprehensive reference documentation for all tox commands and options.
-
-Automatic Installation
-======================
-
-The man page is pre-built and included in tox wheels. When installing tox:
+tox ships a compiled man page in its wheel. When installing tox:
 
 - **System-wide** (``sudo pip install tox``): Installs to ``/usr/share/man/man1/tox.1`` automatically
 - **User install** (``pip install --user tox``): Installs to ``~/.local/share/man/man1/tox.1`` automatically
@@ -105,35 +99,15 @@ For user installs, ensure ``~/.local/share/man`` is in your ``MANPATH``:
 
 After updating your profile, restart your shell or run ``source ~/.bashrc``.
 
-Virtualenv Installations
-========================
+Virtual Environment Installations
+=================================
 
-When tox is installed in a virtualenv (via pipx, uv tool, or venv), the man page is installed but not on the system
-``MANPATH``. Use the ``tox man`` command to set it up automatically:
+When tox is installed in a virtual environment (via pipx, uv tool, or venv), the man page is installed but not on the
+system ``MANPATH``. Use the ``tox man`` command to set it up:
 
 .. code-block:: bash
 
     tox man
-
-This command will:
-
-- Check if the man page is accessible
-- Create a symlink from the virtualenv to ``~/.local/share/man/man1/``
-- Detect your shell and provide instructions for adding ``MANPATH`` to your profile
-
-Alternatively, you can set it up manually:
-
-.. code-block:: bash
-
-    # Find where tox is installed
-    TOX_PREFIX=$(python -c "import sys; print(sys.prefix)")
-
-    # Create symlink to user man directory
-    mkdir -p ~/.local/share/man/man1
-    ln -sf "$TOX_PREFIX/share/man/man1/tox.1" ~/.local/share/man/man1/tox.1
-
-    # Ensure MANPATH includes user directory (if not already set)
-    export MANPATH="$HOME/.local/share/man:$MANPATH"
 
 Building from Source
 ====================
@@ -142,21 +116,10 @@ Package maintainers building from source can generate the man page using Sphinx:
 
 .. code-block:: bash
 
-    # Build documentation (includes man page)
     tox run -e docs
 
     # Man page is generated at .tox/docs_out/man/tox.1
-    # Install to system location
     install -D -m 644 .tox/docs_out/man/tox.1 /usr/share/man/man1/tox.1
     gzip -9 /usr/share/man/man1/tox.1
 
-Viewing the Man Page
-====================
-
-After installation:
-
-.. code-block:: bash
-
-    man tox
-
-For virtualenv-based installations where the man page is not on ``MANPATH``, use ``tox --help`` instead.
+After installation, view with ``man tox``.

--- a/docs/man/tox.1.rst
+++ b/docs/man/tox.1.rst
@@ -1,23 +1,14 @@
 :orphan:
 
-#####
- tox
-#####
-
-************************************************
- virtualenv-based automation of test activities
-************************************************
-
-:Manual section: 1
-:Manual group: User Commands
-
-SYNOPSIS
-========
+##########
+ SYNOPSIS
+##########
 
 **tox** [*options*] [*command* [*command-options*]]
 
-DESCRIPTION
-===========
+#############
+ DESCRIPTION
+#############
 
 tox aims to automate and standardize testing in Python. It is part of a larger vision of easing the packaging, testing
 and release process of Python software.
@@ -25,8 +16,9 @@ and release process of Python software.
 tox creates virtual environments for multiple Python versions, installs project dependencies, and runs tests in each
 environment. It supports parallel execution, custom test commands, and extensive configuration.
 
-COMMANDS
-========
+##########
+ COMMANDS
+##########
 
 **run** (*default*)
     Execute test environments. This is the default command if none is specified.
@@ -48,8 +40,9 @@ COMMANDS
 
 For command-specific help, use: **tox** *command* **--help**
 
-OPTIONS
-=======
+#########
+ OPTIONS
+#########
 
 For a complete list of options, run ``tox --help`` or see the online documentation at https://tox.wiki/
 
@@ -79,8 +72,9 @@ Common options:
 **--override** *KEY=VALUE*, **-x** *KEY=VALUE*
     Override a configuration value.
 
-FILES
-=====
+#######
+ FILES
+#######
 
 **tox.toml**
     Primary configuration file in TOML format (recommended).
@@ -96,8 +90,9 @@ FILES
 
 The configuration files are searched in the order listed above. The first file found is used.
 
-ENVIRONMENT VARIABLES
-=====================
+#######################
+ ENVIRONMENT VARIABLES
+#######################
 
 ``TOX_*``
     Any tox configuration setting can be overridden via environment variables with the ``TOX_`` prefix. For example,
@@ -112,21 +107,18 @@ ENVIRONMENT VARIABLES
 **TOX_PARALLEL_NO_SPINNER**
     When set, disables the progress spinner during parallel execution.
 
-SEE ALSO
-========
+##########
+ SEE ALSO
+##########
 
 Full documentation: https://tox.wiki/
 
 **pip**\(1), **pytest**\(1), **virtualenv**\(1)
 
-AUTHOR
-======
+########
+ AUTHOR
+########
 
 tox development team
 
 https://github.com/tox-dev/tox
-
-COPYRIGHT
-=========
-
-MIT License

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from docutils.core import publish_string
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version: str, build_data: dict[str, Any]) -> None:  # noqa: ARG002
+        if self.target_name == "wheel":
+            root = Path(self.root)
+            (output := root / "build" / "man").mkdir(parents=True, exist_ok=True)
+            (output / "tox.1").write_bytes(
+                publish_string(
+                    "\n".join(
+                        line
+                        for line in (root / "docs" / "man" / "tox.1.rst").read_text(encoding="utf-8").splitlines()
+                        if line.strip() != ":orphan:"
+                    ),
+                    writer_name="manpage",
+                    settings_overrides={"report_level": 5},
+                )
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 build-backend = "hatchling.build"
 requires = [
+  "docutils>=0.21",
   "hatch-vcs>=0.5",
   "hatchling>=1.29",
 ]
@@ -84,6 +85,7 @@ test = [
   "devpi-process>=1.1.1",
   "diff-cover>=10.2",
   "distlib>=0.4",
+  "docutils>=0.21",
   "flaky>=3.8.1",
   "hatch-vcs>=0.5",
   "hatchling>=1.29",
@@ -142,13 +144,14 @@ type-min = [
 build.dev-mode-dirs = [
   "src",
 ]
+build.hooks.custom = {}
 build.hooks.vcs.version-file = "src/tox/version.py"
 build.targets.sdist.include = [
   "/src",
   "/tests",
   "/tox.toml",
 ]
-build.targets.wheel.shared-data = { "docs/man" = "share/man/man1" }
+build.targets.wheel.shared-data = { "build/man" = "share/man/man1" }
 version.source = "vcs"
 
 [tool.ruff]

--- a/src/tox/session/cmd/run/single.py
+++ b/src/tox/session/cmd/run/single.py
@@ -85,6 +85,7 @@ def run_commands(tox_env: RunToxEnv, no_test: bool) -> tuple[int, list[Outcome]]
         chdir.mkdir(exist_ok=True, parents=True)
         ignore_errors: bool = tox_env.conf["ignore_errors"]
         retry_count: int = tox_env.conf["commands_retry"]
+        interrupt_post_commands: bool = tox_env.conf["interrupt_post_commands"]
         MANAGER.tox_before_run_commands(tox_env)
         status_pre, status_main, status_post = -1, -1, -1
         try:
@@ -95,7 +96,8 @@ def run_commands(tox_env: RunToxEnv, no_test: bool) -> tuple[int, list[Outcome]]
                 else:
                     status_main = Outcome.OK
             finally:
-                status_post = run_command_set(tox_env, "commands_post", chdir, ignore_errors, outcomes, retry_count)
+                with tox_env.allow_post_commands_after_interrupt(interrupt_post_commands):
+                    status_post = run_command_set(tox_env, "commands_post", chdir, ignore_errors, outcomes, retry_count)
         finally:
             exit_code = status_pre or status_main or status_post  # first non-success
             MANAGER.tox_after_run_commands(tox_env, exit_code, outcomes)

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -497,6 +497,10 @@
           },
           "description": "the commands to be called after testing"
         },
+        "interrupt_post_commands": {
+          "type": "boolean",
+          "description": "run commands_post even after interrupt (SIGINT), allow second interrupt to cancel"
+        },
         "recreate_commands": {
           "type": "array",
           "items": {

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -75,7 +75,7 @@ class ToxEnvCreateArgs(NamedTuple):
     log_handler: ToxHandler
 
 
-class ToxEnv(ABC):
+class ToxEnv(ABC):  # noqa: PLR0904
     """A tox environment."""
 
     def __init__(self, create_args: ToxEnvCreateArgs) -> None:
@@ -100,6 +100,8 @@ class ToxEnv(ABC):
         self._suspended_out_err: OutErr | None = None
         self._execute_statuses: dict[int, ExecuteStatus] = {}
         self._interrupted = False
+        self._fully_interrupted = False
+        self._allow_interrupted_execution = False
         self._log_id = 0
 
     @property
@@ -467,10 +469,24 @@ class ToxEnv(ABC):
 
     def interrupt(self) -> None:
         """Interrupt the execution of a tox environment."""
-        logging.warning("interrupt tox environment: %s", self.conf.name)
-        self._interrupted = True
+        if self._interrupted:
+            logging.warning("second interrupt received for tox environment: %s - forcing full stop", self.conf.name)
+            self._fully_interrupted = True
+        else:
+            logging.warning("interrupt tox environment: %s", self.conf.name)
+            self._interrupted = True
         for status in list(self._execute_statuses.values()):
             status.interrupt()
+
+    @contextmanager
+    def allow_post_commands_after_interrupt(self, enabled: bool) -> Iterator[None]:  # noqa: FBT001
+        """Context manager to allow commands_post execution after interrupt when enabled."""
+        if enabled and self._interrupted and not self._fully_interrupted:
+            self._allow_interrupted_execution = True
+        try:
+            yield
+        finally:
+            self._allow_interrupted_execution = False
 
     @contextmanager
     def execute_async(  # noqa: PLR0913
@@ -482,7 +498,7 @@ class ToxEnv(ABC):
         run_id: str = "",
         executor: Execute | None = None,
     ) -> Iterator[ExecuteStatus]:
-        if self._interrupted:
+        if self._fully_interrupted or (self._interrupted and not self._allow_interrupted_execution):
             raise SystemExit(-2)  # pragma: no cover
         if cwd is None:
             cwd = self.core["tox_root"]

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -72,6 +72,12 @@ class RunToxEnv(ToxEnv, ABC):
             desc="the commands to be called after testing",
         )
         self.conf.add_config(
+            keys=["interrupt_post_commands"],
+            of_type=bool,
+            default=False,
+            desc="run commands_post even after interrupt (SIGINT), allow second interrupt to cancel",
+        )
+        self.conf.add_config(
             keys=["recreate_commands"],
             of_type=list[Command],
             default=[],

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import json
 import os
 import re
+import signal
 import sys
 import sysconfig
 from pathlib import Path
+from subprocess import PIPE, Popen
+from time import sleep
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -726,3 +729,102 @@ def test_no_capture_short_flag_parsed(tox_project: ToxProjectCreator) -> None:
     result = project.run("r", "-e", "py", "-i")
     result.assert_success()
     assert execute_calls.call_count > 0
+
+
+def test_interrupt_post_commands_config_and_context_manager(tox_project: ToxProjectCreator) -> None:
+    toml = "[env_run_base]\npackage = 'skip'\ninterrupt_post_commands = true"
+    proj = tox_project({"tox.toml": toml})
+    result = proj.run("c", "-e", "py", "-k", "interrupt_post_commands")
+    result.assert_success()
+    assert "interrupt_post_commands = True" in result.out
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGINT tests hang on Windows CI")
+@pytest.mark.flaky(max_runs=3, min_passes=1)
+def test_interrupt_post_commands_runs_after_sigint(tox_project: ToxProjectCreator, tmp_path: Path) -> None:
+    marker_main = tmp_path / "main"
+    marker_post = tmp_path / "post"
+    main_cmd = f"from pathlib import Path; Path('{marker_main}').write_text(''); import time; time.sleep(100)"
+    post_cmd = f"from pathlib import Path; Path('{marker_post}').write_text('done')"
+    toml = f"""
+    [env_run_base]
+    package = "skip"
+    interrupt_post_commands = true
+    commands = [["python", "-c", "{main_cmd}"]]
+    commands_post = [["python", "-c", "{post_cmd}"]]
+    """
+    proj = tox_project({"tox.toml": toml})
+    cmd = ["-c", str(proj.path / "tox.toml"), "r", "-e", "py"]
+    process = Popen([sys.executable, "-m", "tox", *cmd], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    while not marker_main.exists() and (process.poll() is None):
+        sleep(0.05)
+    sig = signal.CTRL_C_EVENT if sys.platform == "win32" else signal.SIGINT
+    process.send_signal(sig)
+    _out, err = process.communicate()
+    assert process.returncode != 0
+    assert "KeyboardInterrupt" in err
+    assert marker_post.exists(), "commands_post should have run after SIGINT"
+    assert marker_post.read_text() == "done"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGINT tests hang on Windows CI")
+@pytest.mark.flaky(max_runs=3, min_passes=1)
+def test_interrupt_post_commands_not_run_by_default(tox_project: ToxProjectCreator, tmp_path: Path) -> None:
+    marker_main = tmp_path / "main"
+    marker_post = tmp_path / "post"
+    main_cmd = f"from pathlib import Path; Path('{marker_main}').write_text(''); import time; time.sleep(100)"
+    post_cmd = f"from pathlib import Path; Path('{marker_post}').write_text('done')"
+    toml = f"""
+    [env_run_base]
+    package = "skip"
+    commands = [["python", "-c", "{main_cmd}"]]
+    commands_post = [["python", "-c", "{post_cmd}"]]
+    """
+    proj = tox_project({"tox.toml": toml})
+    cmd = ["-c", str(proj.path / "tox.toml"), "r", "-e", "py"]
+    process = Popen([sys.executable, "-m", "tox", *cmd], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    while not marker_main.exists() and (process.poll() is None):
+        sleep(0.05)
+    sig = signal.CTRL_C_EVENT if sys.platform == "win32" else signal.SIGINT
+    process.send_signal(sig)
+    _out, err = process.communicate()
+    assert process.returncode != 0
+    assert "KeyboardInterrupt" in err
+    assert not marker_post.exists(), "commands_post should NOT run after SIGINT by default"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGINT tests hang on Windows CI")
+@pytest.mark.flaky(max_runs=3, min_passes=1)
+def test_second_interrupt_stops_post_commands(tox_project: ToxProjectCreator, tmp_path: Path) -> None:
+    marker_main = tmp_path / "main"
+    marker_post_start = tmp_path / "post_start"
+    marker_post_end = tmp_path / "post_end"
+    main_cmd = f"from pathlib import Path; Path('{marker_main}').write_text(''); import time; time.sleep(100)"
+    post_start_cmd = f"from pathlib import Path; Path('{marker_post_start}').write_text('')"
+    post_end_cmd = f"from pathlib import Path; Path('{marker_post_end}').write_text('done')"
+    toml = f"""
+    [env_run_base]
+    package = "skip"
+    interrupt_post_commands = true
+    commands = [["python", "-c", "{main_cmd}"]]
+    commands_post = [
+        ["python", "-c", "{post_start_cmd}"],
+        ["python", "-c", "import time; time.sleep(100)"],
+        ["python", "-c", "{post_end_cmd}"],
+    ]
+    """
+    proj = tox_project({"tox.toml": toml})
+    cmd = ["-c", str(proj.path / "tox.toml"), "r", "-e", "py"]
+    process = Popen([sys.executable, "-m", "tox", *cmd], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    while not marker_main.exists() and (process.poll() is None):
+        sleep(0.05)
+    sig = signal.CTRL_C_EVENT if sys.platform == "win32" else signal.SIGINT
+    process.send_signal(sig)
+    while not marker_post_start.exists() and (process.poll() is None):
+        sleep(0.05)
+    process.send_signal(sig)
+    out, _err = process.communicate()
+    assert process.returncode != 0
+    assert marker_post_start.exists(), "commands_post should have started"
+    assert not marker_post_end.exists(), "second SIGINT should have stopped commands_post"
+    assert "second interrupt received" in out


### PR DESCRIPTION
Users pressing Ctrl-C during test runs had no way to execute cleanup tasks in `commands_post`. While the finally block ensures `commands_post` starts, the interrupt check in `execute_async()` immediately exits with `SystemExit(-2)` before any commands execute. This prevents cleanup like stopping Docker containers or removing temp files when tests are interrupted.

Add `interrupt_post_commands` config option (default `false`). When enabled, first Ctrl-C interrupts `commands` and `commands_pre` but allows `commands_post` to proceed for cleanup. Second Ctrl-C during `commands_post` forces immediate termination. Implementation uses a context manager `allow_post_commands_after_interrupt()` that temporarily sets `_allow_interrupted_execution` flag to bypass the interrupt check, tracks interrupt levels with `_fully_interrupted` for second Ctrl-C detection, and wraps `commands_post` execution in the context manager when the config is enabled.

Tests verify cleanup runs after single Ctrl-C when enabled, doesn't run by default, and stops on second Ctrl-C. Cross-platform support uses `CTRL_C_EVENT` on Windows and `SIGINT` on Unix.

Fixes #3858