### PR TITLE
✨ feat(config): support escaped dots in -x override keys

### DIFF
--- a/docs/changelog/3910.feature.rst
+++ b/docs/changelog/3910.feature.rst
@@ -1,0 +1,2 @@
+Support escaped dots (``\.``) in ``-x``/``--override`` keys, allowing overrides to target environments with dots in
+their names such as ``py3.14`` - by :user:`gaborbernat`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -2191,6 +2191,30 @@ Or reset override and append to that (note the first override is ``=`` and not `
 
        tox -x testenv.deps=pytest-xdist -x testenv.deps+=pytest-cov
 
+Escaping dots in override keys
+==============================
+
+.. versionadded:: 4.52
+
+Environment names can contain literal dots (e.g., ``py3.14``). Since ``.`` is also the separator between namespace
+components and the config key, you need to escape literal dots with a backslash (``\.``) so they are not treated as
+separators:
+
+.. tab:: TOML
+
+    .. code-block:: bash
+
+       tox -x 'env.3\.14.deps=pytest-xdist'
+
+.. tab:: INI
+
+    .. code-block:: bash
+
+       tox -x 'testenv:3\.14.deps=pytest-xdist'
+
+Multiple dots can be escaped in the same key: ``-x 'some\.dotted\.name.key=val'``. A backslash not followed by a dot
+passes through literally.
+
 ***********
  TOML only
 ***********

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ lint.per-file-ignores."tests/**/*.py" = [
   "D",       # don't care about documentation in tests
   "FBT",     # don't care about booleans as positional arguments in tests
   "INP001",  # no implicit namespace
+  "PLR0913", # too many arguments to function definition
   "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
   "S101",    # asserts allowed in tests
   "S603",    # `subprocess` call: check for execution of untrusted input

--- a/src/tox/config/loader/api.py
+++ b/src/tox/config/loader/api.py
@@ -34,13 +34,17 @@ class Override:  # noqa: PLW1641
             key = key[:-1]
             self.append = True
 
-        self.namespace, _, self.key = key.rpartition(".")
+        parts = self._split_on_unescaped_dot(key)
+        self._namespace_parts = parts[:-1]
+        self.namespace = ".".join(self._namespace_parts)
+        self.key = parts[-1]
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}('{self}')"
 
     def __str__(self) -> str:
-        return f"{self.namespace}{'.' if self.namespace else ''}{self.key}={self.value}"
+        escaped_ns = ".".join(part.replace(".", "\\.") for part in self._namespace_parts)
+        return f"{escaped_ns}{'.' if escaped_ns else ''}{self.key}{'+' if self.append else ''}={self.value}"
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Override):
@@ -53,6 +57,25 @@ class Override:  # noqa: PLW1641
 
     def __ne__(self, other: object) -> bool:
         return not (self == other)
+
+    @staticmethod
+    def _split_on_unescaped_dot(value: str) -> list[str]:
+        parts: list[str] = []
+        current: list[str] = []
+        pos = 0
+        while pos < len(value):
+            if value[pos] == "\\" and pos + 1 < len(value) and value[pos + 1] == ".":
+                current.append(".")
+                pos += 2
+            elif value[pos] == ".":
+                parts.append("".join(current))
+                current = []
+                pos += 1
+            else:
+                current.append(value[pos])
+                pos += 1
+        parts.append("".join(current))
+        return parts
 
 
 class ConfigLoadArgs:

--- a/tests/config/cli/test_cli_ini.py
+++ b/tests/config/cli/test_cli_ini.py
@@ -67,7 +67,7 @@ def default_options() -> dict[str, Any]:
 
 
 @pytest.mark.parametrize("content", ["[tox]", ""])
-def test_ini_empty(  # noqa: PLR0913
+def test_ini_empty(
     tmp_path: Path,
     core_handlers: dict[str, Callable[[State], int]],
     default_options: dict[str, Any],

--- a/tests/config/cli/test_parser.py
+++ b/tests/config/cli/test_parser.py
@@ -37,7 +37,7 @@ def test_parser_const_with_default_none(monkeypatch: MonkeyPatch) -> None:
 @pytest.mark.parametrize("tox_color", [None, "bad", "no", "yes"])
 @pytest.mark.parametrize("tty_compatible", [None, "", "0", "1", "other"])
 @pytest.mark.parametrize("term", [None, "xterm", "dumb"])
-def test_parser_color(  # noqa: PLR0913
+def test_parser_color(
     monkeypatch: MonkeyPatch,
     mocker: MockerFixture,
     no_color: str | None,

--- a/tests/config/loader/test_loader.py
+++ b/tests/config/loader/test_loader.py
@@ -62,3 +62,26 @@ def test_override_not_equals_different_type() -> None:
 
 def test_override_repr() -> None:
     assert repr(Override("b.a=c")) == "Override('b.a=c')"
+
+
+@pytest.mark.parametrize(
+    ("raw", "namespace", "key", "value", "append", "expected_str"),
+    [
+        pytest.param("env.3\\.14.deps=foo", "env.3.14", "deps", "foo", False, "env.3\\.14.deps=foo", id="escaped_dot"),
+        pytest.param("a\\.b\\.c.key=val", "a.b.c", "key", "val", False, "a\\.b\\.c.key=val", id="multiple_escaped"),
+        pytest.param(
+            "env.3\\.14.deps+=bar", "env.3.14", "deps", "bar", True, "env.3\\.14.deps+=bar", id="escaped_append"
+        ),
+        pytest.param("testenv.deps=foo", "testenv", "deps", "foo", False, "testenv.deps=foo", id="no_escape_compat"),
+        pytest.param(
+            "test\\env.key=val", "test\\env", "key", "val", False, "test\\env.key=val", id="backslash_not_before_dot"
+        ),
+    ],
+)
+def test_override_escaped_dot(raw: str, namespace: str, key: str, value: str, append: bool, expected_str: str) -> None:
+    override = Override(raw)
+    assert override.namespace == namespace
+    assert override.key == key
+    assert override.value == value
+    assert override.append is append
+    assert str(override) == expected_str

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -553,7 +553,7 @@ def test_config_in_toml_replace_glob_extend(tox_project: ToxProjectCreator, tmp_
         pytest.param({"CI": "1"}, "not env.CI", "local", "ci", "ci", id="not_false"),
     ],
 )
-def test_config_in_toml_replace_if(  # noqa: PLR0913
+def test_config_in_toml_replace_if(
     tox_project: ToxProjectCreator,
     monkeypatch: pytest.MonkeyPatch,
     env_vars: dict[str, str],

--- a/tests/config/test_main.py
+++ b/tests/config/test_main.py
@@ -276,6 +276,16 @@ package_glob = "{env_tmp_dir}/dist/*.whl"
         assert "{env_tmp_dir}" not in cmd_str, f"env_tmp_dir not expanded in command: {cmd}"
 
 
+def test_config_override_escaped_dot_namespace(tox_ini_conf: ToxIniCreator) -> None:
+    example = """
+    [testenv:3.14]
+    deps = original
+    """
+    conf = tox_ini_conf(example, override=[Override("testenv:3\\.14.deps=replaced")]).get_env("3.14")
+    conf.add_config("deps", of_type=str, default="", desc="desc")
+    assert conf["deps"] == "replaced"
+
+
 def test_relative_config_paths_resolve(tox_project: ToxProjectCreator) -> None:
     project = tox_project({"tox.ini": "[tox]"})
     ini = str(Path(project.path.name) / "tox.ini")

--- a/tests/execute/local_subprocess/test_local_subprocess.py
+++ b/tests/execute/local_subprocess/test_local_subprocess.py
@@ -63,7 +63,7 @@ def _create_mock_env() -> MagicMock:
     ["RED", "YELLOW", "RESET"],
     ids=["stderr_color_default", "stderr_color_yellow", "stderr_color_reset"],
 )
-def test_local_execute_basic_pass(  # noqa: PLR0913
+def test_local_execute_basic_pass(
     caplog: LogCaptureFixture,
     os_env: dict[str, str],
     out: str,

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -522,7 +522,7 @@ commands = [["python", "-c", "print('ok')"]]
         ("cpython", 3, 12, 64, None, "macosx-14.0-arm64", "arm64"),
     ],
 )
-def test_python_spec_for_sys_executable(  # noqa: PLR0913
+def test_python_spec_for_sys_executable(
     impl: str,
     major: int,
     minor: int,
@@ -602,7 +602,7 @@ _PY_VER_NODOT = f"{sys.version_info[0]}{sys.version_info[1]}"
         ),
     ],
 )
-def test_base_python_file(  # noqa: PLR0913
+def test_base_python_file(
     tox_project: ToxProjectCreator,
     config_file: str,
     config: str,

--- a/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
@@ -231,7 +231,7 @@ def test_pyproject_invalid_extra_no_optional_deps(tox_project: ToxProjectCreator
         ),
     ],
 )
-def test_pyproject_deps_static_with_dynamic(  # noqa: PLR0913
+def test_pyproject_deps_static_with_dynamic(
     tox_project: ToxProjectCreator,
     demo_pkg_inline: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
The `-x`/`--override` flag uses `.` to separate namespace components from the config key, e.g. `-x testenv.deps=foo`. Environment names like `py3.14` contain literal dots, making it impossible to target them with overrides since `rpartition(".")` splits on the wrong dot.

This adds backslash escaping so `\.` in the override key is treated as a literal dot. For example, `-x 'env.3\.14.deps=foo'` correctly resolves to namespace `env.3.14` with key `deps`. ✨ Unescaped dots continue to work as separators, preserving full backward compatibility. A backslash not followed by `.` passes through unchanged.

The `Override.__str__` method re-escapes dots within namespace parts, so round-tripping through `str(Override(...))` reproduces the original escaped form.