### PR TITLE
🐛 fix(pkg): distinguish free-threaded Python in wheel build env

### DIFF
--- a/docs/changelog/3314.bugfix.rst
+++ b/docs/changelog/3314.bugfix.rst
@@ -1,0 +1,3 @@
+Use separate ``.pkg`` environments for free-threaded Python targets by including the ``t`` suffix in the wheel build
+environment name (e.g., ``.pkg-cpython314t``), preventing wheel tag mismatches when building for ``py314t`` - by
+:user:`gaborbernat`.

--- a/src/tox/tox_env/python/package.py
+++ b/src/tox/tox_env/python/package.py
@@ -112,10 +112,12 @@ class PythonPackageToxEnv(Python, PackageToxEnv, ABC):
             if (
                 default_pkg_py.version_no_dot == run_py.version_no_dot
                 and default_pkg_py.impl_lower == run_py.impl_lower
+                and default_pkg_py.free_threaded == run_py.free_threaded
             ):
                 return self.conf.name
 
-            return f"{self.conf.name}-{run_py.impl_lower}{run_py.version_no_dot}"
+            threaded = "t" if run_py.free_threaded else ""
+            return f"{self.conf.name}-{run_py.impl_lower}{run_py.version_no_dot}{threaded}"
 
         run_env.conf.add_config(
             keys=["wheel_build_env"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,10 @@ if sys.implementation.name == "pypy":
     collect_ignore.append("util/test_spinner.py")
 
 
+class PatchPrevPy(Protocol):
+    def __call__(self, has_prev: bool, free_threaded: bool | None = None) -> tuple[str, str, bool]: ...
+
+
 class ToxIniCreator(Protocol):
     def __call__(self, conf: str, override: Sequence[Override] | None = None) -> Config: ...
 
@@ -80,12 +84,13 @@ def demo_pkg_inline() -> Path:
 
 
 @pytest.fixture
-def patch_prev_py(mocker: MockerFixture) -> Callable[[bool], tuple[str, str]]:
-    def _func(has_prev: bool) -> tuple[str, str]:
+def patch_prev_py(mocker: MockerFixture) -> PatchPrevPy:
+    def _func(has_prev: bool, free_threaded: bool | None = None) -> tuple[str, str, bool]:
         ver = sys.version_info[0:2]
         prev_ver = "".join(str(i) for i in (ver[0], ver[1] - 1))
         prev_py = f"py{prev_ver}"
         impl = sys.implementation.name.lower()
+        is_free_threaded = sysconfig.get_config_var("Py_GIL_DISABLED") == 1 if free_threaded is None else free_threaded
 
         def get_python(self: VirtualEnv, base_python: list[str]) -> PythonInfo | None:  # noqa: ARG001
             if base_python[0] == "py31" or (base_python[0] == prev_py and not has_prev):
@@ -101,12 +106,12 @@ def patch_prev_py(mocker: MockerFixture) -> Callable[[bool], tuple[str, str]]:
                 is_64=True,
                 platform=sys.platform,
                 extra={"executable": Path(sys.executable)},
-                free_threaded=sysconfig.get_config_var("Py_GIL_DISABLED") == 1,
+                free_threaded=is_free_threaded,
                 machine=sysconfig.get_platform().rsplit("-", 1)[-1] or None,
             )
 
         mocker.patch.object(VirtualEnv, "_get_python", get_python)
-        return prev_ver, impl
+        return prev_ver, impl, is_free_threaded
 
     return _func
 

--- a/tests/session/cmd/test_depends.py
+++ b/tests/session/cmd/test_depends.py
@@ -5,13 +5,12 @@ from textwrap import dedent
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
+    from tests.conftest import PatchPrevPy
     from tox.pytest import ToxProjectCreator
 
 
-def test_depends_wheel(tox_project: ToxProjectCreator, patch_prev_py: Callable[[bool], tuple[str, str]]) -> None:
-    prev_ver, impl = patch_prev_py(True)  # has previous python
+def test_depends_wheel(tox_project: ToxProjectCreator, patch_prev_py: PatchPrevPy) -> None:
+    prev_ver, impl, _ = patch_prev_py(True)  # has previous python
     ver = sys.version_info[0:2]
     py = f"py{''.join(str(i) for i in ver)}"
     prev_py = f"py{prev_ver}"
@@ -53,8 +52,8 @@ def test_depends_wheel(tox_project: ToxProjectCreator, patch_prev_py: Callable[[
     assert outcome.out == dedent(expected).lstrip()
 
 
-def test_depends_sdist(tox_project: ToxProjectCreator, patch_prev_py: Callable[[bool], tuple[str, str]]) -> None:
-    prev_ver, _impl = patch_prev_py(True)  # has previous python
+def test_depends_sdist(tox_project: ToxProjectCreator, patch_prev_py: PatchPrevPy) -> None:
+    prev_ver, _impl, _ = patch_prev_py(True)  # has previous python
     ver = sys.version_info[0:2]
     py = f"py{''.join(str(i) for i in ver)}"
     prev_py = f"py{prev_ver}"

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -13,11 +13,11 @@ from tox.config.types import Command
 from tox.execute.request import shell_cmd
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from pathlib import Path
 
     from pytest_mock import MockerFixture
 
+    from tests.conftest import PatchPrevPy
     from tox.pytest import MonkeyPatch, ToxProjectCreator
 
 
@@ -218,9 +218,9 @@ def test_pass_env_config_default(tox_project: ToxProjectCreator, stdout_is_atty:
 
 def test_show_config_pkg_env_once(
     tox_project: ToxProjectCreator,
-    patch_prev_py: Callable[[bool], tuple[str, str]],
+    patch_prev_py: PatchPrevPy,
 ) -> None:
-    prev_ver, impl = patch_prev_py(True)
+    prev_ver, impl, _ = patch_prev_py(True)
     ini = f"[tox]\nenv_list=py{prev_ver},py\n[testenv]\npackage=wheel"
     project = tox_project({"tox.ini": ini, "pyproject.toml": ""})
     result = project.run("c", "-e", "ALL", raise_on_config_fail=False)
@@ -232,9 +232,9 @@ def test_show_config_pkg_env_once(
 
 def test_show_config_pkg_env_skip(
     tox_project: ToxProjectCreator,
-    patch_prev_py: Callable[[bool], tuple[str, str]],
+    patch_prev_py: PatchPrevPy,
 ) -> None:
-    prev_ver, _impl = patch_prev_py(False)
+    prev_ver, _impl, _ = patch_prev_py(False)
     ini = f"[tox]\nenv_list=py{prev_ver},py\n[testenv]\npackage=wheel"
     project = tox_project({"tox.ini": ini, "pyproject.toml": ""})
     result = project.run("c", "-e", "ALL", raise_on_config_fail=False)

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -13,10 +13,9 @@ from tox.tox_env.errors import Fail
 from tox.tox_env.python.api import Python
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from pytest_mock import MockerFixture
 
+    from tests.conftest import PatchPrevPy
     from tox.pytest import ToxProjectCreator
 
 
@@ -81,7 +80,7 @@ def test_validate_base_python_conflicting_factors_no_ignore() -> None:
 
 def test_build_wheel_in_non_base_pkg_env(
     tox_project: ToxProjectCreator,
-    patch_prev_py: Callable[[bool], tuple[str, str]],
+    patch_prev_py: PatchPrevPy,
     demo_pkg_inline: Path,
     mocker: MockerFixture,
 ) -> None:
@@ -95,7 +94,7 @@ def test_build_wheel_in_non_base_pkg_env(
         return mock
 
     mocker.patch("tox.tox_env.python.virtual_env.api.session_via_cli", side_effect=_fake_session)
-    prev_ver, impl = patch_prev_py(True)
+    prev_ver, impl, _ = patch_prev_py(True)
     prev_py = f"py{prev_ver}"
     prj = tox_project({"tox.ini": f"[tox]\nenv_list= {prev_py}\n[testenv]\npackage=wheel"})
     execute_calls = prj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
@@ -108,6 +107,38 @@ def test_build_wheel_in_non_base_pkg_env(
         (f".pkg-{impl}{prev_ver}", "build_wheel"),
         (f"py{prev_ver}", "install_package"),
         (f".pkg-{impl}{prev_ver}", "_exit"),
+    ]
+
+
+def test_build_wheel_in_free_threaded_pkg_env(
+    tox_project: ToxProjectCreator,
+    patch_prev_py: PatchPrevPy,
+    demo_pkg_inline: Path,
+    mocker: MockerFixture,
+) -> None:
+    def _fake_session(env_dir: list[str], **_: object) -> MagicMock:
+        bin_dir = Path(env_dir[0]) / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        (bin_dir / "python").symlink_to(sys.executable)
+        mock = MagicMock()
+        mock.creator.bin_dir = bin_dir
+        mock.creator.script_dir = bin_dir
+        return mock
+
+    mocker.patch("tox.tox_env.python.virtual_env.api.session_via_cli", side_effect=_fake_session)
+    prev_ver, impl, _ = patch_prev_py(True, free_threaded=True)
+    prev_py = f"py{prev_ver}"
+    prj = tox_project({"tox.ini": f"[tox]\nenv_list= {prev_py}\n[testenv]\npackage=wheel"})
+    execute_calls = prj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = prj.run("-r", "--root", str(demo_pkg_inline), "--workdir", str(prj.path / ".tox"))
+    result.assert_success()
+    calls = [(i[0][0].conf.name, i[0][3].run_id) for i in execute_calls.call_args_list]
+    assert calls == [
+        (f".pkg-{impl}{prev_ver}t", "_optional_hooks"),
+        (f".pkg-{impl}{prev_ver}t", "get_requires_for_build_wheel"),
+        (f".pkg-{impl}{prev_ver}t", "build_wheel"),
+        (f"py{prev_ver}", "install_package"),
+        (f".pkg-{impl}{prev_ver}t", "_exit"),
     ]
 
 


### PR DESCRIPTION
Running `tox -e py314t` builds the wheel in a `.pkg` environment that may use non-free-threaded Python. The `default_wheel_tag` function only compared `version_no_dot` and `impl_lower` between the package env and target env. Since `version_no_dot` is `"314"` for both `py314` and `py314t`, they shared the same `.pkg` environment, producing wheels with `cp314` tags instead of `cp314t`. 🐛 `pip install` in the free-threaded target env then rejects the wheel as unsupported.

The fix adds `free_threaded` to the compatibility check in `default_wheel_tag()` and appends the `t` suffix to the generated environment name when the target interpreter is free-threaded (e.g., `.pkg-cpython314t`). This ensures each threading variant gets its own build environment with matching wheel tags.

Fixes #3314