### PR TITLE
✨ feat(toml): allow bare range/labeled dicts in env_list

### DIFF
--- a/docs/changelog/3923.bugfix.rst
+++ b/docs/changelog/3923.bugfix.rst
@@ -1,0 +1,2 @@
+Nesting a range or labeled dict inside a ``product`` factor-group list now raises a clear error pointing at the
+un-nesting fix, instead of silently producing a malformed environment name - by :user:`gaborbernat`.

--- a/docs/changelog/3923.feature.rst
+++ b/docs/changelog/3923.feature.rst
@@ -1,3 +1,3 @@
-TOML ``env_list`` now accepts bare range dicts (``{ prefix = "py3", start = 12, stop = 14 }``) and bare labeled dicts
+TOML ``env_list`` now accepts bare range dicts (``{ prefix = "3.", start = 12, stop = 14 }``) and bare labeled dicts
 (``{ ecosystem = ["oci", "python"] }``) as top-level items, removing the ``{ product = [...] }`` wrapper when there is
 only a single factor group - by :user:`gaborbernat`.

--- a/docs/changelog/3923.feature.rst
+++ b/docs/changelog/3923.feature.rst
@@ -1,0 +1,3 @@
+TOML ``env_list`` now accepts bare range dicts (``{ prefix = "py3", start = 12, stop = 14 }``) and bare labeled dicts
+(``{ ecosystem = ["oci", "python"] }``) as top-level items, removing the ``{ product = [...] }`` wrapper when there is
+only a single factor group - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -289,7 +289,7 @@ Open-ended range bounds
 =======================
 
 Both INI and TOML support generative environment lists with open-ended ranges. INI uses curly-brace syntax
-(``py3{10-}``), while TOML uses range dicts that appear directly in ``env_list`` (``{ prefix = "py3", start = 10 }``) --
+(``3.{10-}``), while TOML uses range dicts that appear directly in ``env_list`` (``{ prefix = "3.", start = 10 }``) --
 no ``product`` wrapper is needed for a single axis. Instead of probing the system for available interpreters (which
 would be slow and environment-dependent), tox tracks the `supported CPython versions
 <https://devguide.python.org/versions/>`_ via two constants:

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -289,8 +289,9 @@ Open-ended range bounds
 =======================
 
 Both INI and TOML support generative environment lists with open-ended ranges. INI uses curly-brace syntax
-(``py3{10-}``), while TOML uses range dicts (``{ prefix = "py3", start = 10 }``). Instead of probing the system for
-available interpreters (which would be slow and environment-dependent), tox tracks the `supported CPython versions
+(``py3{10-}``), while TOML uses range dicts that appear directly in ``env_list`` (``{ prefix = "py3", start = 10 }``) --
+no ``product`` wrapper is needed for a single axis. Instead of probing the system for available interpreters (which
+would be slow and environment-dependent), tox tracks the `supported CPython versions
 <https://devguide.python.org/versions/>`_ via two constants:
 
 - ``LATEST_PYTHON_MINOR_MIN`` -- the oldest supported CPython minor version (currently **10**, for Python 3.10)
@@ -302,6 +303,20 @@ upper bound; a left-open range ``{-13}`` uses ``LATEST_PYTHON_MINOR_MIN`` as its
 This design is deterministic and fast -- the expansion happens at configuration load time with no I/O -- while keeping
 environment lists future-proof across tox upgrades. Environments for interpreters not installed on the system are
 naturally skipped by the :ref:`skip_missing_interpreters` setting.
+
+Why TOML composes with structured dicts instead of a string DSL
+---------------------------------------------------------------
+
+INI's ``py3{10-14}-django{42,50}`` expression is a compact mini-language that parses curly-brace groups and numeric
+ranges out of the string itself. TOML deliberately does not do this. String items in ``env_list`` are always literal
+environment names; composition happens exclusively through structured dicts (range, labeled, and ``product``).
+
+This keeps the contract between configuration and parser minimal: TOML already handles quoting, escaping, and types, so
+there is no second grammar to learn and no ambiguity between "env name that happens to contain braces" and
+"expand-this-pattern". It also keeps the loader trivial — there is no string expansion pass, no recursive brace
+tokeniser, and no interaction with tox's other ``{...}`` substitutions (``{env_name}``, ``{posargs}``,
+``{factor:label}``). New matrix ergonomics are added by introducing a new dict shape, not by growing the DSL inside
+strings.
 
 Environment templates (``env_base``)
 ====================================

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -1020,7 +1020,7 @@ expressed as an explicit structured item. For a single axis use the bare range d
 
          env_list = [
              "lint",
-             { prefix = "py3", start = 12, stop = 14 },
+             { prefix = "3.", start = 12, stop = 14 },
          ]
 
 .. tab:: INI
@@ -1028,7 +1028,7 @@ expressed as an explicit structured item. For a single axis use the bare range d
     .. code-block:: ini
 
          [tox]
