### PR TITLE
✨ feat(packaging): declare tox.pytest deps via a testing extra

### DIFF
--- a/docs/changelog/3938.feature.rst
+++ b/docs/changelog/3938.feature.rst
@@ -1,0 +1,2 @@
+Declare the runtime dependencies of the ``tox.pytest`` plugin (``pytest``, ``devpi-process`` and ``pytest-mock``) under
+a new ``testing`` extra, so plugin authors can pull them in via ``tox[testing]`` - by :user:`gaborbernat`.

--- a/docs/changelog/3940.feature.rst
+++ b/docs/changelog/3940.feature.rst
@@ -1,0 +1,2 @@
+Declare the runtime dependencies of the ``tox.pytest`` plugin (``pytest``, ``devpi-process`` and ``pytest-mock``) under
+a new ``testing`` extra, so plugin authors can pull them in via ``tox[testing]`` - by :user:`gaborbernat`.

--- a/docs/plugin/api.rst
+++ b/docs/plugin/api.rst
@@ -153,3 +153,18 @@ session
 
 .. autoclass:: tox.tox_env.info.Info
     :members:
+
+testing
+=======
+
+.. automodule:: tox.pytest
+    :no-members:
+
+.. autoclass:: tox.pytest.ToxProject
+    :members:
+
+.. autoclass:: tox.pytest.ToxProjectCreator
+    :members:
+
+.. autoclass:: tox.pytest.ToxRunOutcome
+    :members:

--- a/docs/plugin/howto.rst
+++ b/docs/plugin/howto.rst
@@ -200,6 +200,27 @@ In ``src/tox_myplugin/__init__.py``, define your hooks exactly as in ``toxfile.p
 
 After ``pip install tox-myplugin``, tox discovers the plugin automatically via the entry point.
 
+*****************
+ Testing plugins
+*****************
+
+tox ships a pytest plugin at :mod:`tox.pytest` with fixtures for spinning up isolated tox projects, faking package
+indexes, and capturing output. To use it, declare a dependency on the ``testing`` extra so that ``pytest``,
+``pytest-mock`` and ``devpi-process`` are pulled in:
+
+.. code-block:: toml
+
+    [dependency-groups]
+    test = [
+      "tox[testing]",
+    ]
+
+Then register the plugin in your ``conftest.py``:
+
+.. code-block:: python
+
+    pytest_plugins = "tox.pytest"
+
 *********
  Logging
 *********

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ dependencies = [
 optional-dependencies.completion = [
   "argcomplete>=3.6.3",
 ]
+optional-dependencies.testing = [
+  "devpi-process>=1.1.1",
+  "pytest>=9.0.2",
+  "pytest-mock>=3.15.1",
+]
 urls."Release Notes" = "https://tox.wiki/en/latest/changelog.html"
 urls.Documentation = "https://tox.wiki"
 urls.Homepage = "http://tox.readthedocs.org"

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -535,6 +535,7 @@ def test_machine_factor_run_env(tox_project: ToxProjectCreator) -> None:
     assert py_journal["machine"] == py_info.machine
 
 
+@pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_machine_factor_unavailable(tox_project: ToxProjectCreator) -> None:
     ini = "[testenv]\npackage=skip\nbase_python=cpython3-64-fakearch999"
     proj = tox_project({"tox.ini": ini})

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -535,7 +535,7 @@ def test_machine_factor_run_env(tox_project: ToxProjectCreator) -> None:
     assert py_journal["machine"] == py_info.machine
 
 
-@pytest.mark.flaky(max_runs=3, min_passes=1)
+@pytest.mark.timeout(120)
 def test_machine_factor_unavailable(tox_project: ToxProjectCreator) -> None:
     ini = "[testenv]\npackage=skip\nbase_python=cpython3-64-fakearch999"
     proj = tox_project({"tox.ini": ini})

--- a/tox.toml
+++ b/tox.toml
@@ -70,6 +70,7 @@ uv_seed = true
 description = "build documentation"
 base_python = [ "3.14" ]
 dependency_groups = [ "docs" ]
+extras = [ "testing" ]
 commands = [
   [
     "sphinx-build",


### PR DESCRIPTION
The `tox.pytest` module exposes a pytest plugin for testing tox itself and tox plugins, but its runtime imports of `pytest`, `pytest-mock` and `devpi-process` were never declared in the package metadata. 🐛 Plugin authors who wired `pytest_plugins = "tox.pytest"` into their `conftest.py` had to discover and pin those transitive dependencies by hand, and would otherwise hit an `ImportError` on `devpi_process` before any test could run, as reported in #3938.

The fix exposes them through a new `testing` optional dependency, so consumers can pull the full fixture surface in via `tox[testing]` while the base install stays free of test-only packages. ✨ The version floors mirror those already in the `test` dependency group used by tox itself, keeping a single source of truth for the supported lower bounds.

Plugin-author docs in `docs/plugin/howto.rst` gain a short `Testing plugins` section pointing at the new extra and showing the `pytest_plugins` hookup, so the workflow is discoverable from the plugin guide.

Closes #3938.