### PR TITLE
🐛 fix(config): apply testenv overrides to TOML env templates

### DIFF
--- a/src/tox/config/source/ini.py
+++ b/src/tox/config/source/ini.py
@@ -53,10 +53,13 @@ class IniSource(Source):
             # if no matching section/prefix is found, use the requested section key as-is (for custom prefixes)
             key = section.key
         if self._parser.has_section(key):
+            overrides = list(override_map.get(section.key, []))
+            if section.prefix is not None:
+                overrides.extend(override_map.get(section.prefix, []))
             return IniLoader(
                 section=section,
                 parser=self._parser,
-                overrides=override_map.get(section.key, []),
+                overrides=overrides,
                 core_section=self.CORE_SECTION,
                 section_key=key,
             )

--- a/src/tox/config/source/toml_pyproject.py
+++ b/src/tox/config/source/toml_pyproject.py
@@ -132,9 +132,16 @@ class TomlPyProject(Source):
             unused_exclude = {sec.ENV, sec.ENV_BASE, sec.RUN_ENV_BASE, sec.PKG_ENV_BASE}
         elif is_env_base:
             unused_exclude = {"factors"}
+        overrides = list(override_map.get(section.key, []))
+        if section.prefix is not None:
+            overrides.extend(override_map.get(section.prefix, []))
+        if "testenv" in override_map and (
+            section.key == sec.RUN_ENV_BASE or (section.prefix and section.prefix.endswith(sec.ENV))
+        ):
+            overrides.extend(override_map.get("testenv", []))
         return TomlLoader(
             section=section,
-            overrides=override_map.get(section.key, []),
+            overrides=overrides,
             content=current,
             root_content=self._content,
             unused_exclude=unused_exclude,

--- a/tests/tox_env/test_tox_env_api.py
+++ b/tests/tox_env/test_tox_env_api.py
@@ -266,3 +266,44 @@ def test_gitignore_created_in_work_dir(tox_project: ToxProjectCreator) -> None:
     gitignore = prj.path / ".tox" / ".gitignore"
     assert gitignore.exists()
     assert gitignore.read_text(encoding="utf-8") == "*\n"
+
+
+def test_tox_override_pass_env_runtime(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+    cmd = (
+        "import os; "
+        "nix_ld = os.environ.get('NIX_LD'); "
+        "nix_lib = os.environ.get('NIX_LD_LIBRARY_PATH'); "
+        "print(f'NIX_LD={nix_ld}'); "
+        "print(f'NIX_LD_LIBRARY_PATH={nix_lib}'); "
+        "exit(0 if nix_ld and nix_lib else 1)"
+    )
+    toml = f"""
+    [env_run_base]
+    package = "skip"
+    commands = [["python", "-c", "{cmd}"]]
+    """
+    project = tox_project({"tox.toml": toml})
+    monkeypatch.setenv("NIX_LD", "/nix/store/test-ld")
+    monkeypatch.setenv("NIX_LD_LIBRARY_PATH", "/nix/store/test-lib")
+    monkeypatch.setenv("TOX_OVERRIDE", "testenv.pass_env+=NIX_LD,NIX_LD_LIBRARY_PATH")
+    result = project.run("r")
+    result.assert_success()
+    assert "NIX_LD=/nix/store/test-ld" in result.out
+    assert "NIX_LD_LIBRARY_PATH=/nix/store/test-lib" in result.out
+
+
+def test_tox_override_pass_env_custom_var(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+    cmd = "import os; val = os.environ.get('CUSTOM_VAR'); print(f'CUSTOM_VAR={val}'); exit(0 if val else 1)"
+    toml = f"""
+    [env_run_base]
+    package = "skip"
+    commands = [["python", "-c", "{cmd}"]]
+    """
+    project = tox_project({"tox.toml": toml})
+    monkeypatch.setenv("CUSTOM_VAR", "test_value")
+    monkeypatch.setenv("TOX_OVERRIDE", "testenv.pass_env+=CUSTOM_VAR")
+    config_result = project.run("c", "-k", "pass_env")
+    assert "CUSTOM_VAR" in config_result.out, f"CUSTOM_VAR not in config output:\n{config_result.out}"
+    result = project.run("r")
+    result.assert_success()
+    assert "CUSTOM_VAR=test_value" in result.out


### PR DESCRIPTION
Users setting `TOX_OVERRIDE` with the `testenv` prefix found their overrides ignored in TOML-based projects, while the same syntax worked perfectly in INI configs. 🔧 For example, `testenv.pass_env+=CUSTOM_VAR` would appear in the config output but the variable wouldn't actually pass through at runtime, breaking CI pipelines and NixOS setups that rely on environment overrides.

TOML uses different section naming conventions than INI. Where INI uses `testenv` as the section prefix, TOML uses `env_run_base` for base templates and `tool.tox.env` for individual environments. The loader only looked up overrides by exact section key match, so `testenv.*` overrides never matched TOML section names and were silently dropped.

The fix maps the familiar `testenv` namespace to TOML-style sections by checking the override map for `testenv` entries and applying them to TOML env templates and env-prefixed sections. ✨ This preserves the consistent `testenv.*` override syntax that users expect to work across both config formats, without requiring them to learn TOML-specific override paths.

Fixes #3860