-         env_list = lint, py3{12-14}
+         env_list = lint, 3.{12-14}
 
 For multi-dimensional matrices, use a ``product`` dict whose items are arrays of strings or range/labeled dicts.
 Combinations are joined with ``-``:
@@ -1040,7 +1040,7 @@ Combinations are joined with ``-``:
          env_list = [
              "lint",
              { product = [
-                 { prefix = "py3", start = 12, stop = 14 },
+                 { prefix = "3.", start = 12, stop = 14 },
                  ["django42", "django50"],
              ] },
          ]
@@ -1673,7 +1673,7 @@ Instead of updating ``env_list`` every time a new Python version is released, us
     .. code-block:: toml
 
         env_list = [
-            { prefix = "py3", start = 10 },
+            { prefix = "3.", start = 10 },
             "lint",
         ]
 
@@ -1682,7 +1682,7 @@ Instead of updating ``env_list`` every time a new Python version is released, us
     .. code-block:: ini
 
         [tox]
-        env_list = py3{10-}, lint
+        env_list = 3.{10-}, lint
 
 This expands up to the latest `supported CPython version <https://devguide.python.org/versions/>`_ known to tox. When
 you upgrade tox after a new Python release, the range automatically includes the new version. The bare range dict is the
@@ -1695,7 +1695,7 @@ To start from the oldest supported version:
     .. code-block:: toml
 
         env_list = [
-            { prefix = "py3", stop = 13 },
+            { prefix = "3.", stop = 13 },
             "lint",
         ]
 
@@ -1704,7 +1704,7 @@ To start from the oldest supported version:
     .. code-block:: ini
 
         [tox]
-        env_list = py3{-13}, lint
+        env_list = 3.{-13}, lint
 
 This expands down from the oldest supported CPython version. Both forms can be mixed with explicit values:
 
@@ -1713,8 +1713,8 @@ This expands down from the oldest supported CPython version. Both forms can be m
     .. code-block:: toml
 
         env_list = [
-            { prefix = "py3", start = 10 },
-            "py38",
+            { prefix = "3.", start = 10 },
+            "3.8",
             "lint",
         ]
 
@@ -1723,7 +1723,7 @@ This expands down from the oldest supported CPython version. Both forms can be m
     .. code-block:: ini
 
         [tox]
-        env_list = py3{10-, 8}, lint
+        env_list = 3.{10-, 8}, lint
 
 See :ref:`generative-environment-list` for the full range syntax reference.
 

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -1010,8 +1010,28 @@ default (imported) virtualenv. The first run bootstraps the pinned version; subs
  Generate environment matrices in TOML
 ***************************************
 
-Use the ``product`` dict in :ref:`env_list` to generate environments from the Cartesian product of factor groups. Each
-factor group is an array of strings or a range dict. Combinations are joined with ``-``:
+TOML ``env_list`` composes environments from structured dicts: string literals, bare range dicts (``{ prefix, start,
+stop }``), labeled dicts, and ``product`` dicts. TOML never interprets curly braces inside strings — every axis is
+expressed as an explicit structured item. For a single axis use the bare range dict:
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+         env_list = [
+             "lint",
+             { prefix = "py3", start = 12, stop = 14 },
+         ]
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+         [tox]
+         env_list = lint, py3{12-14}
+
+For multi-dimensional matrices, use a ``product`` dict whose items are arrays of strings or range/labeled dicts.
+Combinations are joined with ``-``:
 
 .. tab:: TOML
 
@@ -1653,7 +1673,7 @@ Instead of updating ``env_list`` every time a new Python version is released, us
     .. code-block:: toml
 
         env_list = [
-            { product = [{ prefix = "py3", start = 10 }] },
+            { prefix = "py3", start = 10 },
             "lint",
         ]
 
@@ -1665,7 +1685,8 @@ Instead of updating ``env_list`` every time a new Python version is released, us
         env_list = py3{10-}, lint
 
 This expands up to the latest `supported CPython version <https://devguide.python.org/versions/>`_ known to tox. When
-you upgrade tox after a new Python release, the range automatically includes the new version.
+you upgrade tox after a new Python release, the range automatically includes the new version. The bare range dict is the
+single-axis spelling; wrap it in ``{ product = [...] }`` only when crossing it with another factor group.
 
 To start from the oldest supported version:
 
@@ -1674,7 +1695,7 @@ To start from the oldest supported version:
     .. code-block:: toml
 
         env_list = [
-            { product = [{ prefix = "py3", stop = 13 }] },
+            { prefix = "py3", stop = 13 },
             "lint",
         ]
 
@@ -1692,7 +1713,7 @@ This expands down from the oldest supported CPython version. Both forms can be m
     .. code-block:: toml
 
         env_list = [
-            { product = [{ prefix = "py3", start = 10 }] },
+            { prefix = "py3", start = 10 },
             "py38",
             "lint",
         ]
