### PR TITLE
🐛 fix(security): harden user-facing logs and untrusted inputs

### DIFF
--- a/docs/changelog/3924.bugfix.rst
+++ b/docs/changelog/3924.bugfix.rst
@@ -1,0 +1,10 @@
+Hardening pass on user-facing logging and config parsing:
+
+- Mask secret-looking ``--key=value`` flag values in command logs (terminal warnings, ``.tox/<env>/log/*.log``, and
+  ``Outcome`` ``__repr__``) using the same keyword regex previously applied to environment variable values.
+- Resolve PEP 723 ``script`` paths and reject any that escape ``tox_root``; cap the script read at 5 MiB so a symlink to
+  ``/dev/zero`` cannot exhaust memory.
+- Replace ``eval()`` of a constructed ``Literal[...]`` string in the CLI parser with a direct
+  ``Literal[tuple(action.choices)]`` subscript.
+- Pass ``timeout=30`` to ``urlopen`` when fetching a remote requirements file so a slow or unresponsive mirror cannot
+  hang ``tox`` indefinitely.

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -71,10 +71,7 @@ class ArgumentParserWithEnvAndConfig(ArgumentParser):
                 else:
                     of_type = list[action.type]  # ty: ignore[invalid-type-form] # runtime generic from argparse action type
             elif isinstance(action, argparse._StoreAction) and action.choices:  # noqa: SLF001
-                loc = locals()
-                loc["Literal"] = Literal
-                as_literal = f"Literal[{', '.join(repr(i) for i in action.choices)}]"
-                of_type = eval(as_literal, globals(), loc)  # noqa: S307
+                of_type = Literal[tuple(action.choices)]  # ty: ignore[invalid-type-form] # dynamic Literal from choices
             elif action.default is not None:
                 of_type = type(action.default)
             elif isinstance(action, argparse._StoreConstAction) and action.const is not None:  # noqa: SLF001

--- a/src/tox/execute/api.py
+++ b/src/tox/execute/api.py
@@ -268,7 +268,7 @@ class Outcome:
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}: exit {self.exit_code} in {self.elapsed:.2f} seconds"
-            f" for {self.request.shell_cmd}"
+            f" for {self.request.shell_cmd_redacted}"
         )
 
     def assert_success(self) -> None:
@@ -314,7 +314,7 @@ class Outcome:
             self.exit_code,
             self.elapsed,
             req.cwd,
-            req.shell_cmd,
+            req.shell_cmd_redacted,
             metadata,
         )
 

--- a/src/tox/execute/request.py
+++ b/src/tox/execute/request.py
@@ -7,6 +7,8 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from tox.util.redact import redact_argv
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -58,12 +60,21 @@ class ExecuteRequest:
     @property
     def shell_cmd(self) -> str:
         """:returns: the command to run as a shell command"""
+        return self._shell_cmd(redact=False)
+
+    @property
+    def shell_cmd_redacted(self) -> str:
+        """:returns: the command to run as a shell command with secret-looking flag values masked"""
+        return self._shell_cmd(redact=True)
+
+    def _shell_cmd(self, *, redact: bool) -> str:
         try:
             exe = str(Path(self.cmd[0]).relative_to(self.cwd))
         except ValueError:
             exe = self.cmd[0]
-        cmd = [exe]
-        cmd.extend(self.cmd[1:])
+        cmd = [exe, *self.cmd[1:]]
+        if redact:
+            cmd = redact_argv(cmd)
         return shell_cmd(cmd)
 
     def __repr__(self) -> str:

--- a/src/tox/tox_env/api.py
+++ b/src/tox/tox_env/api.py
@@ -17,6 +17,7 @@ from tox.execute.request import ExecuteRequest
 from tox.tox_env.errors import Fail, Recreate, Skip
 from tox.tox_env.info import Info
 from tox.util.path import ensure_cachedir_tag, ensure_empty_dir, ensure_gitignore
+from tox.util.redact import redact_value
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -32,37 +33,6 @@ if TYPE_CHECKING:
     from tox.tox_env.installer import Installer
 
 LOGGER = logging.getLogger(__name__)
-# Based on original gitleaks rule named generic-api-key
-# See: https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml#L587
-SECRET_KEYWORDS = [
-    "access",
-    "api",
-    "auth",
-    "client",
-    "cred",
-    "key",
-    "passwd",
-    "password",
-    "private",
-    "pwd",
-    "secret",
-    "token",
-]
-SECRET_ENV_VAR_REGEX = re.compile(
-    r"""
-    .*                  # any prefix
-    ( {keywords} )      # one of the secret keywords
-    .*                  # any suffix
-    """.format(keywords="|".join(SECRET_KEYWORDS)),
-    re.VERBOSE | re.IGNORECASE,
-)
-
-
-def redact_value(name: str, value: str) -> str:
-    """Returns a redacted text if the key name looks like a secret."""
-    if SECRET_ENV_VAR_REGEX.match(name):
-        return "*" * len(value)
-    return value
 
 
 class ToxEnvCreateArgs(NamedTuple):
@@ -512,7 +482,7 @@ class ToxEnv(ABC):  # noqa: PLR0904
                 repr_cwd = f" {_CWD.relative_to(cwd)}"
             except ValueError:
                 repr_cwd = f" {cwd}"
-        LOGGER.warning("%s%s> %s", run_id, repr_cwd, request.shell_cmd)
+        LOGGER.warning("%s%s> %s", run_id, repr_cwd, request.shell_cmd_redacted)
         out_err = self.log_handler.stdout, self.log_handler.stderr
         if executor is None:
             executor = self.executor
@@ -553,7 +523,7 @@ class ToxEnv(ABC):  # noqa: PLR0904
             file.write(f"cwd: {request.cwd}\n")
             allow = ["*"] if request.allow is None else request.allow
             file.write(f"allow: {':'.join(allow)}\n")
-            file.write(f"cmd: {request.shell_cmd}\n")
+            file.write(f"cmd: {request.shell_cmd_redacted}\n")
             file.write(f"exit_code: {status.exit_code}\n")
         with log_file.open("ab") as file_b:
             if status.out:

--- a/src/tox/tox_env/python/pep723.py
+++ b/src/tox/tox_env/python/pep723.py
@@ -43,6 +43,7 @@ _SCRIPT_METADATA_RE: Final = re.compile(
     """,
     re.VERBOSE,
 )
+_MAX_SCRIPT_BYTES: Final[int] = 5 * 1024 * 1024  # 5 MiB; PEP 723 metadata blocks are tiny in practice
 
 
 @dataclass(frozen=True)
@@ -92,11 +93,8 @@ class Pep723Mixin(Python, RunToxEnv):
         if self._base_python_explicitly_set:
             msg = "cannot set base_python with virtualenv-pep-723 runner; use requires-python in the script"
             raise Fail(msg)
-        if script := self.conf["script"]:
-            tox_root: Path = self.core["tox_root"]
-            if not (tox_root / script).is_file():
-                msg = f"script file not found: {tox_root / script}"
-                raise Fail(msg)
+        if self.conf["script"]:
+            self._resolve_script_path()  # validates containment and existence, raises Fail on issue
         metadata = self._get_script_metadata()
         if metadata.requires_python:
             info = self.base_python
@@ -114,16 +112,38 @@ class Pep723Mixin(Python, RunToxEnv):
 
     def _get_script_metadata(self) -> ScriptMetadata:
         if self._script_metadata is None:
-            if not (script := self.conf["script"]):
+            full_path = self._resolve_script_path()
+            if full_path is None:
                 self._script_metadata = ScriptMetadata()
                 return self._script_metadata
-            tox_root: Path = self.core["tox_root"]
-            full_path = tox_root / script
-            if not full_path.is_file():
-                self._script_metadata = ScriptMetadata()
-                return self._script_metadata
+            if (size := full_path.stat().st_size) > _MAX_SCRIPT_BYTES:
+                msg = f"script file {full_path} is {size} bytes, exceeds the {_MAX_SCRIPT_BYTES} byte limit"
+                raise Fail(msg)
             self._script_metadata = _parse_script_metadata(full_path.read_text(encoding="utf-8"))
         return self._script_metadata
+
+    def _resolve_script_path(self) -> Path | None:
+        """Resolve the configured script path and verify it stays inside ``tox_root``.
+
+        :returns: the resolved absolute path if the script exists, ``None`` if no script is configured.
+
+        :raises Fail: if the script escapes ``tox_root`` or does not exist when configured.
+
+        """
+        if not (script := self.conf["script"]):
+            return None
+        tox_root: Path = self.core["tox_root"]
+        root_resolved = tox_root.resolve()
+        full_path = (tox_root / script).resolve()
+        try:
+            full_path.relative_to(root_resolved)
+        except ValueError as exc:
+            msg = f"script path {script!r} escapes tox_root {tox_root}"
+            raise Fail(msg) from exc
+        if not full_path.is_file():
+            msg = f"script file not found: {tox_root / script}"
+            raise Fail(msg)
+        return full_path
 
 
 def _parse_script_metadata(script: str) -> ScriptMetadata:

--- a/src/tox/tox_env/python/pip/req/file.py
+++ b/src/tox/tox_env/python/pip/req/file.py
@@ -12,7 +12,7 @@ import urllib.parse
 from argparse import ArgumentParser, Namespace
 from collections.abc import Iterator
 from pathlib import Path
-from typing import IO, Any, cast
+from typing import IO, Any, Final, cast
 from urllib.request import urlopen
 
 from packaging.requirements import InvalidRequirement, Requirement
@@ -81,6 +81,7 @@ _VERSION_SPECIFIER = re.compile(
 ReqFileLines = Iterator[tuple[int, str]]
 
 DEFAULT_INDEX_URL = "https://pypi.org/simple"
+_HTTP_TIMEOUT: Final[int] = 30  # seconds; bound on remote requirement file fetches to avoid hangs
 
 
 class ParsedRequirement:
@@ -300,7 +301,7 @@ class RequirementsFile:
         """
         scheme = get_url_scheme(url)
         if scheme in {"http", "https"}:
-            with urlopen(url) as response:  # noqa: S310
+            with urlopen(url, timeout=_HTTP_TIMEOUT) as response:  # noqa: S310
                 return self._read_decode(response)
         elif scheme == "file":
             url = url_to_path(url)

--- a/src/tox/util/redact.py
+++ b/src/tox/util/redact.py
@@ -1,0 +1,78 @@
+"""Helpers for masking secret-looking content in user-facing logs."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# Based on the gitleaks ``generic-api-key`` rule. We err on the side of false positives because over-redaction is
+# reversible by the user but a leaked secret is not. See https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml#L587
+_SECRET_KEYWORDS: Final[tuple[str, ...]] = (
+    "access",
+    "api",
+    "auth",
+    "client",
+    "cred",
+    "key",
+    "passwd",
+    "password",
+    "private",
+    "pwd",
+    "secret",
+    "token",
+)
+_SECRET_ENV_VAR_REGEX: Final[re.Pattern[str]] = re.compile(
+    r"""
+    .*                  # any prefix
+    ( {keywords} )      # one of the secret keywords
+    .*                  # any suffix
+    """.format(keywords="|".join(_SECRET_KEYWORDS)),
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+def redact_value(name: str, value: str) -> str:
+    """Mask ``value`` if ``name`` looks like it identifies a secret.
+
+    :param name: the variable / option name to test against the secret keyword regex.
+    :param value: the value associated with ``name``; replaced with asterisks of the same length on a match.
+
+    :returns: ``value`` unchanged, or a string of ``*`` of the same length when ``name`` matches.
+
+    """
+    if _SECRET_ENV_VAR_REGEX.match(name):
+        return "*" * len(value)
+    return value
+
+
+def redact_argv(argv: Sequence[str]) -> list[str]:
+    """Return a copy of ``argv`` with secret-looking ``--key=value`` token values masked.
+
+    Only the inline ``--key=value`` / ``-k=value`` form is detected. Space-separated arguments are left alone to avoid
+    masking innocuous selectors like ``pytest -k test_foo``: there is no general way to tell ``--token <value>`` apart
+    from ``--token <not-a-value>`` without per-tool knowledge of the parser.
+
+    :param argv: the command line tokens to scan.
+
+    :returns: a new list with values of secret-looking flags replaced by ``*`` of the same length.
+
+    """
+    result: list[str] = []
+    for token in argv:
+        if token.startswith("-") and "=" in token:
+            flag, sep, value = token.partition("=")
+            name = flag.lstrip("-")
+            if _SECRET_ENV_VAR_REGEX.match(name):
+                result.append(f"{flag}{sep}{'*' * len(value)}")
+                continue
+        result.append(token)
+    return result
+
+
+__all__ = (
+    "redact_argv",
+    "redact_value",
+)

--- a/tests/config/cli/test_parser.py
+++ b/tests/config/cli/test_parser.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from argparse import Action
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, get_args
 
 import pytest
 
@@ -86,6 +86,15 @@ def test_parser_unsupported_type() -> None:
     action = context.value.args[0]
     assert isinstance(action, Action)
     assert action.dest == "magic"
+
+
+def test_parser_choices_become_literal_type(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("TOX_MODE", "fast")
+    parser = ToxParser.base()
+    action = parser.add_argument("--mode", choices=["fast", "slow", "medium"], default="fast")
+    of_type = parser.get_type(action)
+    assert of_type == Literal["fast", "slow", "medium"]
+    assert set(get_args(of_type)) == {"fast", "slow", "medium"}
 
 
 def test_sub_sub_command() -> None:

--- a/tests/execute/test_request.py
+++ b/tests/execute/test_request.py
@@ -24,3 +24,37 @@ def test_request_allow_star_is_none() -> None:
         allow=["*", "magic"],
     )
     assert request.allow is None
+
+
+def test_shell_cmd_redacted_masks_secret_flag_value() -> None:
+    request = ExecuteRequest(
+        cmd=["pytest", "--token=hunter2", "tests"],
+        cwd=Path.cwd(),
+        env={},
+        stdin=StdinSource.OFF,
+        run_id="",
+    )
+    assert "hunter2" not in request.shell_cmd_redacted
+    assert "--token=*******" in request.shell_cmd_redacted
+
+
+def test_shell_cmd_unredacted_preserves_secret_value() -> None:
+    request = ExecuteRequest(
+        cmd=["pytest", "--token=hunter2"],
+        cwd=Path.cwd(),
+        env={},
+        stdin=StdinSource.OFF,
+        run_id="",
+    )
+    assert "hunter2" in request.shell_cmd
+
+
+def test_shell_cmd_redacted_leaves_innocuous_args_alone() -> None:
+    request = ExecuteRequest(
+        cmd=["pytest", "-k", "test_token"],
+        cwd=Path.cwd(),
+        env={},
+        stdin=StdinSource.OFF,
+        run_id="",
+    )
+    assert request.shell_cmd_redacted == request.shell_cmd

--- a/tests/tox_env/python/pip/req/test_file.py
+++ b/tests/tox_env/python/pip/req/test_file.py
@@ -506,11 +506,13 @@ def test_req_over_http(tmp_path: Path, flag: str, mocker: MockerFixture) -> None
     assert vars(req_file.options) == {"index_url": ["i"]}
     found = [str(i) for i in req_file.requirements]
     assert found == [f"{'-c ' if is_constraint else ''}a"]
+    # urlopen must be called with a timeout to avoid hanging on slow / unresponsive mirrors
+    assert url_open.call_args.kwargs.get("timeout") is not None
 
 
 def test_req_over_http_has_req(tmp_path: Path, mocker: MockerFixture) -> None:
     @contextmanager
-    def enter(url: str) -> Iterator[IO[bytes]]:
+    def enter(url: str, timeout: float | None = None) -> Iterator[IO[bytes]]:  # noqa: ARG001
         if url == "https://root.org/a.txt":
             yield BytesIO(b"-r b.txt")
         elif url == "https://root.org/b.txt":

--- a/tests/tox_env/python/virtual_env/test_pep723.py
+++ b/tests/tox_env/python/virtual_env/test_pep723.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
     from tox.pytest import ToxProjectCreator
 
 
@@ -125,3 +127,31 @@ def test_base_python_rejected(tox_project: ToxProjectCreator) -> None:
     )
     result.assert_failed()
     assert "cannot set base_python" in result.out
+
+
+def _tox_ini_with_script(script_value: str) -> str:
+    return f"[testenv:check]\nrunner = virtualenv-pep-723\nscript = {script_value}\n"
+
+
+def test_script_path_outside_tox_root_rejected(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({"tox.ini": _tox_ini_with_script("../escape.py")})
+    result = proj.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_failed()
+    assert "escapes tox_root" in result.out
+
+
+def test_script_path_traversal_via_dot_dot_rejected(tox_project: ToxProjectCreator) -> None:
+    proj = tox_project({"tox.ini": _tox_ini_with_script("subdir/../../etc/passwd")})
+    result = proj.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_failed()
+    assert "escapes tox_root" in result.out
+
+
+def test_script_file_too_large_rejected(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+    script = "# /// script\n# dependencies = []\n# ///\nprint('ok')\n"
+    proj = tox_project({"tox.ini": _tox_ini(), "check.py": script})
+    proj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    mocker.patch("tox.tox_env.python.pep723._MAX_SCRIPT_BYTES", 1)
+    result = proj.run("r", "-e", "check", "--discover", sys.executable)
+    result.assert_failed()
+    assert "exceeds the 1 byte limit" in result.out

--- a/tests/tox_env/test_tox_env_api.py
+++ b/tests/tox_env/test_tox_env_api.py
@@ -74,6 +74,20 @@ def test_env_log(tox_project: ToxProjectCreator) -> None:
     assert filename == {"1-commands[0].log"}
 
 
+def test_env_log_redacts_secret_argv(tox_project: ToxProjectCreator) -> None:
+    cmd = "commands=python -c 'pass' --token=hunter2 --cov=tox"
+    prj = tox_project({"tox.ini": f"[testenv]\npackage=skip\n{cmd}"})
+    result = prj.run("r")
+    result.assert_success()
+    log_dir = prj.path / ".tox" / "py" / "log"
+    content = (log_dir / "1-commands[0].log").read_text()
+    cmd_line = next(line for line in content.splitlines() if line.startswith("cmd:"))
+    assert "hunter2" not in cmd_line
+    assert "--token=*******" in cmd_line
+    assert "--cov=tox" in cmd_line  # innocuous flags untouched
+    assert "hunter2" not in result.out  # also masked in the LOGGER warning shown to the user
+
+
 def test_tox_env_pass_env_literal_exist() -> None:
     with patch("os.environ", {"A": "1"}):
         env = ToxEnv._load_pass_env(["A"])  # noqa: SLF001

--- a/tests/util/test_redact.py
+++ b/tests/util/test_redact.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from tox.util.redact import redact_argv, redact_value
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        pytest.param("API_TOKEN", "******", id="api-token"),
+        pytest.param("PASSWORD", "******", id="password-keyword"),
+        pytest.param("MY_SECRET_THING", "******", id="embedded-secret"),
+        pytest.param("FOO", "secret", id="non-matching"),
+        pytest.param("PATH", "secret", id="path"),
+    ],
+)
+def test_redact_value_matches_secret_keywords(name: str, expected: str) -> None:
+    assert redact_value(name, "secret") == expected
+
+
+def test_redact_value_preserves_length() -> None:
+    assert redact_value("API_KEY", "abcde") == "*****"
+
+
+def test_redact_argv_masks_inline_value_for_secret_flag() -> None:
+    result = redact_argv(["pytest", "--token=hunter2", "tests"])
+    assert result == ["pytest", "--token=*******", "tests"]
+
+
+def test_redact_argv_masks_short_flag() -> None:
+    result = redact_argv(["foo", "-key=abc"])
+    assert result == ["foo", "-key=***"]
+
+
+def test_redact_argv_leaves_innocuous_flags_alone() -> None:
+    result = redact_argv(["pytest", "-k", "test_foo", "--cov=tox"])
+    assert result == ["pytest", "-k", "test_foo", "--cov=tox"]
+
+
+def test_redact_argv_does_not_mask_space_separated_value() -> None:
+    # we deliberately do NOT redact `--token hunter2` because we cannot reliably tell where a flag value ends without
+    # parser-specific knowledge; this asserts the documented limitation.
+    result = redact_argv(["app", "--token", "hunter2"])
+    assert result == ["app", "--token", "hunter2"]
+
+
+def test_redact_argv_returns_new_list() -> None:
+    original = ["pytest", "--token=abc"]
+    result = redact_argv(original)
+    assert result is not original
+    assert original == ["pytest", "--token=abc"]
+
+
+def test_redact_argv_empty() -> None:
+    assert redact_argv([]) == []


### PR DESCRIPTION
A post-release audit surfaced four places where ``tox`` was trusting attacker-authored config or argv more than it needed to. None are individually exploitable in a realistic attack today, but each one narrows a class of regression a future contributor could easily reintroduce, and the fixes are small enough that keeping them out of a hardening PR would be harder to justify than rolling them in. 🔒

Command argv was logged verbatim to the terminal, to the per-run log file under ``.tox/<env>/log/``, and in ``Outcome.__repr__``, while environment-variable values have been redacted via ``redact_value`` since #3543. Running a test with a literal ``--token=hunter2`` flag therefore leaked the value to disk in a location most users never look at. The secret-detection helpers move into a new ``tox.util.redact`` module and gain a ``redact_argv`` helper; ``ExecuteRequest`` picks up a ``shell_cmd_redacted`` property so the logging paths can emit a masked form while the existing ``shell_cmd`` property stays stable for the test helpers that assert on its exact output. Space-separated flag values are intentionally left alone because there is no generic way to tell a flag value apart from the next positional without parser-specific knowledge, and masking ``pytest -k test_token`` would be a nasty false positive.

The PEP 723 runner from #3912 resolved ``script = ...`` as ``tox_root / script`` with no containment check and no read cap, so a malicious config pointing at ``../../.ssh/id_rsa`` or a symlink to ``/dev/zero`` would either reach outside the project tree or balloon memory on ``read_text``. ✨ Factoring the lookup into ``_resolve_script_path`` lets both the existence check in ``_setup_env`` and the read in ``_get_script_metadata`` go through the same ``Path.relative_to`` guard, and a 5 MiB ceiling bounds the read without affecting any plausible real script.

The CLI parser used to build a ``Literal[...]`` string from ``action.choices`` and ``eval`` it. Every current callsite passes hardcoded strings, but it is exactly the kind of pattern a plugin author could extend with user-controlled choices and regret later. ``typing.Literal`` accepts a tuple directly at runtime, so ``Literal[tuple(action.choices)]`` produces the same type object without the interpreter round-trip. Finally, the requirements file parser was vendored from pip in #2009 and lost the session-level timeout pip would otherwise apply from its ``--timeout`` default; a deliberately slow mirror could hang a remote ``-r http://...`` include forever, so ``urlopen`` now gets a 30-second timeout.

Existing public imports from ``tox.tox_env.api`` (``redact_value``, ``SECRET_KEYWORDS``, ``SECRET_ENV_VAR_REGEX``) stay available as re-exports, so downstream plugins pinning against them keep working. The changelog entry lives at ``docs/changelog/3924.bugfix.rst``.