### PR TITLE
🐛 fix(type): correct argparse override signatures for ty 0.0.33

### DIFF
--- a/docs/changelog/3932.bugfix.rst
+++ b/docs/changelog/3932.bugfix.rst
@@ -1,0 +1,5 @@
+Correct type annotations for `ArgumentParser.parse_args` and `parse_known_args` overrides following
+`typeshed PR #15613 <https://github.com/python/typeshed/pull/15613>`\_, which widened the `args` parameter from
+`Sequence[str]` to `Iterable[str]`. The narrower type in tox's overrides violated the Liskov substitution principle and
+caused `invalid-method-override` errors with `ty` 0.0.33. Also correct the `option_spec` annotation in
+`docs/tox_conf.py` to use `ClassVar[dict[str, Callable[[str], Any]]]` matching the docutils stubs type.

--- a/docs/changelog/3932.bugfix.rst
+++ b/docs/changelog/3932.bugfix.rst
@@ -1,5 +1,5 @@
-Correct type annotations for `ArgumentParser.parse_args` and `parse_known_args` overrides following
-`typeshed PR #15613 <https://github.com/python/typeshed/pull/15613>`\_, which widened the `args` parameter from
-`Sequence[str]` to `Iterable[str]`. The narrower type in tox's overrides violated the Liskov substitution principle and
-caused `invalid-method-override` errors with `ty` 0.0.33. Also correct the `option_spec` annotation in
-`docs/tox_conf.py` to use `ClassVar[dict[str, Callable[[str], Any]]]` matching the docutils stubs type.
+Correct type annotations for ``ArgumentParser.parse_args`` and ``parse_known_args`` overrides following `typeshed PR
+#15613 <https://github.com/python/typeshed/pull/15613>`_, which widened the ``args`` parameter from ``Sequence[str]`` to
+``Iterable[str]``. The narrower type in tox's overrides violated the Liskov substitution principle and caused
+``invalid-method-override`` errors with ``ty`` 0.0.33. Also correct the ``option_spec`` annotation in
+``docs/tox_conf.py`` to ``ClassVar[dict[str, Callable[[str], Any]]]`` matching the docutils stubs type.

--- a/docs/tox_conf.py
+++ b/docs/tox_conf.py
@@ -10,6 +10,8 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.logging import getLogger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from docutils.parsers.rst.states import RSTState, RSTStateMachine
     from sphinx.domains.std import StandardDomain
 
@@ -19,7 +21,7 @@ LOGGER = getLogger(__name__)
 class ToxConfig(SphinxDirective):
     name = "conf"
     has_content = True