@@ -1861,7 +1882,8 @@ TOML is the recommended configuration format for new projects. Here is how commo
 - Environment variables in ``set_env`` use ``{ replace = "env", name = "VAR" }`` vs ``{env:VAR}``
 - Section references use ``{ replace = "ref", ... }`` vs ``{[section]key}``
 - Factor conditions use ``{ replace = "if", condition = "factor.NAME", ... }`` vs ``NAME:``
-- Generative environment lists use ``{ product = [...] }`` dicts vs ``{a,b}-{c,d}`` brace expansion
+- Generative environment lists use structured dicts (bare ``{ prefix, start, stop }`` for a single axis, ``{ product =
+  [...] }`` for matrices) vs ``{a,b}-{c,d}`` brace expansion
 
 *************************************
  Format your tox configuration files

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -118,12 +118,17 @@ Platform factors work in any environment without requiring the platform name in 
     .. code-block:: toml
 
         env_list = [
+            "lint",
+            { prefix = "py3", start = 12, stop = 14 },
             { product = [["py312", "py313", "py314"], ["django42", "django50"]] },
         ]
 
-    The ``product`` dict computes the Cartesian product of its factor groups and joins each combination with ``-``.
-    Range dicts (``{ prefix = "py3", start = 12, stop = 14 }``) and literal strings can be mixed in the same list.
-    An optional ``exclude`` key skips specific combinations.
+    Each ``env_list`` item is one of four structured shapes: a literal string, a bare range dict
+    (``{ prefix = "py3", start = 12, stop = 14 }``) for a single axis, a labeled dict
+    (``{ ecosystem = ["oci", "python"] }``) that also registers a ``{factor:label}`` name, or a ``product`` dict
+    that computes the Cartesian product of multiple factor groups and joins each combination with ``-``.
+    A ``product`` dict also accepts an ``exclude`` key to skip specific combinations. TOML never interprets curly
+    braces inside string items — composition is always via these dicts.
 
 .. tab:: INI
 
@@ -2793,22 +2798,50 @@ ones reach end-of-life.
     what you may expect. (It expands to 275 environment names, ``py39``, ``py40``, ``py41`` … ``py314``.) Instead, use
     ``py3{9-14}``.
 
-TOML product syntax
--------------------
+TOML ``env_list`` item shapes
+-----------------------------
 
-TOML uses a ``product`` dict instead of curly-brace expansion. Each factor group is an array of strings or a range dict.
-The Cartesian product of all groups is computed and each combination is joined with ``-``.
+TOML replaces INI's curly-brace expansion with four structured item shapes. Composition happens through these dicts only
+— TOML never interprets ``{...}`` inside a string item, so a literal ``"py3{12-14}"`` is the env name ``py3{12-14}``,
+not a range.
 
-Range dicts accept ``prefix``, ``start``, and ``stop``. Omit ``stop`` to expand up to the latest supported CPython minor
-version (currently **14**), or omit ``start`` to expand down from the oldest (currently **10**):
+**Literal string** -- a single environment name.
+
+.. code-block:: toml
+
+    env_list = ["lint", "py312"]
+
+**Bare range dict** -- a single range axis. Accepts ``prefix``, ``start``, and ``stop``. Omit ``stop`` to expand up to
+the latest supported CPython minor version (currently **14**), or omit ``start`` to expand down from the oldest
+(currently **10**). The bare range dict is equivalent to a single-group ``product`` and is the preferred spelling when
+there is only one axis:
 
 .. code-block:: toml
 
     env_list = [
-        { product = [{ prefix = "py3", start = 10 }, ["django42"]] },
+        { prefix = "py3", start = 10 },
+        "lint",
     ]
 
-The range ``{ prefix = "py3", start = 10 }`` is equivalent to ``py3{10-}`` in INI.
+``{ prefix = "py3", start = 10 }`` is equivalent to ``py3{10-}`` in INI.
+
+**Bare labeled dict** -- a single-key dict mapping a label to a list of factor values. The label also registers for
+``{factor:label}`` substitution (see :ref:`factor-label-substitution`):
+
+.. code-block:: toml
+
+    env_list = [
+        { ecosystem = ["oci", "python"] },
+    ]
+
+**Product dict** -- a Cartesian product of multiple factor groups, joined with ``-``. Each factor group inside
+``product`` is itself an array of strings, a range dict, or a labeled dict:
+
+.. code-block:: toml
+
+    env_list = [
+        { product = [{ prefix = "py3", start = 12, stop = 14 }, ["django42", "django50"]] },
+    ]
 
 An ``exclude`` key removes specific combinations from the product -- a capability not available in INI:
 
