### PR TITLE
🧪 test(conftest): strip broken nspkg.pth files under py3.15

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import os
+import site
 import sys
 import sysconfig
 from pathlib import Path
@@ -28,6 +30,26 @@ if TYPE_CHECKING:
 
 pytest_plugins = "tox.pytest"
 HERE = Path(__file__).absolute().parent
+
+
+def _strip_broken_namespace_pth_files() -> None:
+    # Legacy setuptools-generated *-nspkg.pth files (from PasteDeploy and repoze.lru, pulled in
+    # transitively by devpi-server) read sys._getframe(1).f_locals['sitedir']. Python 3.13
+    # rewrote site.py as a frozen module and this lookup no longer resolves, so each Python
+    # startup emits a KeyError to stderr that breaks tests asserting on subprocess stderr.
+    # Removing the files is safe: the paste and repoze namespaces still resolve via PEP 420.
+    legacy = b"sys._getframe(1).f_locals['sitedir']"
+    for raw in site.getsitepackages():
+        site_dir = Path(raw)
+        if not site_dir.is_dir():
+            continue
+        for pth in site_dir.glob("*-nspkg.pth"):
+            with contextlib.suppress(OSError):
+                if legacy in pth.read_bytes():
+                    pth.unlink()
+
+
+_strip_broken_namespace_pth_files()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Six tests in the local subprocess and parallel suites fail on the weekly Python 3.15 check (run [25667044284](https://github.com/tox-dev/tox/actions/runs/25667044284)) because every spawned interpreter prints a `KeyError` to stderr before user code runs, and the assertions compare stderr byte-for-byte.

The noise originates in the legacy `*-nspkg.pth` files shipped by `PasteDeploy 3.1.0` and `repoze.lru 0.7`, both pulled in transitively by `devpi-server` → `pyramid`. Those pth files call `sys._getframe(1).f_locals['sitedir']`, which worked when `site.py` walked its own frame. PEP 829 (CPython [#149109](https://github.com/python/cpython/pull/149109)) replaced that machinery with a deferred `_exec_imports()` that has no `sitedir` local, so every interpreter startup raises `KeyError: "local variable ''sitedir'' is not defined"`. The regression is tracked upstream in CPython [#149671](https://github.com/python/cpython/issues/149671).

This is genuinely an upstream problem: the proper fix lives either in CPython (restoring compatibility with legacy `.pth` hacks, or providing a migration path) or in `setuptools` (which still generates these pth files for `namespace_packages=` declarations even though `pkg_resources` was removed in 82.0.0). The `paste` and `repoze` namespaces would still resolve via PEP 420 without the `.pth` shim, so the affected packages could also drop `namespace_packages=` upstream.

Until any of those land, this patch removes the offending pth files at conftest import — gated by the broken `f_locals['sitedir']` substring so unrelated namespace pth files are untouched, and wrapped in `contextlib.suppress(OSError)` to stay idempotent under `xdist` workers racing on the same file. Revert once the upstream fix is available.