### PR TITLE
fix: allow deps arrays in TOML schema

### DIFF
--- a/docs/changelog/3929.bugfix.rst
+++ b/docs/changelog/3929.bugfix.rst
@@ -1,0 +1,1 @@
+Allow the generated TOML schema to validate array values for ``deps``.

--- a/src/tox/session/cmd/schema.py
+++ b/src/tox/session/cmd/schema.py
@@ -209,12 +209,18 @@ def _get_schema(conf: ConfigSet, path: str) -> dict[str, dict[str, typing.Any]]:
 
 
 def _process_type(of_type: typing.Any) -> dict[str, typing.Any]:  # noqa: C901, PLR0911, PLR0912
+    if of_type is tox.tox_env.python.pip.req_file.PythonDeps:
+        return {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "array", "items": {"$ref": "#/definitions/subs"}},
+            ]
+        }
     if of_type in {
         Path,
         str,
         packaging.version.Version,
         packaging.requirements.Requirement,
-        tox.tox_env.python.pip.req_file.PythonDeps,
         tox.tox_env.python.pip.req_file.PythonConstraints,
     }:
         return {"type": "string"}

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -563,9 +563,7 @@
               "type": "boolean"
             }
           },
-          "required": [
-            "replace"
-          ],
+          "required": ["replace"],
           "additionalProperties": false
         },
         {
@@ -597,19 +595,14 @@
               "type": "boolean"
             }
           },
-          "required": [
-            "replace",
-            "of"
-          ],
+          "required": ["replace", "of"],
           "additionalProperties": false
         }
       ]
     },
     "factor_range_dict": {
       "type": "object",
-      "required": [
-        "prefix"
-      ],
+      "required": ["prefix"],
       "properties": {
         "prefix": {
           "type": "string"
@@ -629,9 +622,7 @@
       "minProperties": 1,
       "maxProperties": 1,
       "not": {
-        "required": [
-          "prefix"
-        ]
+        "required": ["prefix"]
       },
       "additionalProperties": {
         "type": "array",
@@ -664,9 +655,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "product"
-          ],
+          "required": ["product"],
           "properties": {
             "product": {
               "type": "array",

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -400,7 +400,17 @@
           "deprecated": true
         },
         "deps": {
-          "type": "string",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/subs"
+              }
+            }
+          ],
           "description": "python dependencies with optional version specifiers, as specified by PEP-440"
         },
         "dependency_groups": {
@@ -553,7 +563,9 @@
               "type": "boolean"
             }
           },
-          "required": ["replace"],
+          "required": [
+            "replace"
+          ],
           "additionalProperties": false
         },
         {
@@ -585,14 +597,19 @@
               "type": "boolean"
             }
           },
-          "required": ["replace", "of"],
+          "required": [
+            "replace",
+            "of"
+          ],
           "additionalProperties": false
         }
       ]
     },
     "factor_range_dict": {
       "type": "object",
-      "required": ["prefix"],
+      "required": [
+        "prefix"
+      ],
       "properties": {
         "prefix": {
           "type": "string"
@@ -612,7 +629,9 @@
       "minProperties": 1,
       "maxProperties": 1,
       "not": {
-        "required": ["prefix"]
+        "required": [
+          "prefix"
+        ]
       },
       "additionalProperties": {
         "type": "array",
@@ -645,7 +664,9 @@
         },
         {
           "type": "object",
-          "required": ["product"],
+          "required": [
+            "product"
+          ],
           "properties": {
             "product": {
               "type": "array",

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -39,6 +39,14 @@ def test_schema_freshness(tox_project: ToxProjectCreator, monkeypatch: MonkeyPat
     )
 
 
+def test_schema_allows_deps_array() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text())
+    deps_schema = schema["properties"]["env_run_base"]["properties"]["deps"]
+
+    assert {"type": "string"} in deps_schema["oneOf"]
+    assert {"type": "array", "items": {"$ref": "#/definitions/subs"}} in deps_schema["oneOf"]
+
+
 @pytest.mark.parametrize(
     ("filename", "tombi_cfg", "content"),
     [
@@ -52,7 +60,7 @@ def test_schema_freshness(tox_project: ToxProjectCreator, monkeypatch: MonkeyPat
             "pyproject.toml",
             '[[schemas]]\nroot = "tool.tox"\npath = "tox.schema.json"\ninclude = ["pyproject.toml"]\n',
             "[tool.tox]\nrequires = ['tox>=4']\nenv_list = ['py']\nskip_missing_interpreters = true\n\n"
-            "[tool.tox.env_run_base]\ncommands = [['pytest']]\ndeps = 'pytest'\n\n"
+            "[tool.tox.env_run_base]\ncommands = [['pytest']]\ndeps = ['pytest', '-r requirements.txt']\n\n"
             "[tool.tox.env.lint]\ncommands = [['ruff', 'check', '.']]\n",
             id="pyproject.toml",
         ),


### PR DESCRIPTION
## Summary

Allow tox's generated TOML schema to validate `deps` as either a string or an array, matching the forms tox already accepts in configuration.

Fixes #3929

## Test plan

- `python -m pytest tests/session/cmd/test_schema.py -q`
- `git diff --check`
- `python -m json.tool src/tox/tox.schema.json >/tmp/tox-schema-jsoncheck.json`

Note: local `python -m ruff check ...` could not run because the installed Ruff version does not recognize the repo's configured `RUF067` rule.