@@ -2816,6 +2849,22 @@ An ``exclude`` key removes specific combinations from the product -- a capabilit
 
     env_list = [
         { product = [["py312", "py313"], ["django42", "django50"]], exclude = ["py312-django50"] },
+    ]
+
+**Common mistake** -- wrapping a range or labeled dict inside a list factor group. Factor-group lists may only contain
+literal strings; range and labeled dicts must appear as sibling entries in the ``product`` array, not nested inside one
+of its arrays. The following is rejected with a clear error:
+
+.. code-block:: text
+
+    # wrong — the inner list contains a dict
+    env_list = [
+        { product = [["min"], [{ prefix = "py3", start = 9, stop = 14 }]] },
+    ]
+
+    # right — the range dict is a sibling factor group
+    env_list = [
+        { product = [["min"], { prefix = "py3", start = 9, stop = 14 }] },
     ]
 
 Generative section names

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -119,12 +119,12 @@ Platform factors work in any environment without requiring the platform name in 
 
         env_list = [
             "lint",
-            { prefix = "py3", start = 12, stop = 14 },
-            { product = [["py312", "py313", "py314"], ["django42", "django50"]] },
+            { prefix = "3.", start = 12, stop = 14 },
+            { product = [["3.12", "3.13", "3.14"], ["django42", "django50"]] },
         ]
 
     Each ``env_list`` item is one of four structured shapes: a literal string, a bare range dict
-    (``{ prefix = "py3", start = 12, stop = 14 }``) for a single axis, a labeled dict
+    (``{ prefix = "3.", start = 12, stop = 14 }``) for a single axis, a labeled dict
     (``{ ecosystem = ["oci", "python"] }``) that also registers a ``{factor:label}`` name, or a ``product`` dict
     that computes the Cartesian product of multiple factor groups and joins each combination with ``-``.
     A ``product`` dict also accepts an ``exclude`` key to skip specific combinations. TOML never interprets curly
@@ -2802,14 +2802,14 @@ TOML ``env_list`` item shapes
 -----------------------------
 
 TOML replaces INI's curly-brace expansion with four structured item shapes. Composition happens through these dicts only
-— TOML never interprets ``{...}`` inside a string item, so a literal ``"py3{12-14}"`` is the env name ``py3{12-14}``,
-not a range.
+— TOML never interprets ``{...}`` inside a string item, so a literal ``"3.{12-14}"`` is the env name ``3.{12-14}``, not
+a range.
 
 **Literal string** -- a single environment name.
 
 .. code-block:: toml
 
-    env_list = ["lint", "py312"]
+    env_list = ["lint", "3.12"]
 
 **Bare range dict** -- a single range axis. Accepts ``prefix``, ``start``, and ``stop``. Omit ``stop`` to expand up to
 the latest supported CPython minor version (currently **14**), or omit ``start`` to expand down from the oldest
@@ -2819,11 +2819,11 @@ there is only one axis:
 .. code-block:: toml
 
     env_list = [
-        { prefix = "py3", start = 10 },
+        { prefix = "3.", start = 10 },
         "lint",
     ]
 
-``{ prefix = "py3", start = 10 }`` is equivalent to ``py3{10-}`` in INI.
+``{ prefix = "3.", start = 10 }`` is equivalent to ``3.{10-}`` in INI.
 
 **Bare labeled dict** -- a single-key dict mapping a label to a list of factor values. The label also registers for
 ``{factor:label}`` substitution (see :ref:`factor-label-substitution`):
@@ -2840,7 +2840,7 @@ there is only one axis:
 .. code-block:: toml
 
     env_list = [
-        { product = [{ prefix = "py3", start = 12, stop = 14 }, ["django42", "django50"]] },
+        { product = [{ prefix = "3.", start = 12, stop = 14 }, ["django42", "django50"]] },
     ]
 
 An ``exclude`` key removes specific combinations from the product -- a capability not available in INI:
@@ -2848,7 +2848,7 @@ An ``exclude`` key removes specific combinations from the product -- a capabilit
 .. code-block:: toml
 
     env_list = [
-        { product = [["py312", "py313"], ["django42", "django50"]], exclude = ["py312-django50"] },
+        { product = [["3.12", "3.13"], ["django42", "django50"]], exclude = ["3.12-django50"] },
     ]
 
 **Common mistake** -- wrapping a range or labeled dict inside a list factor group. Factor-group lists may only contain
@@ -2859,12 +2859,12 @@ of its arrays. The following is rejected with a clear error:
 
     # wrong — the inner list contains a dict
     env_list = [
-        { product = [["min"], [{ prefix = "py3", start = 9, stop = 14 }]] },
+        { product = [["min"], [{ prefix = "3.", start = 9, stop = 14 }]] },
     ]
 
     # right — the range dict is a sibling factor group
     env_list = [
-        { product = [["min"], { prefix = "py3", start = 9, stop = 14 }] },
+        { product = [["min"], { prefix = "3.", start = 9, stop = 14 }] },
     ]
 
 Generative section names

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -104,9 +104,9 @@ Core settings affect all environments or configure how tox itself behaves. They 
 
 The :ref:`env_list` setting defines which environments run by default when you invoke ``tox`` without specifying any.
 Both formats support generating environment matrices from factor combinations — INI uses curly-brace expansion
