### PR TITLE
fix(python): tolerate older virtualenv PythonSpec missing machine/free_threaded

### DIFF
--- a/docs/changelog/3934.bugfix.rst
+++ b/docs/changelog/3934.bugfix.rst
@@ -1,4 +1,3 @@
-Tolerate ``virtualenv.discovery.py_spec.PythonSpec`` instances that do not expose the
-``machine`` and ``free_threaded`` attributes (e.g. ``virtualenv < 20.30``), so
-``tox`` does not crash with ``AttributeError`` on older system-packaged virtualenv -
-by :user:`SAY-5`.
+Tolerate ``virtualenv.discovery.py_spec.PythonSpec`` instances that do not expose the ``machine`` and ``free_threaded``
+attributes (e.g. ``virtualenv < 20.30``), so ``tox`` does not crash with ``AttributeError`` on older system-packaged
+virtualenv - by :user:`SAY-5`.

--- a/docs/changelog/3934.bugfix.rst
+++ b/docs/changelog/3934.bugfix.rst
@@ -1,0 +1,4 @@
+Tolerate ``virtualenv.discovery.py_spec.PythonSpec`` instances that do not expose the
+``machine`` and ``free_threaded`` attributes (e.g. ``virtualenv < 20.30``), so
+``tox`` does not crash with ``AttributeError`` on older system-packaged virtualenv -
+by :user:`SAY-5`.

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -276,9 +276,9 @@ class Python(ToxEnv, ABC):
                     else:
                         spec_base = cls.python_spec_for_path(path)
                 if any(
-                    getattr(spec_base, key) != getattr(spec_name, key)
+                    getattr(spec_base, key, None) != getattr(spec_name, key, None)
                     for key in ("implementation", "major", "minor", "micro", "architecture", "machine", "free_threaded")
-                    if getattr(spec_name, key) is not None
+                    if getattr(spec_name, key, None) is not None
                 ):
                     msg = f"env name {env_name} conflicting with base python {base_python}"
                     if ignore_base_python_conflict:

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -78,6 +78,24 @@ def test_validate_base_python_conflicting_factors_no_ignore() -> None:
         Python._validate_base_python("unit-py3.10-2.16", ["python3"], ignore_base_python_conflict=False)  # noqa: SLF001
 
 
+def test_validate_base_python_old_virtualenv_missing_attrs(mocker: MockerFixture) -> None:
+    # Older virtualenv versions ship a PythonSpec without ``machine`` / ``free_threaded``.
+    # ``_validate_base_python`` must not raise AttributeError on those platforms.
+    major, minor = sys.version_info[0:2]
+    legacy_spec = SimpleNamespace(
+        implementation="CPython",
+        major=major,
+        minor=minor,
+        micro=None,
+        architecture=None,
+        path=None,
+    )
+    mocker.patch("tox.tox_env.python.api.PythonSpec.from_string_spec", return_value=legacy_spec)
+    base = [f"python{major}.{minor}"]
+    result = Python._validate_base_python(f"py{major}{minor}", base, ignore_base_python_conflict=False)  # noqa: SLF001
+    assert result == base
+
+
 def test_build_wheel_in_non_base_pkg_env(
     tox_project: ToxProjectCreator,
     patch_prev_py: PatchPrevPy,


### PR DESCRIPTION
- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation

Fixes #3934.

`_validate_base_python` iterates over `("implementation", "major", "minor", "micro", "architecture", "machine", "free_threaded")` and unconditionally calls `getattr(spec_name, key)` on the `PythonSpec` returned by `virtualenv`. The `machine` and `free_threaded` attributes were introduced in newer `virtualenv` releases, so on systems that still ship an older `virtualenv` (e.g. OpenIndiana's system package, `virtualenv 20.37.0`), `tox -e py314` aborts with:

```
AttributeError: 'PythonSpec' object has no attribute 'machine'
```

Switching the lookups to `getattr(spec, key, None)` makes the comparison safely treat the missing keys as "no constraint", restoring the pre-3815 behaviour for environments that have not upgraded `virtualenv` yet. Added a regression test that monkey-patches `PythonSpec.from_string_spec` to return an attribute-stripped spec.