### PR TITLE
✨ feat(config): support subscript syntax and env_name in conditionals

### DIFF
--- a/docs/changelog/3880.feature.rst
+++ b/docs/changelog/3880.feature.rst
@@ -1,0 +1,3 @@
+Add ``factor['NAME']`` and ``env['VAR']`` subscript syntax for conditional expressions, enabling checks of factors with
+non-identifier names like ``factor['3.14']``. Add ``env_name`` variable to check the full environment name in
+conditions.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -173,6 +173,8 @@ Conditional value evaluation
 
 .. versionadded:: 4.40
 
+.. versionchanged:: 4.50 Added ``factor['NAME']``/``env['VAR']`` subscript syntax and ``env_name`` variable.
+
 TOML configurations support ``replace = "if"`` to conditionally select values at configuration load time. The
 ``condition`` field accepts expressions that are parsed using Python's ``ast`` module and evaluated against the host
 ``os.environ``.
@@ -181,6 +183,12 @@ The expression language supports:
 
 - ``env.VAR`` -- resolves to the value of the environment variable ``VAR``, or empty string if unset. An empty string is
   falsy, any non-empty string is truthy.
+- ``env['VAR']`` -- same as ``env.VAR``, useful when the variable name needs to be in a string.
+- ``factor.NAME`` -- resolves to ``True`` if ``NAME`` is a factor in the environment name or platform, ``False``
+  otherwise.
+- ``factor['NAME']`` -- same as ``factor.NAME``, for names that aren't valid Python identifiers. Use this for version
+  numbers like ``factor['3.14']`` since ``factor.3.14`` would be a syntax error.
+- ``env_name`` -- the full environment name as a string (e.g., ``test-3.14``). Use for exact name matching.
 - ``'literal'`` -- a string literal for comparison.
 - ``==``, ``!=`` -- string equality and inequality.
 - ``and``, ``or``, ``not`` -- boolean combinators with standard Python precedence.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -520,6 +520,8 @@ Common architecture values (after normalization):
 
 .. versionchanged:: 4.42 Added ``factor.NAME`` lookups for environment name factors and platform.
 
+.. versionchanged:: 4.50 Added ``factor['NAME']``/``env['VAR']`` subscript syntax and ``env_name`` variable.
+
 TOML configurations can conditionally select values based on environment variables and factors using ``replace = "if"``.
 The ``condition`` field accepts expressions with ``env.VAR`` lookups for environment variables, ``factor.NAME`` lookups
 for environment name factors and platform, ``==``/``!=`` comparisons, and ``and``/``or``/``not`` boolean logic.
@@ -557,6 +559,22 @@ Combine multiple conditions (environment variables and factors):
 
     [env_run_base]
     commands = [["pytest", { replace = "if", condition = "factor.linux and not env.CI", then = ["--numprocesses=auto"], "else" = [], extend = true }]]
+
+Use subscript syntax for version-number factors that aren't valid Python identifiers:
+
+.. code-block:: toml
+
+    [env."test-3.14"]
+    commands = [
+        ["pytest", { replace = "if", condition = "factor['3.14']", then = ["--strict-markers"], "else" = [], extend = true }],
+    ]
+
+Target a specific environment by name with ``env_name``:
+
+.. code-block:: toml
+
+    [env_run_base]
+    set_env.EXTRA = { replace = "if", condition = "env_name == 'test-3.14'", then = "latest", "else" = "" }
 
 For the full expression syntax and more examples, see :ref:`conditional-value-reference`.
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -2350,6 +2350,8 @@ Conditional value reference
 
 .. versionchanged:: 4.42 Added ``factor.NAME`` lookups for environment name factors and platform.
 
+.. versionchanged:: 4.50 Added ``factor['NAME']`` and ``env['VAR']`` subscript syntax and ``env_name`` variable.
+
 You can conditionally select values based on environment variables and factors via the ``if`` replacement. The
 ``condition`` field accepts an expression language that supports ``env.VAR_NAME`` lookups for environment variables,
 ``factor.NAME`` lookups for environment name factors and platform, ``==``/``!=`` comparisons, and ``and``/``or``/``not``
@@ -2376,30 +2378,30 @@ If ``TAG_NAME`` is set and non-empty, ``MATURITY`` becomes ``production``, other
 .. code-block:: toml
 
     [env.A]
-    description = { replace = "if", condition = "env.CI and env.DEPLOY", then = "deploying", "else" = "skipped" }
+    set_env.DEPLOY_TARGET = { replace = "if", condition = "env.CI and env.DEPLOY", then = "production", "else" = "none" }
 
     [env.B]