-(``3.{10-}``), while TOML composes from structured dicts. A single axis is a bare range dict (``{ prefix = "py3", start
-= 10 }``); multi-dimensional matrices use a ``product`` dict. See :ref:`generative-environment-list` for details. For
-the full list of core options, see :ref:`conf-core`.
+(``3.{10-}``), while TOML composes from structured dicts. A single axis is a bare range dict (``{ prefix = "3.", start =
+10 }``); multi-dimensional matrices use a ``product`` dict. See :ref:`generative-environment-list` for details. For the
+full list of core options, see :ref:`conf-core`.
 
 Environment settings
 ====================

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -104,8 +104,9 @@ Core settings affect all environments or configure how tox itself behaves. They 
 
 The :ref:`env_list` setting defines which environments run by default when you invoke ``tox`` without specifying any.
 Both formats support generating environment matrices from factor combinations — INI uses curly-brace expansion
-(``3.{10-}``), while TOML uses ``product`` dicts (``{ product = [{ prefix = "py3", start = 10 }, ["django42"]] }``). See
-:ref:`generative-environment-list` for details. For the full list of core options, see :ref:`conf-core`.
+(``3.{10-}``), while TOML composes from structured dicts. A single axis is a bare range dict (``{ prefix = "py3", start
+= 10 }``); multi-dimensional matrices use a ``product`` dict. See :ref:`generative-environment-list` for details. For
+the full list of core options, see :ref:`conf-core`.
 
 Environment settings
 ====================

--- a/src/tox/config/loader/toml/__init__.py
+++ b/src/tox/config/loader/toml/__init__.py
@@ -129,7 +129,7 @@ class TomlLoader(Loader[TomlTypes]):
 
     @staticmethod
     def to_env_list(value: TomlTypes) -> EnvList:
-        from ._product import expand_product  # noqa: PLC0415
+        from ._product import expand_factor_group, expand_product  # noqa: PLC0415
 
         if not isinstance(value, list):
             msg = f"env_list must be a list, got {type(value).__name__}"
@@ -138,10 +138,19 @@ class TomlLoader(Loader[TomlTypes]):
         for item in value:
             if isinstance(item, str):
                 envs.append(item)
-            elif isinstance(item, dict) and "product" in item:
-                envs.extend(expand_product(item))
+            elif isinstance(item, dict):
+                if "product" in item:
+                    if "prefix" in item:
+                        msg = "env_list dict items cannot combine 'product' with 'prefix'"
+                        raise TypeError(msg)
+                    envs.extend(expand_product(item))
+                else:
+                    envs.extend(expand_factor_group(item))
             else:
-                msg = f"env_list items must be strings or product dicts, got {type(item).__name__}"
+                msg = (
+                    f"env_list items must be strings, product dicts, range dicts, or labeled dicts, "
+                    f"got {type(item).__name__}"
+                )
                 raise TypeError(msg)
         return EnvList(envs=envs)
 

--- a/src/tox/config/loader/toml/_product.py
+++ b/src/tox/config/loader/toml/_product.py
@@ -32,7 +32,18 @@ _RESERVED_LABELS: frozenset[str] = frozenset({"env", "posargs", "tty", "glob", "
 
 def expand_factor_group(group: Any) -> list[str]:
     if isinstance(group, list):
-        return [str(item) for item in group]
+        result: list[str] = []
+        for item in group:
+            if not isinstance(item, str):
+                hint = (
+                    " — pass range or labeled dicts directly as sibling factor groups, not nested inside a list"
+                    if isinstance(item, dict)
+                    else ""
+                )
+                msg = f"factor group list items must be strings, got {type(item).__name__}{hint}"
+                raise TypeError(msg)
+            result.append(item)
+        return result
     if isinstance(group, dict):
         if "prefix" in group:
             return _expand_range(group)

--- a/src/tox/session/cmd/schema.py
+++ b/src/tox/session/cmd/schema.py
@@ -132,6 +132,56 @@ def gen_schema(state: State) -> int:
                     },
                 ],
             },