-    option_spec: ClassVar[dict[str, Any]] = {
+    option_spec: ClassVar[dict[str, Callable[[str], Any]]] = {
         "keys": unchanged_required,
         "version_added": unchanged,
         "version_deprecated": unchanged,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ test = [
 ]
 type = [
   "ty>=0.0.19",
+  "types-docutils>=0.21",
   { include-group = "docs" },
   { include-group = "release" },
   { include-group = "test" },

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -26,7 +26,7 @@ else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Iterable, Sequence
 
     from tox.session.state import State
 
@@ -83,20 +83,20 @@ class ArgumentParserWithEnvAndConfig(ArgumentParser):
         return of_type
 
     @overload
-    def parse_args(self, args: Sequence[str] | None = None, namespace: None = None) -> Namespace: ...
+    def parse_args(self, args: Iterable[str] | None = None, namespace: None = None) -> Namespace: ...
 
     @overload
-    def parse_args(self, args: Sequence[str] | None, namespace: _N) -> _N: ...
+    def parse_args(self, args: Iterable[str] | None, namespace: _N) -> _N: ...
 
     @overload
     def parse_args(self, *, namespace: _N) -> _N: ...
 
-    def parse_args(  # ty: ignore[invalid-method-override]  # astral-sh/ty#3389
+    def parse_args(
         self,
-        args: Sequence[str] | None = None,
+        args: Iterable[str] | None = None,
         namespace: _N | None = None,
     ) -> _N:
-        res, argv = self.parse_known_args(args, namespace)
+        res, argv = self.parse_known_args(list(args) if args is not None else None, namespace)
         if argv:
             self.error(
                 f"unrecognized arguments: {' '.join(argv)}\n"
@@ -387,38 +387,39 @@ class ToxParser(ArgumentParserWithEnvAndConfig):
 
     @overload
     def parse_known_args(
-        self, args: Sequence[str] | None = None, namespace: None = None
+        self, args: Iterable[str] | None = None, namespace: None = None
     ) -> tuple[Parsed, list[str]]: ...
 
     @overload
-    def parse_known_args(self, args: Sequence[str] | None, namespace: _N) -> tuple[_N, list[str]]: ...
+    def parse_known_args(self, args: Iterable[str] | None, namespace: _N) -> tuple[_N, list[str]]: ...
 
     @overload
     def parse_known_args(self, *, namespace: _N) -> tuple[_N, list[str]]: ...
 
-    def parse_known_args(  # ty: ignore[invalid-method-override]  # astral-sh/ty#3389
+    def parse_known_args(
         self,
-        args: Sequence[str] | None = None,
+        args: Iterable[str] | None = None,
         namespace: _N | None = None,
     ) -> tuple[_N, list[str]]:
-        if args is None:
-            args = sys.argv[1:]
+        args_list: list[str] = list(args) if args is not None else sys.argv[1:]
         cmd_at: int | None = None
-        if self._cmd is not None and args:
-            for at, arg in enumerate(args):
+        if self._cmd is not None and args_list:
+            for at, arg in enumerate(args_list):
                 if arg in self._cmd.choices:
                     cmd_at = at
                     break
             else:
                 cmd_at = None
         if cmd_at is not None:  # if we found a command move it to the start
-            args = args[cmd_at], *args[:cmd_at], *args[cmd_at + 1 :]
-        elif tuple(args) not in {("--help",), ("-h",)} and (self._cmd is not None and "legacy" in self._cmd.choices):
+            args_list = [args_list[cmd_at], *args_list[:cmd_at], *args_list[cmd_at + 1 :]]
+        elif tuple(args_list) not in {("--help",), ("-h",)} and (
+            self._cmd is not None and "legacy" in self._cmd.choices
+        ):
             # on help no mangling needed, and we also want to insert once we have legacy to insert
-            args = "legacy", *args
+            args_list = ["legacy", *args_list]
         result = Parsed() if namespace is None else namespace
-        _, args = super().parse_known_args(args, namespace=result)
-        return cast("tuple[_N, list[str]]", (result, args))
+        _, remainder = super().parse_known_args(args_list, namespace=result)
+        return cast("tuple[_N, list[str]]", (result, remainder))
 
 
 def add_core_arguments(parser: ArgumentParser) -> None:

--- a/src/tox/config/cli/parser.py
+++ b/src/tox/config/cli/parser.py
@@ -10,7 +10,7 @@ import sys
 from argparse import SUPPRESS, Action, ArgumentDefaultsHelpFormatter, ArgumentError, ArgumentParser, Namespace
 from pathlib import Path
 from types import UnionType
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
 
 from colorama import Fore
 
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
     from tox.session.state import State
+
+_N = TypeVar("_N", bound=Namespace)
 
 
 class ArgumentParserWithEnvAndConfig(ArgumentParser):
@@ -80,11 +82,20 @@ class ArgumentParserWithEnvAndConfig(ArgumentParser):
                 raise TypeError(action)
         return of_type
 
-    def parse_args(  # avoid defining all overloads
+    @overload
+    def parse_args(self, args: Sequence[str] | None = None, namespace: None = None) -> Namespace: ...
+
+    @overload
+    def parse_args(self, args: Sequence[str] | None, namespace: _N) -> _N: ...
+
+    @overload
+    def parse_args(self, *, namespace: _N) -> _N: ...
+
+    def parse_args(  # ty: ignore[invalid-method-override]  # astral-sh/ty#3389
         self,
         args: Sequence[str] | None = None,
-        namespace: Namespace | None = None,
-    ) -> Namespace:
+        namespace: _N | None = None,
+    ) -> _N:
         res, argv = self.parse_known_args(args, namespace)
         if argv:
             self.error(
@@ -93,7 +104,7 @@ class ArgumentParserWithEnvAndConfig(ArgumentParser):
             )
         if getattr(res, "no_capture", False) and getattr(res, "result_json", None):
             self.error("argument -i/--no-capture: not allowed with argument --result-json")
-        return cast("Namespace", res)
+        return cast("_N", res)
 
 
 class HelpFormatter(ArgumentDefaultsHelpFormatter):
@@ -374,11 +385,22 @@ class ToxParser(ArgumentParserWithEnvAndConfig):
         add_core_arguments(self)
         self.fix_defaults()
 
+    @overload
     def parse_known_args(
+        self, args: Sequence[str] | None = None, namespace: None = None
+    ) -> tuple[Parsed, list[str]]: ...
+
+    @overload
+    def parse_known_args(self, args: Sequence[str] | None, namespace: _N) -> tuple[_N, list[str]]: ...
+
+    @overload
+    def parse_known_args(self, *, namespace: _N) -> tuple[_N, list[str]]: ...
+
+    def parse_known_args(  # ty: ignore[invalid-method-override]  # astral-sh/ty#3389
         self,
         args: Sequence[str] | None = None,
-        namespace: Parsed | None = None,
-    ) -> tuple[Parsed, list[str]]:
+        namespace: _N | None = None,
+    ) -> tuple[_N, list[str]]:
         if args is None:
             args = sys.argv[1:]
         cmd_at: int | None = None
@@ -396,7 +418,7 @@ class ToxParser(ArgumentParserWithEnvAndConfig):
             args = "legacy", *args
         result = Parsed() if namespace is None else namespace
         _, args = super().parse_known_args(args, namespace=result)
-        return result, args
+        return cast("tuple[_N, list[str]]", (result, args))
 
 
 def add_core_arguments(parser: ArgumentParser) -> None:


### PR DESCRIPTION
ty 0.0.33 picked up [python/typeshed#15613](https://github.com/python/typeshed/pull/15613), which widened the `args` parameter of `ArgumentParser.parse_args` and `parse_known_args` from `Sequence[str]` to `Iterable[str]`. Our overrides kept the narrower `Sequence[str]`, violating the Liskov substitution principle and causing `invalid-method-override` errors on every CI run.

The fix adds proper `@overload` signatures matching all three of argparse's overloads, switches `args` to `Iterable[str] | None`, and converts to `list` inside `ToxParser.parse_known_args` where indexing is required. A `_N = TypeVar("_N", bound=Namespace)` is introduced so callers who pass a custom namespace subclass get that type back rather than the base `Namespace`. 🔧

The same ty update flagged `option_spec` in `docs/tox_conf.py`. The annotation is corrected to `ClassVar[dict[str, Callable[[str], Any]]]`, matching the type defined in the docutils typeshed stubs (`ClassVar[dict[str, Callable[[str], Incomplete]] | None]`).