-    description = { replace = "if", condition = "env.CI or env.LOCAL", then = "active", "else" = "inactive" }
+    pass_env = [{ replace = "if", condition = "env.CI or env.LOCAL", then = ["AWS_*"], "else" = [], extend = true }]
 
     [env.C]
-    description = { replace = "if", condition = "not env.CI", then = "local dev", "else" = "CI build" }
+    commands = [["pytest", { replace = "if", condition = "not env.CI", then = ["--pdb"], "else" = [], extend = true }]]
 
     [env.D]
-    description = { replace = "if", condition = "env.MODE != 'prod'", then = "non-production", "else" = "production" }
+    set_env.LOG_LEVEL = { replace = "if", condition = "env.MODE != 'prod'", then = "DEBUG", "else" = "INFO" }
 
 **Omitting the else clause** defaults to an empty string:
 
 .. code-block:: toml
 
     [env.A]
-    description = { replace = "if", condition = "env.DEPLOY", then = "deployment mode" }
+    set_env.DEPLOY_FLAG = { replace = "if", condition = "env.DEPLOY", then = "1" }
 
 **Nested substitutions** in ``then``/``else`` values are processed normally:
 
 .. code-block:: toml
 
     [env.A]
-    description = { replace = "if", condition = "env.DEPLOY", then = "{env_name}", "else" = "none" }
+    set_env.TEST_ENV = { replace = "if", condition = "env.DEPLOY", then = "{env_name}", "else" = "local" }
 
 **With extend in list contexts:**
 
@@ -2440,10 +2442,37 @@ factor without requiring it in the environment name.
     [env_run_base]
     commands = [["pytest", { replace = "if", condition = "factor.linux and env.CI", then = ["--numprocesses=auto"], "else" = [], extend = true }]]
 
+**Check factors with non-identifier names:**
+
+Factor names like ``3.14`` are not valid Python identifiers, so ``factor.3.14`` would be a syntax error. Use subscript
+syntax instead:
+
+.. code-block:: toml
+
+    [env."test-3.14"]
+    commands = [
+        ["pytest", { replace = "if", condition = "factor['3.14']", then = ["--strict-markers"], "else" = [], extend = true }],
+    ]
+
+In this example, the environment name ``test-3.14`` has factors ``test`` and ``3.14``. The subscript syntax also works
+for environment variables: ``env['CI']`` is equivalent to ``env.CI``.
+
+**Check the environment name:**
+
+Use ``env_name`` to match the full environment name as a string:
+
+.. code-block:: toml
+
+    [env_run_base]
+    set_env.CUSTOM_FLAG = { replace = "if", condition = "env_name == 'test-3.14'", then = "enabled", "else" = "" }
+
 **Condition expression reference:**
 
 - ``env.VAR`` -- value of environment variable ``VAR`` (empty string if unset); truthy when non-empty
+- ``env['VAR']`` -- same as ``env.VAR``
 - ``factor.NAME`` -- ``True`` if ``NAME`` is a factor in the environment name or platform; ``False`` otherwise
+- ``factor['NAME']`` -- same as ``factor.NAME``, for names that aren't valid Python identifiers (e.g. ``3.14``)
+- ``env_name`` -- the full environment name as a string
 - ``==``, ``!=`` -- string comparison
 - ``and``, ``or``, ``not`` -- boolean logic
 - ``'string'`` -- string literal

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -173,6 +173,12 @@ Prefer the ``N.M`` form (e.g. ``3.14``) over ``pyNMM`` (e.g. ``py314``). The dot
 naturally in environment lists and CI output, and avoids confusion for Python versions >= 3.10 where the concatenated
 digits become three characters.
 
+.. note::
+
+    Version-number factors like ``3.14`` can be checked in conditional expressions using subscript syntax:
+    ``factor['3.14']`` (the dot-syntax ``factor.3.14`` would be a syntax error). See :ref:`conditional-value-reference`
+    for details.
+
 If the name doesn't match any pattern, tox uses the same Python as the one tox is installed into (this is the case for
 ``lint`` in our example). To override this fallback, set :ref:`default_base_python`:
 