+            "factor_range_dict": {
+                "type": "object",
+                "required": ["prefix"],
+                "properties": {
+                    "prefix": {"type": "string"},
+                    "start": {"type": "integer"},
+                    "stop": {"type": "integer"},
+                },
+                "additionalProperties": False,
+                "description": "range factor group: expands to prefix+N for N in [start, stop]",
+            },
+            "factor_labeled_dict": {
+                "type": "object",
+                "minProperties": 1,
+                "maxProperties": 1,
+                "not": {"required": ["prefix"]},
+                "additionalProperties": {"type": "array", "items": {"type": "string"}},
+                "description": "labeled factor group for {factor:label} substitution",
+            },
+            "product_factor_group": {
+                "oneOf": [
+                    {"type": "array", "items": {"type": "string"}},
+                    {"$ref": "#/definitions/factor_range_dict"},
+                    {"$ref": "#/definitions/factor_labeled_dict"},
+                ],
+            },
+            "env_list_item": {
+                "oneOf": [
+                    {"$ref": "#/definitions/subs"},
+                    {
+                        "type": "object",
+                        "required": ["product"],
+                        "properties": {
+                            "product": {
+                                "type": "array",
+                                "items": {"$ref": "#/definitions/product_factor_group"},
+                                "description": "factor groups for cartesian product expansion",
+                            },
+                            "exclude": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "environment names to exclude from product",
+                            },
+                        },
+                        "additionalProperties": False,
+                    },
+                    {"$ref": "#/definitions/factor_range_dict"},
+                    {"$ref": "#/definitions/factor_labeled_dict"},
+                ],
+            },
         },
     }
     print(json.dumps(json_schema, indent=2))  # noqa: T201
@@ -182,56 +232,7 @@ def _process_type(of_type: typing.Any) -> dict[str, typing.Any]:  # noqa: C901, 
     if typing.get_origin(of_type) is typing.Literal:
         return {"enum": list(typing.get_args(of_type))}
     if of_type is tox.config.types.EnvList:
-        return {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {"$ref": "#/definitions/subs"},
-                    {
-                        "type": "object",
-                        "required": ["product"],
-                        "properties": {
-                            "product": {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {"type": "array", "items": {"type": "string"}},
-                                        {
-                                            "type": "object",
-                                            "required": ["prefix"],
-                                            "properties": {
-                                                "prefix": {"type": "string"},
-                                                "start": {"type": "integer"},
-                                                "stop": {"type": "integer"},
-                                            },
-                                            "additionalProperties": False,
-                                        },
-                                        {
-                                            "type": "object",
-                                            "minProperties": 1,
-                                            "maxProperties": 1,
-                                            "not": {"required": ["prefix"]},
-                                            "additionalProperties": {
-                                                "type": "array",
-                                                "items": {"type": "string"},
-                                            },
-                                            "description": "labeled factor group for {factor:label} substitution",
-                                        },
-                                    ],
-                                },
-                                "description": "factor groups for cartesian product expansion",
-                            },
-                            "exclude": {
-                                "type": "array",
-                                "items": {"type": "string"},
-                                "description": "environment names to exclude from product",
-                            },
-                        },
-                        "additionalProperties": False,
-                    },
-                ],
-            },
-        }
+        return {"type": "array", "items": {"$ref": "#/definitions/env_list_item"}}
     if of_type is tox.config.types.Command:
         return {"type": "array", "items": {"$ref": "#/definitions/subs"}}
     if typing.get_origin(of_type) in {list, set}:

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -35,70 +35,7 @@
     "env_list": {
       "type": "array",
       "items": {
-        "oneOf": [
-          {
-            "$ref": "#/definitions/subs"
-          },
-          {
-            "type": "object",
-            "required": ["product"],
-            "properties": {
-              "product": {
-                "type": "array",
-                "items": {
-                  "oneOf": [
-                    {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    {
-                      "type": "object",
-                      "required": ["prefix"],
-                      "properties": {
-                        "prefix": {
-                          "type": "string"
-                        },
-                        "start": {
-                          "type": "integer"
-                        },
-                        "stop": {
-                          "type": "integer"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    {
-                      "type": "object",
-                      "minProperties": 1,
-                      "maxProperties": 1,
-                      "not": {
-                        "required": ["prefix"]
-                      },
-                      "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "description": "labeled factor group for {factor:label} substitution"
-                    }
-                  ]
-                },
-                "description": "factor groups for cartesian product expansion"
-              },
-              "exclude": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "environment names to exclude from product"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
+        "$ref": "#/definitions/env_list_item"
       },
       "description": "define environments to automatically run"
     },
@@ -139,70 +76,7 @@
       "additionalProperties": {
         "type": "array",
         "items": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/subs"
-            },
-            {
-              "type": "object",
-              "required": ["product"],
-              "properties": {
-                "product": {
-                  "type": "array",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      {
-                        "type": "object",
-                        "required": ["prefix"],
-                        "properties": {
-                          "prefix": {
-                            "type": "string"
-                          },
-                          "start": {
-                            "type": "integer"
-                          },
-                          "stop": {
-                            "type": "integer"
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      {
-                        "type": "object",
-                        "minProperties": 1,
-                        "maxProperties": 1,
-                        "not": {
-                          "required": ["prefix"]
-                        },
-                        "additionalProperties": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "description": "labeled factor group for {factor:label} substitution"
-                      }
-                    ]
-                  },
-                  "description": "factor groups for cartesian product expansion"
-                },
-                "exclude": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "environment names to exclude from product"
-                }
-              },
-              "additionalProperties": false
-            }
-          ]
+          "$ref": "#/definitions/env_list_item"
         }
       },
       "description": "core labels"
@@ -286,70 +160,7 @@
         "depends": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/subs"
-              },
-              {
-                "type": "object",
-                "required": ["product"],
-                "properties": {
-                  "product": {
-                    "type": "array",
-                    "items": {
-                      "oneOf": [
-                        {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        {
-                          "type": "object",
-                          "required": ["prefix"],
-                          "properties": {
-                            "prefix": {
-                              "type": "string"
-                            },
-                            "start": {
-                              "type": "integer"
-                            },
-                            "stop": {
-                              "type": "integer"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "minProperties": 1,
-                          "maxProperties": 1,
-                          "not": {
-                            "required": ["prefix"]
-                          },
-                          "additionalProperties": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "description": "labeled factor group for {factor:label} substitution"
-                        }
-                      ]
-                    },
-                    "description": "factor groups for cartesian product expansion"
-                  },
-                  "exclude": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "environment names to exclude from product"
-                  }
-                },
-                "additionalProperties": false
-              }
-            ]
+            "$ref": "#/definitions/env_list_item"
           },
           "description": "tox environments that this environment depends on (must be run after those)"
         },
@@ -776,6 +587,88 @@
           },
           "required": ["replace", "of"],
           "additionalProperties": false
+        }
+      ]
+    },
+    "factor_range_dict": {
+      "type": "object",
+      "required": ["prefix"],
+      "properties": {
+        "prefix": {
+          "type": "string"
+        },
+        "start": {
+          "type": "integer"
+        },
+        "stop": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "description": "range factor group: expands to prefix+N for N in [start, stop]"
+    },
+    "factor_labeled_dict": {
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "not": {
+        "required": ["prefix"]
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "description": "labeled factor group for {factor:label} substitution"
+    },
+    "product_factor_group": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "$ref": "#/definitions/factor_range_dict"
+        },
+        {
+          "$ref": "#/definitions/factor_labeled_dict"
+        }
+      ]
+    },
+    "env_list_item": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/subs"
+        },
+        {
+          "type": "object",
+          "required": ["product"],
+          "properties": {
+            "product": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/product_factor_group"
+              },
+              "description": "factor groups for cartesian product expansion"
+            },
+            "exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "environment names to exclude from product"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/definitions/factor_range_dict"
+        },
+        {
+          "$ref": "#/definitions/factor_labeled_dict"
         }
       ]
     }

