### PR TITLE
fix(sdist): include `docs/man/tox.1.rst`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build package
-        run: uv build --python 3.14 --python-preference only-managed --sdist --wheel . --out-dir dist
+        run: uv build --python 3.14 --python-preference only-managed . --out-dir dist
       - name: Store the distribution packages
         uses: actions/upload-artifact@v7
         with:

--- a/docs/changelog/3889.bugfix.rst
+++ b/docs/changelog/3889.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the sdist to include the missing ``docs/man/tox.1.rst`` file for building the manpage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ build.dev-mode-dirs = [
 build.hooks.custom = {}
 build.hooks.vcs.version-file = "src/tox/version.py"
 build.targets.sdist.include = [
+  "/docs/man",
   "/src",
   "/tests",
   "/tox.toml",


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [ ] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

Fixes #3889 (and #3885)

As described in the issues, the sdist is broken without `docs/man/tox.1.rst`. Also, I removed the `--sdist` and `--wheel` flags from `uv build` since [by default](https://docs.astral.sh/uv/reference/cli/#uv-build), uv will build the sdist first and then the wheel from it, which would have caught this issue