--- a/src/tox/config/loader/toml/_replace.py
+++ b/src/tox/config/loader/toml/_replace.py
@@ -155,48 +155,77 @@ def _replace_if_toml(
     if "then" not in value:
         msg = "No 'then' value was supplied in if replacement"
         raise MatchError(msg)
-    return unroll(
-        value["then"] if _evaluate_condition(condition, factors) else value.get("else", ""), depth, skip_str=skip_str
-    )
+    matched = _evaluate_condition(condition, factors, unroll.args.env_name)
+    return unroll(value["then"] if matched else value.get("else", ""), depth, skip_str=skip_str)
 
 
-def _evaluate_condition(expr: str, factors: set[str]) -> bool:  # noqa: C901
+def _evaluate_condition(expr: str, factors: set[str], env_name: str | None) -> bool:
     """Evaluate a condition expression supporting env.VAR, factor.NAME lookups, comparisons, and boolean logic."""
     try:
         tree = ast.parse(expr, mode="eval")
     except SyntaxError:
         msg = f"Invalid condition expression: {expr}"
         raise MatchError(msg) from None
+    return bool(_eval_condition_node(tree.body, expr, factors, env_name))
 
-    def _eval(node: ast.expr) -> str | bool:  # noqa: PLR0911, C901
-        if isinstance(node, ast.BoolOp):
-            if isinstance(node.op, ast.And):
-                return all(bool(_eval(v)) for v in node.values)
-            return any(bool(_eval(v)) for v in node.values)
-        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
-            return not bool(_eval(node.operand))
-        if isinstance(node, ast.Compare) and len(node.ops) == 1 and len(node.comparators) == 1:
-            left = _eval(node.left)
-            right = _eval(node.comparators[0])
-            if isinstance(node.ops[0], ast.Eq):
-                return left == right
-            if isinstance(node.ops[0], ast.NotEq):
-                return left != right
-            msg = f"Unsupported comparison operator in condition: {expr}"
-            raise MatchError(msg)
-        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
-            if node.value.id == "env":
-                return os.environ.get(node.attr, "")
-            if node.value.id == "factor":
-                return node.attr in factors
-            msg = f"Unsupported namespace in condition: {node.value.id} (expected 'env' or 'factor')"
-            raise MatchError(msg)
-        if isinstance(node, ast.Constant) and isinstance(node.value, str):
-            return node.value
+
+def _eval_condition_node(node: ast.expr, expr: str, factors: set[str], env_name: str | None) -> str | bool:
+    if isinstance(node, ast.BoolOp):
+        return _eval_bool_op(node, expr, factors, env_name)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return not bool(_eval_condition_node(node.operand, expr, factors, env_name))
+    if isinstance(node, ast.Compare):
+        return _eval_compare(node, expr, factors, env_name)
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if (lookup_result := _try_lookup_or_name(node, factors, env_name)) is not None:
+        return lookup_result
+    msg = f"Unsupported expression in condition: {ast.dump(node)}"
+    raise MatchError(msg)
+
+
+def _eval_bool_op(node: ast.BoolOp, expr: str, factors: set[str], env_name: str | None) -> bool:
+    if isinstance(node.op, ast.And):
+        return all(bool(_eval_condition_node(v, expr, factors, env_name)) for v in node.values)
+    return any(bool(_eval_condition_node(v, expr, factors, env_name)) for v in node.values)
+
+
+def _eval_compare(node: ast.Compare, expr: str, factors: set[str], env_name: str | None) -> bool:
+    if len(node.ops) != 1 or len(node.comparators) != 1:
         msg = f"Unsupported expression in condition: {ast.dump(node)}"
         raise MatchError(msg)
+    left = _eval_condition_node(node.left, expr, factors, env_name)
+    right = _eval_condition_node(node.comparators[0], expr, factors, env_name)
+    if isinstance(node.ops[0], ast.Eq):
+        return left == right
+    if isinstance(node.ops[0], ast.NotEq):
+        return left != right
+    msg = f"Unsupported comparison operator in condition: {expr}"
+    raise MatchError(msg)
 
-    return bool(_eval(tree.body))
+
+def _try_lookup_or_name(node: ast.expr, factors: set[str], env_name: str | None) -> str | bool | None:
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        return _lookup_namespace(node.value.id, node.attr, factors)
+    if (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and isinstance(node.slice, ast.Constant)
+        and isinstance(node.slice.value, str)
+    ):
+        return _lookup_namespace(node.value.id, node.slice.value, factors)
+    if isinstance(node, ast.Name) and node.id == "env_name":
+        return env_name or ""
+    return None
+
+
+def _lookup_namespace(namespace: str, key: str, factors: set[str]) -> str | bool:
+    if namespace == "env":
+        return os.environ.get(key, "")
+    if namespace == "factor":
+        return key in factors
+    msg = f"Unsupported namespace in condition: {namespace} (expected 'env' or 'factor')"
+    raise MatchError(msg)
 
 
 _REFERENCE_PATTERN = re.compile(

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -771,6 +771,82 @@ def test_config_in_toml_replace_if_factor_combined_with_env(
     outcome.assert_out_err("[testenv:3.13-django50]\ndescription = django in CI\n", "")
 
 
+@pytest.mark.parametrize(
+    ("env_name", "condition", "expected"),
+    [
+        pytest.param("test-3.14", "factor['3.14']", "matched", id="match"),
+        pytest.param("test-3.13", "factor['3.14']", "no match", id="no-match"),
+        pytest.param("test-3.13", "not factor['3.14']", "not 3.14", id="negated"),
+        pytest.param("test-3.14-3.13", "factor['3.14'] and factor['3.13']", "both", id="combined"),
+    ],
+)
+def test_config_in_toml_replace_if_factor_subscript(
+    tox_project: ToxProjectCreator, env_name: str, condition: str, expected: str
+) -> None:
+    project = tox_project({
+        "pyproject.toml": dedent(f"""
+        [tool.tox.env."{env_name}"]
+        description.replace = "if"
+        description.condition = "{condition}"
+        description.then = "{expected}"
+        description.else = "no match"
+        """),
+    })
+    outcome = project.run("c", "-e", env_name, "-k", "description")
+    outcome.assert_success()
+    outcome.assert_out_err(f"[testenv:{env_name}]\ndescription = {expected}\n", "")
+
+
+@pytest.mark.parametrize(
+    ("env_value", "condition", "expected"),
+    [
+        pytest.param("1", "env['CI']", "in CI", id="truthy"),
+        pytest.param("true", "env['CI'] == 'true'", "ci true", id="compare"),
+    ],
+)
+def test_config_in_toml_replace_if_env_subscript(
+    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch, env_value: str, condition: str, expected: str
+) -> None:
+    monkeypatch.setenv("CI", env_value)
+    project = tox_project({
+        "pyproject.toml": dedent(f"""
+        [tool.tox.env.test]
+        description.replace = "if"
+        description.condition = "{condition}"
+        description.then = "{expected}"
+        description.else = "not CI"
+        """),
+    })
+    outcome = project.run("c", "-e", "test", "-k", "description")
+    outcome.assert_success()
+    outcome.assert_out_err(f"[testenv:test]\ndescription = {expected}\n", "")
+
+
+@pytest.mark.parametrize(
+    ("env_name", "condition", "expected"),
+    [
+        pytest.param("test-3.14", "env_name == 'test-3.14'", "exact", id="match"),
+        pytest.param("test-3.13", "env_name == 'test-3.14'", "other", id="no-match"),
+        pytest.param("test-3.14", "env_name != 'test-3.13'", "not 3.13", id="not-equal"),
+    ],
+)
+def test_config_in_toml_replace_if_env_name(
+    tox_project: ToxProjectCreator, env_name: str, condition: str, expected: str
+) -> None:
+    project = tox_project({
+        "pyproject.toml": dedent(f"""
+        [tool.tox.env."{env_name}"]
+        description.replace = "if"
+        description.condition = "{condition}"
+        description.then = "{expected}"
+        description.else = "other"
+        """),
+    })
+    outcome = project.run("c", "-e", env_name, "-k", "description")
+    outcome.assert_success()
+    outcome.assert_out_err(f"[testenv:{env_name}]\ndescription = {expected}\n", "")
+
+
 def test_config_in_toml_replace_if_list_without_extend_in_deps(
     tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/docs/test_doc_config_examples.py
+++ b/tests/docs/test_doc_config_examples.py
@@ -145,7 +145,7 @@ def _replace_python_versions(content: str) -> str:
     content = re.sub(r"python3\.\d+", f"python{current_version}", content)
     content = re.sub(r"py\d{2,3}", current_py, content)
     content = re.sub(r"cpython3\.\d+", f"cpython{current_version}", content)
-    return re.sub(r"(?<=[\s\[\"',=])3\.\d+", current_version, content)
+    return re.sub(r"(?<=[\s\[\"',=\-])3\.\d+", current_version, content)
 
 
 def _classify(lang: str, content: str) -> tuple[str, str]:


### PR DESCRIPTION
Factor names like `3.14` are valid in tox for Python version-based environments, but they cannot be referenced in `replace = "if"` condition expressions because `factor.3.14` is invalid Python syntax—the parser interprets `.3.14` as a float literal. This limitation prevents users from writing conditional configuration based on Python version factors. ✨ Additionally, there was no way to check the full environment name in conditions, limiting the ability to target specific environments with conditional values.

This change adds subscript syntax for both `factor` and `env` lookups (`factor['3.14']` and `env['CI']`) to handle names that aren't valid Python identifiers. It also introduces an `env_name` variable that resolves to the full environment name as a string, enabling exact name matching like `env_name == 'test-3.14'`. 🔧 The implementation refactors the condition evaluator by extracting helper functions to reduce complexity while maintaining full backward compatibility with existing dot-syntax expressions (`factor.NAME` and `env.VAR`).

The new syntax works seamlessly with existing configurations. Users can now write version-specific conditional dependencies in environment configurations and target specific environments by name without workarounds. Documentation has been updated across reference, how-to, explanation, and tutorial sections with practical examples.