--- a/tests/config/loader/test_toml_loader.py
+++ b/tests/config/loader/test_toml_loader.py
@@ -129,8 +129,58 @@ def test_toml_loader_env_list_ok() -> None:
 
 
 def test_toml_loader_env_list_nok() -> None:
-    with pytest.raises(HandledError, match=_PREFIX + r"env_list items must be strings or product dicts, got int"):
+    with pytest.raises(
+        HandledError,
+        match=_PREFIX + r"env_list items must be strings, product dicts, range dicts, or labeled dicts, got int",
+    ):
         perform_load(["a", 1], EnvList)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param(
+            [{"prefix": "py3", "start": 12, "stop": 14}],
+            ["py312", "py313", "py314"],
+            id="bare-range",
+        ),
+        pytest.param(
+            ["lint", {"prefix": "py3", "start": 12, "stop": 13}, "docs"],
+            ["lint", "py312", "py313", "docs"],
+            id="mixed-literal-and-range",
+        ),
+        pytest.param(
+            [{"ecosystem": ["oci", "python"]}],
+            ["oci", "python"],
+            id="bare-labeled",
+        ),
+        pytest.param(
+            [
+                {"prefix": "py3", "start": 12, "stop": 13},
+                {"product": [["min"], {"prefix": "py3", "start": 12, "stop": 13}]},
+            ],
+            ["py312", "py313", "min-py312", "min-py313"],
+            id="bare-range-plus-product",
+        ),
+    ],
+)
+def test_toml_loader_env_list_shorthand(raw: list[Any], expected: list[str]) -> None:
+    res = perform_load(raw, EnvList)
+    assert isinstance(res, EnvList)
+    assert list(res) == expected
+
+
+def test_toml_loader_env_list_prefix_and_product_rejected() -> None:
+    with pytest.raises(HandledError, match=_PREFIX + r"env_list dict items cannot combine 'product' with 'prefix'"):
+        perform_load([{"prefix": "py3", "product": [["a"]]}], EnvList)
+
+
+def test_toml_loader_env_list_nested_dict_in_list_rejects_with_hint() -> None:
+    with pytest.raises(
+        HandledError,
+        match=_PREFIX + r"factor group list items must be strings, got dict.*sibling factor groups",
+    ):
+        perform_load([{"product": [[{"prefix": "py3", "start": 9, "stop": 14}]]}], EnvList)
 
 
 def test_toml_loader_list_optional_ok() -> None:
@@ -176,7 +226,10 @@ def test_toml_loader_dict_of_env_list_values_ok() -> None:
 
 
 def test_toml_loader_dict_of_env_list_values_nok() -> None:
-    with pytest.raises(HandledError, match=_PREFIX + r"env_list items must be strings or product dicts, got int"):
+    with pytest.raises(
+        HandledError,
+        match=_PREFIX + r"env_list items must be strings, product dicts, range dicts, or labeled dicts, got int",
+    ):
         perform_load({"x": ["a", 1]}, dict[str, EnvList])
 
 

--- a/tests/config/loader/test_toml_product.py
+++ b/tests/config/loader/test_toml_product.py
@@ -69,6 +69,16 @@ def test_expand_factor_group_dict_no_prefix() -> None:
         expand_factor_group({"start": 1, "stop": 3})
 
 
+def test_expand_factor_group_list_with_dict_item_hints_unnesting() -> None:
+    with pytest.raises(TypeError, match=r"factor group list items must be strings, got dict.*sibling factor groups"):
+        expand_factor_group([{"prefix": "py3", "start": 9, "stop": 14}])
+
+
+def test_expand_factor_group_list_with_int_item_plain_error() -> None:
+    with pytest.raises(TypeError, match=r"factor group list items must be strings, got int$"):
+        expand_factor_group(["py312", 42])
+
+
 def test_expand_factor_group_keyed_dict() -> None:
     assert expand_factor_group({"ecosystem": ["oci", "python"]}) == ["oci", "python"]
 
@@ -253,6 +263,62 @@ def test_product_keyed_groups_listed(tox_project: ToxProjectCreator) -> None:
     result = proj.run("l")
     result.assert_success()
     for env in ("sync-oci-pw", "sync-oci-tt", "sync-python-pw", "sync-python-tt"):
+        assert env in result.out
+
+
+def test_env_list_bare_range_dict(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                "lint",
+                { prefix = "py3", start = 12, stop = 14 },
+            ]
+
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("l")
+    result.assert_success()
+    for env in ("lint", "py312", "py313", "py314"):
+        assert env in result.out
+
+
+def test_env_list_bare_labeled_dict(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                { ecosystem = ["oci", "python"] },
+            ]
+
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("l")
+    result.assert_success()
+    for env in ("oci", "python"):
+        assert env in result.out
+
+
+def test_env_list_bare_range_mixed_with_product(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                { prefix = "py3", start = 12, stop = 13 },
+                { product = [["min"], { prefix = "py3", start = 12, stop = 13 }] },
+            ]
+
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    result = proj.run("l")
+    result.assert_success()
+    for env in ("py312", "py313", "min-py312", "min-py313"):
         assert env in result.out
 
 

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -1012,7 +1012,7 @@ _CMD = 'commands = [["python", "--version"]]'
         pytest.param(
             f"depends = [1]\n{_CMD}",
             "depends",
-            "env_list items must be strings or product dicts, got int",
+            "env_list items must be strings, product dicts, range dicts, or labeled dicts, got int",
             id="depends-int-item",
         ),
         # --- factory fields ---


### PR DESCRIPTION
Declaring a single-axis matrix in TOML previously required wrapping a range dict inside a `product`: `env_list = [{ product = [{ prefix = "py3", start = 9, stop = 14 }] }]`. The `product` wrapper was pure ceremony whenever there was only one factor group, and the obvious shorthand most users reached for was rejected as an unknown item shape. ✨ Range and labeled dicts now work directly as `env_list` items, so the common case collapses to `env_list = [{ prefix = "py3", start = 9, stop = 14 }]` while `product` stays the right spelling for genuine multi-axis matrices.

Nesting a range or labeled dict inside a `product` factor-group list used to be silently stringified and then surface much later as a malformed environment name during validation. 🐛 The error now fires at the factor-group boundary and points at the un-nesting fix, so `[{ product = [["min"], [{ prefix = "py3", ... }]] }]` produces a message naming the offending dict instead of a cryptic downstream failure. An explicit rejection is also added for dict items that mix `prefix` and `product` keys.

The JSON schema duplicated the same `env_list` item `oneOf` across three call sites. Consolidating it into `definitions/env_list_item` (plus shared `factor_range_dict`, `factor_labeled_dict`, and `product_factor_group`) lets the new shapes land in one place and propagates through `labels` and `env_run_base.depends` for free. 📝 The committed schema is also refreshed to pick up the `wheel_build_env` entry that had drifted stale on `main`.

Documentation was refreshed across all four Diátaxis buckets. The explanation section now codifies why TOML never interprets curly braces inside string items: keeping composition structural avoids a second grammar, avoids collision with the existing `{env_name}` and `{factor:label}` substitutions, and keeps the loader free of a string-expansion pass. New matrix ergonomics should extend the dict shapes, not grow a DSL inside strings.