### PR TITLE
🐛 fix(schema): cover every replace form in the TOML schema

### DIFF
--- a/docs/changelog/3939.bugfix.rst
+++ b/docs/changelog/3939.bugfix.rst
@@ -1,0 +1,5 @@
+Extend the generated TOML schema to cover every ``replace`` table form
+(``env``, ``ref``, ``posargs``, ``glob``, ``if``), including conditional
+replacements used inside ``commands``. A guard test asserts the schema stays
+in sync with the loader implementation so future replace types cannot be
+added without a corresponding schema entry.

--- a/docs/changelog/3939.bugfix.rst
+++ b/docs/changelog/3939.bugfix.rst
@@ -1,5 +1,3 @@
-Extend the generated TOML schema to cover every ``replace`` table form
-(``env``, ``ref``, ``posargs``, ``glob``, ``if``), including conditional
-replacements used inside ``commands``. A guard test asserts the schema stays
-in sync with the loader implementation so future replace types cannot be
-added without a corresponding schema entry.
+Extend the generated TOML schema to cover every ``replace`` table form (``env``, ``ref``, ``posargs``, ``glob``,
+``if``), including conditional replacements used inside ``commands``. A guard test asserts the schema stays in sync with
+the loader implementation so future replace types cannot be added without a corresponding schema entry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ test = [
   "re-assert>=1.1",
   "setuptools<82,>=81",
   "time-machine>=3.2; implementation_name!='pypy'",
+  "tombi>=0.11.3",
   "wheel>=0.46.3",
 ]
 type = [

--- a/src/tox/session/cmd/schema.py
+++ b/src/tox/session/cmd/schema.py
@@ -98,38 +98,103 @@ def gen_schema(state: State) -> int:
             "subs": {
                 "anyOf": [
                     {"type": "string"},
-                    {
-                        "type": "object",
-                        "properties": {
-                            "replace": {"type": "string"},
-                            "name": {"type": "string"},
-                            "default": {
-                                "oneOf": [
-                                    {"type": "string"},
-                                    {"type": "array", "items": {"$ref": "#/definitions/subs"}},
-                                ]
-                            },
-                            "extend": {"type": "boolean"},
-                        },
-                        "required": ["replace"],
-                        "additionalProperties": False,
+                    {"$ref": "#/definitions/replace_env"},
+                    {"$ref": "#/definitions/replace_ref"},
+                    {"$ref": "#/definitions/replace_posargs"},
+                    {"$ref": "#/definitions/replace_glob"},
+                    {"$ref": "#/definitions/replace_if"},
+                ],
+            },
+            "replace_env": {
+                "type": "object",
+                "description": "substitute the value of an environment variable",
+                "properties": {
+                    "replace": {"const": "env"},
+                    "name": {"type": "string"},
+                    "default": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"$ref": "#/definitions/subs"}},
+                        ]
                     },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "replace": {"type": "string"},
-                            "of": {"type": "array", "items": {"type": "string"}},
-                            "default": {
-                                "oneOf": [
-                                    {"type": "string"},
-                                    {"type": "array", "items": {"$ref": "#/definitions/subs"}},
-                                ]
-                            },
-                            "extend": {"type": "boolean"},
-                        },
-                        "required": ["replace", "of"],
-                        "additionalProperties": False,
+                    "extend": {"type": "boolean"},
+                    "marker": {"type": "string"},
+                },
+                "required": ["replace", "name"],
+                "additionalProperties": False,
+            },
+            "replace_ref": {
+                "type": "object",
+                "description": "substitute the value of another configuration key",
+                "properties": {
+                    "replace": {"const": "ref"},
+                    "of": {"type": "array", "items": {"type": "string"}},
+                    "env": {"type": "string"},
+                    "key": {"type": "string"},
+                    "default": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"$ref": "#/definitions/subs"}},
+                        ]
                     },
+                    "extend": {"type": "boolean"},
+                    "marker": {"type": "string"},
+                },
+                "required": ["replace"],
+                "additionalProperties": False,
+            },
+            "replace_posargs": {
+                "type": "object",
+                "description": "substitute the positional arguments passed to tox",
+                "properties": {
+                    "replace": {"const": "posargs"},
+                    "default": {"type": "array", "items": {"$ref": "#/definitions/subs"}},
+                    "extend": {"type": "boolean"},
+                    "marker": {"type": "string"},
+                },
+                "required": ["replace"],
+                "additionalProperties": False,
+            },
+            "replace_glob": {
+                "type": "object",
+                "description": "substitute matches of a filesystem glob pattern",
+                "properties": {
+                    "replace": {"const": "glob"},
+                    "pattern": {"type": "string"},
+                    "default": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"$ref": "#/definitions/subs"}},
+                        ]
+                    },
+                    "extend": {"type": "boolean"},
+                    "marker": {"type": "string"},
+                },
+                "required": ["replace", "pattern"],
+                "additionalProperties": False,
+            },
+            "replace_if": {
+                "type": "object",
+                "description": "conditional substitution based on env vars, factors, or env_name",
+                "properties": {
+                    "replace": {"const": "if"},
+                    "condition": {"type": "string"},
+                    "then": True,
+                    "else": True,
+                    "extend": {"type": "boolean"},
+                    "marker": {"type": "string"},
+                },
+                "required": ["replace", "condition", "then"],
+                "additionalProperties": False,
+            },
+            "replace_object": {
+                "description": "any of the table-form replacements; usable wherever a list item can be a replacement",
+                "anyOf": [
+                    {"$ref": "#/definitions/replace_env"},
+                    {"$ref": "#/definitions/replace_ref"},
+                    {"$ref": "#/definitions/replace_posargs"},
+                    {"$ref": "#/definitions/replace_glob"},
+                    {"$ref": "#/definitions/replace_if"},
                 ],
             },
             "factor_range_dict": {
@@ -245,7 +310,15 @@ def _process_type(of_type: typing.Any) -> dict[str, typing.Any]:  # noqa: C901, 
         if typing.get_args(of_type)[0] in {str, packaging.requirements.Requirement}:
             return {"type": "array", "items": {"$ref": "#/definitions/subs"}}
         if typing.get_args(of_type)[0] is tox.config.types.Command:
-            return {"type": "array", "items": _process_type(typing.get_args(of_type)[0])}
+            return {
+                "type": "array",
+                "items": {
+                    "oneOf": [
+                        _process_type(typing.get_args(of_type)[0]),
+                        {"$ref": "#/definitions/replace_object"},
+                    ]
+                },
+            }
         msg = f"Unknown list type: {of_type}"
         raise ValueError(msg)
     if of_type is tox.config.set_env.SetEnv:

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -619,10 +619,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace",
-        "name"
-      ],
+      "required": ["replace", "name"],
       "additionalProperties": false
     },
     "replace_ref": {
@@ -664,9 +661,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace"
-      ],
+      "required": ["replace"],
       "additionalProperties": false
     },
     "replace_posargs": {
@@ -689,9 +684,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace"
-      ],
+      "required": ["replace"],
       "additionalProperties": false
     },
     "replace_glob": {
@@ -724,10 +717,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace",
-        "pattern"
-      ],
+      "required": ["replace", "pattern"],
       "additionalProperties": false
     },
     "replace_if": {
@@ -749,11 +739,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "replace",
-        "condition",
-        "then"
-      ],
+      "required": ["replace", "condition", "then"],
       "additionalProperties": false
     },
     "replace_object": {
@@ -778,9 +764,7 @@
     },
     "factor_range_dict": {
       "type": "object",
-      "required": [
-        "prefix"
-      ],
+      "required": ["prefix"],
       "properties": {
         "prefix": {
           "type": "string"
@@ -800,9 +784,7 @@
       "minProperties": 1,
       "maxProperties": 1,
       "not": {
-        "required": [
-          "prefix"
-        ]
+        "required": ["prefix"]
       },
       "additionalProperties": {
         "type": "array",
@@ -835,9 +817,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "product"
-          ],
+          "required": ["product"],
           "properties": {
             "product": {
               "type": "array",

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -281,30 +281,51 @@
         "commands_pre": {
           "type": "array",
           "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/subs"
-            }
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/subs"
+                }
+              },
+              {
+                "$ref": "#/definitions/replace_object"
+              }
+            ]
           },
           "description": "the commands to be called before testing"
         },
         "commands": {
           "type": "array",
           "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/subs"
-            }
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/subs"
+                }
+              },
+              {
+                "$ref": "#/definitions/replace_object"
+              }
+            ]
           },
           "description": "the commands to be called for testing"
         },
         "commands_post": {
           "type": "array",
           "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/subs"
-            }
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/subs"
+                }
+              },
+              {
+                "$ref": "#/definitions/replace_object"
+              }
+            ]
           },
           "description": "the commands to be called after testing"
         },
@@ -315,10 +336,17 @@
         "recreate_commands": {
           "type": "array",
           "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/subs"
-            }
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/subs"
+                }
+              },
+              {
+                "$ref": "#/definitions/replace_object"
+              }
+            ]
           },
           "description": "commands to run before the environment is removed during recreation (e.g. cache cleanup)"
         },
@@ -434,10 +462,17 @@
         "extra_setup_commands": {
           "type": "array",
           "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/subs"
-            }
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/subs"
+                }
+              },
+              {
+                "$ref": "#/definitions/replace_object"
+              }
+            ]
           },
           "description": "commands to execute after setup (deps and package install) but before test commands"
         },
@@ -538,71 +573,214 @@
           "type": "string"
         },
         {
-          "type": "object",
-          "properties": {
-            "replace": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "default": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/subs"
-                  }
-                }
-              ]
-            },
-            "extend": {
-              "type": "boolean"
-            }
-          },
-          "required": ["replace"],
-          "additionalProperties": false
+          "$ref": "#/definitions/replace_env"
         },
         {
-          "type": "object",
-          "properties": {
-            "replace": {
+          "$ref": "#/definitions/replace_ref"
+        },
+        {
+          "$ref": "#/definitions/replace_posargs"
+        },
+        {
+          "$ref": "#/definitions/replace_glob"
+        },
+        {
+          "$ref": "#/definitions/replace_if"
+        }
+      ]
+    },
+    "replace_env": {
+      "type": "object",
+      "description": "substitute the value of an environment variable",
+      "properties": {
+        "replace": {
+          "const": "env"
+        },
+        "name": {
+          "type": "string"
+        },
+        "default": {
+          "oneOf": [
+            {
               "type": "string"
             },
-            "of": {
+            {
               "type": "array",
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/subs"
               }
-            },
-            "default": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/subs"
-                  }
-                }
-              ]
-            },
-            "extend": {
-              "type": "boolean"
             }
-          },
-          "required": ["replace", "of"],
-          "additionalProperties": false
+          ]
+        },
+        "extend": {
+          "type": "boolean"
+        },
+        "marker": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "replace",
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "replace_ref": {
+      "type": "object",
+      "description": "substitute the value of another configuration key",
+      "properties": {
+        "replace": {
+          "const": "ref"
+        },
+        "of": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "default": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/subs"
+              }
+            }
+          ]
+        },
+        "extend": {
+          "type": "boolean"
+        },
+        "marker": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "replace"
+      ],
+      "additionalProperties": false
+    },
+    "replace_posargs": {
+      "type": "object",
+      "description": "substitute the positional arguments passed to tox",
+      "properties": {
+        "replace": {
+          "const": "posargs"
+        },
+        "default": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/subs"
+          }
+        },
+        "extend": {
+          "type": "boolean"
+        },
+        "marker": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "replace"
+      ],
+      "additionalProperties": false
+    },
+    "replace_glob": {
+      "type": "object",
+      "description": "substitute matches of a filesystem glob pattern",
+      "properties": {
+        "replace": {
+          "const": "glob"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "default": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/subs"
+              }
+            }
+          ]
+        },
+        "extend": {
+          "type": "boolean"
+        },
+        "marker": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "replace",
+        "pattern"
+      ],
+      "additionalProperties": false
+    },
+    "replace_if": {
+      "type": "object",
+      "description": "conditional substitution based on env vars, factors, or env_name",
+      "properties": {
+        "replace": {
+          "const": "if"
+        },
+        "condition": {
+          "type": "string"
+        },
+        "then": true,
+        "else": true,
+        "extend": {
+          "type": "boolean"
+        },
+        "marker": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "replace",
+        "condition",
+        "then"
+      ],
+      "additionalProperties": false
+    },
+    "replace_object": {
+      "description": "any of the table-form replacements; usable wherever a list item can be a replacement",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/replace_env"
+        },
+        {
+          "$ref": "#/definitions/replace_ref"
+        },
+        {
+          "$ref": "#/definitions/replace_posargs"
+        },
+        {
+          "$ref": "#/definitions/replace_glob"
+        },
+        {
+          "$ref": "#/definitions/replace_if"
         }
       ]
     },
     "factor_range_dict": {
       "type": "object",
-      "required": ["prefix"],
+      "required": [
+        "prefix"
+      ],
       "properties": {
         "prefix": {
           "type": "string"
@@ -622,7 +800,9 @@
       "minProperties": 1,
       "maxProperties": 1,
       "not": {
-        "required": ["prefix"]
+        "required": [
+          "prefix"
+        ]
       },
       "additionalProperties": {
         "type": "array",
@@ -655,7 +835,9 @@
         },
         {
           "type": "object",
-          "required": ["product"],
+          "required": [
+            "product"
+          ],
           "properties": {
             "product": {
               "type": "array",

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,6 +15,7 @@ if TYPE_CHECKING:
 
 ROOT = Path(__file__).parents[3]
 SCHEMA_PATH = ROOT / "src" / "tox" / "tox.schema.json"
+REPLACE_PY = ROOT / "src" / "tox" / "config" / "loader" / "toml" / "_replace.py"
 
 
 def test_show_schema_empty_dir(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
@@ -67,13 +70,83 @@ def test_schema_allows_deps_array() -> None:
     ],
 )
 def test_schema_tombi_lint(tmp_path: Path, filename: str, tombi_cfg: str, content: str) -> None:
-    if not (tombi := shutil.which("tombi")):
-        pytest.skip("tombi not installed")
+    tombi = shutil.which("tombi")
+    assert tombi is not None, "tombi must be installed (declared in the test extra)"
     shutil.copy2(SCHEMA_PATH, tmp_path / "tox.schema.json")
     (tmp_path / filename).write_text(content)
     (tmp_path / "tombi.toml").write_text(tombi_cfg)
     result = subprocess.run(
         [tombi, "lint", "--error-on-warnings", "--offline", filename],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+
+
+REPLACE_FORM_TOMLS: dict[str, str] = {
+    "env": dedent("""
+        [env_run_base]
+        deps = [{ replace = "env", name = "DEPS_PIN", default = "pytest" }]
+    """),
+    "ref": dedent("""
+        [env_run_base]
+        deps = [{ replace = "ref", of = ["env_run_base", "deps"] }]
+    """),
+    "posargs": dedent("""
+        [env_run_base]
+        commands = [["pytest", { replace = "posargs", default = ["tests"] }]]
+    """),
+    "glob": dedent("""
+        [env_run_base]
+        deps = [{ replace = "glob", pattern = "requirements*.txt", extend = true }]
+    """),
+    "if": dedent("""
+        [env_run_base]
+        commands = [
+          { replace = "if", condition = "env.CI", then = [["ruff", "check"]], extend = true },
+          ["pytest"],
+        ]
+    """),
+}
+
+
+def _discover_replace_types() -> set[str]:
+    """Return the set of replace_type tokens implemented in `_replace.py`."""
+    return set(re.findall(r'replace_type == "([a-z]+)"', REPLACE_PY.read_text()))
+
+
+def test_schema_covers_every_replace_type() -> None:
+    """Guard: every `replace_type == "..."` in _replace.py needs a schema variant.
+
+    This catches the failure mode behind issue #3939, where a new replace form
+    (`if`) was added to the loader but never wired into the JSON schema.
+    """
+    implemented = _discover_replace_types()
+    schema = json.loads(SCHEMA_PATH.read_text())
+    in_schema = {name.removeprefix("replace_") for name in schema["definitions"] if name.startswith("replace_")} - {
+        "object"
+    }
+    assert implemented == in_schema, (
+        f"replace types in loader {implemented} differ from schema definitions {in_schema}; "
+        f"update src/tox/session/cmd/schema.py and regenerate tox.schema.json"
+    )
+    assert implemented == set(REPLACE_FORM_TOMLS), (
+        f"replace types in loader {implemented} differ from tombi-lint fixtures {set(REPLACE_FORM_TOMLS)}; "
+        f"add a sample to REPLACE_FORM_TOMLS in this file"
+    )
+
+
+@pytest.mark.parametrize("replace_type", sorted(REPLACE_FORM_TOMLS))
+def test_schema_tombi_lint_replace_forms(tmp_path: Path, replace_type: str) -> None:
+    tombi = shutil.which("tombi")
+    assert tombi is not None, "tombi must be installed (declared in the test extra)"
+    shutil.copy2(SCHEMA_PATH, tmp_path / "tox.schema.json")
+    (tmp_path / "tox.toml").write_text(REPLACE_FORM_TOMLS[replace_type])
+    (tmp_path / "tombi.toml").write_text('[[schemas]]\npath = "tox.schema.json"\ninclude = ["tox.toml"]\n')
+    result = subprocess.run(
+        [tombi, "lint", "--error-on-warnings", "--offline", "tox.toml"],
         cwd=tmp_path,
         capture_output=True,
         text=True,

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -6,16 +6,51 @@ import shutil
 import subprocess
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from tox.pytest import MonkeyPatch, ToxProjectCreator
 
 ROOT = Path(__file__).parents[3]
 SCHEMA_PATH = ROOT / "src" / "tox" / "tox.schema.json"
 REPLACE_PY = ROOT / "src" / "tox" / "config" / "loader" / "toml" / "_replace.py"
+DEFAULT_TOMBI_CFG = '[[schemas]]\npath = "tox.schema.json"\ninclude = ["tox.toml"]\n'
+
+
+@pytest.fixture
+def committed_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+@pytest.fixture
+def tombi_bin() -> str:
+    tombi = shutil.which("tombi")
+    assert tombi is not None, "tombi must be installed (declared in the test extra)"
+    return tombi
+
+
+@pytest.fixture
+def lint_workspace(tmp_path: Path, tombi_bin: str) -> Callable[[str, str, str], None]:
+    """Stage a tox config + the committed schema and assert `tombi lint` succeeds."""
+
+    def _run(filename: str, content: str, tombi_cfg: str = DEFAULT_TOMBI_CFG) -> None:
+        shutil.copy2(SCHEMA_PATH, tmp_path / "tox.schema.json")
+        (tmp_path / filename).write_text(content)
+        (tmp_path / "tombi.toml").write_text(tombi_cfg)
+        result = subprocess.run(
+            [tombi_bin, "lint", "--error-on-warnings", "--offline", filename],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+
+    return _run
 
 
 def test_show_schema_empty_dir(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
@@ -28,7 +63,12 @@ def test_show_schema_empty_dir(tox_project: ToxProjectCreator, monkeypatch: Monk
     assert "tox_root" in schema["properties"]
 
 
-def test_schema_freshness(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+def test_schema_freshness(
+    tox_project: ToxProjectCreator,
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+    committed_schema: dict[str, Any],
+) -> None:
     monkeypatch.chdir(tmp_path)
     project = tox_project({
         "tox.toml": 'env_list = ["py"]',
@@ -36,15 +76,13 @@ def test_schema_freshness(tox_project: ToxProjectCreator, monkeypatch: MonkeyPat
     })
     result = project.run("-qq", "schema")
     generated = json.loads(result.out)
-    committed = json.loads(SCHEMA_PATH.read_text())
-    assert generated == committed, (
+    assert generated == committed_schema, (
         "tox.schema.json is out of date — regenerate with: tox schema > src/tox/tox.schema.json"
     )
 
 
-def test_schema_allows_deps_array() -> None:
-    schema = json.loads(SCHEMA_PATH.read_text())
-    deps_schema = schema["properties"]["env_run_base"]["properties"]["deps"]
+def test_schema_allows_deps_array(committed_schema: dict[str, Any]) -> None:
+    deps_schema = committed_schema["properties"]["env_run_base"]["properties"]["deps"]
 
     assert {"type": "string"} in deps_schema["oneOf"]
     assert {"type": "array", "items": {"$ref": "#/definitions/subs"}} in deps_schema["oneOf"]
@@ -55,7 +93,7 @@ def test_schema_allows_deps_array() -> None:
     [
         pytest.param(
             "tox.toml",
-            '[[schemas]]\npath = "tox.schema.json"\ninclude = ["tox.toml"]\n',
+            DEFAULT_TOMBI_CFG,
             (ROOT / "tox.toml").read_text(),
             id="tox.toml",
         ),
@@ -69,88 +107,92 @@ def test_schema_allows_deps_array() -> None:
         ),
     ],
 )
-def test_schema_tombi_lint(tmp_path: Path, filename: str, tombi_cfg: str, content: str) -> None:
-    tombi = shutil.which("tombi")
-    assert tombi is not None, "tombi must be installed (declared in the test extra)"
-    shutil.copy2(SCHEMA_PATH, tmp_path / "tox.schema.json")
-    (tmp_path / filename).write_text(content)
-    (tmp_path / "tombi.toml").write_text(tombi_cfg)
-    result = subprocess.run(
-        [tombi, "lint", "--error-on-warnings", "--offline", filename],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+def test_schema_tombi_lint(
+    lint_workspace: Callable[[str, str, str], None],
+    filename: str,
+    tombi_cfg: str,
+    content: str,
+) -> None:
+    lint_workspace(filename, content, tombi_cfg)
 
 
-REPLACE_FORM_TOMLS: dict[str, str] = {
-    "env": dedent("""
-        [env_run_base]
-        deps = [{ replace = "env", name = "DEPS_PIN", default = "pytest" }]
-    """),
-    "ref": dedent("""
-        [env_run_base]
-        deps = [{ replace = "ref", of = ["env_run_base", "deps"] }]
-    """),
-    "posargs": dedent("""
-        [env_run_base]
-        commands = [["pytest", { replace = "posargs", default = ["tests"] }]]
-    """),
-    "glob": dedent("""
-        [env_run_base]
-        deps = [{ replace = "glob", pattern = "requirements*.txt", extend = true }]
-    """),
-    "if": dedent("""
-        [env_run_base]
-        commands = [
-          { replace = "if", condition = "env.CI", then = [["ruff", "check"]], extend = true },
-          ["pytest"],
-        ]
-    """),
-}
+REPLACE_FORMS = [
+    pytest.param(
+        "env",
+        dedent("""
+            [env_run_base]
+            deps = [{ replace = "env", name = "DEPS_PIN", default = "pytest" }]
+        """),
+        id="env",
+    ),
+    pytest.param(
+        "ref",
+        dedent("""
+            [env_run_base]
+            deps = [{ replace = "ref", of = ["env_run_base", "deps"] }]
+        """),
+        id="ref",
+    ),
+    pytest.param(
+        "posargs",
+        dedent("""
+            [env_run_base]
+            commands = [["pytest", { replace = "posargs", default = ["tests"] }]]
+        """),
+        id="posargs",
+    ),
+    pytest.param(
+        "glob",
+        dedent("""
+            [env_run_base]
+            deps = [{ replace = "glob", pattern = "requirements*.txt", extend = true }]
+        """),
+        id="glob",
+    ),
+    pytest.param(
+        "if",
+        dedent("""
+            [env_run_base]
+            commands = [
+              { replace = "if", condition = "env.CI", then = [["ruff", "check"]], extend = true },
+              ["pytest"],
+            ]
+        """),
+        id="if",
+    ),
+]
+REPLACE_FORM_NAMES = {param.values[0] for param in REPLACE_FORMS}
 
 
-def _discover_replace_types() -> set[str]:
-    """Return the set of replace_type tokens implemented in `_replace.py`."""
+@pytest.fixture
+def implemented_replace_types() -> set[str]:
+    """Replace tokens parsed out of the loader implementation."""
     return set(re.findall(r'replace_type == "([a-z]+)"', REPLACE_PY.read_text()))
 
 
-def test_schema_covers_every_replace_type() -> None:
-    """Guard: every `replace_type == "..."` in _replace.py needs a schema variant.
+def test_schema_covers_every_replace_type(
+    committed_schema: dict[str, Any], implemented_replace_types: set[str]
+) -> None:
+    """Guard: every ``replace_type == "..."`` in _replace.py needs a schema variant.
 
-    This catches the failure mode behind issue #3939, where a new replace form (`if`) was added to the loader but never
+    Catches the failure mode behind issue #3939, where a new replace form (``if``) was added to the loader but never
     wired into the JSON schema.
-
     """
-    implemented = _discover_replace_types()
-    schema = json.loads(SCHEMA_PATH.read_text())
-    in_schema = {name.removeprefix("replace_") for name in schema["definitions"] if name.startswith("replace_")} - {
-        "object"
-    }
-    assert implemented == in_schema, (
-        f"replace types in loader {implemented} differ from schema definitions {in_schema}; "
+    in_schema = {
+        name.removeprefix("replace_") for name in committed_schema["definitions"] if name.startswith("replace_")
+    } - {"object"}
+    assert implemented_replace_types == in_schema, (
+        f"replace types in loader {implemented_replace_types} differ from schema definitions {in_schema}; "
         f"update src/tox/session/cmd/schema.py and regenerate tox.schema.json"
     )
-    assert implemented == set(REPLACE_FORM_TOMLS), (
-        f"replace types in loader {implemented} differ from tombi-lint fixtures {set(REPLACE_FORM_TOMLS)}; "
-        f"add a sample to REPLACE_FORM_TOMLS in this file"
+    assert implemented_replace_types == REPLACE_FORM_NAMES, (
+        f"replace types in loader {implemented_replace_types} differ from tombi-lint fixtures {REPLACE_FORM_NAMES}; "
+        f"add a sample to REPLACE_FORMS in this file"
     )
 
 
-@pytest.mark.parametrize("replace_type", sorted(REPLACE_FORM_TOMLS))
-def test_schema_tombi_lint_replace_forms(tmp_path: Path, replace_type: str) -> None:
-    tombi = shutil.which("tombi")
-    assert tombi is not None, "tombi must be installed (declared in the test extra)"
-    shutil.copy2(SCHEMA_PATH, tmp_path / "tox.schema.json")
-    (tmp_path / "tox.toml").write_text(REPLACE_FORM_TOMLS[replace_type])
-    (tmp_path / "tombi.toml").write_text('[[schemas]]\npath = "tox.schema.json"\ninclude = ["tox.toml"]\n')
-    result = subprocess.run(
-        [tombi, "lint", "--error-on-warnings", "--offline", "tox.toml"],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+@pytest.mark.parametrize(("_name", "content"), REPLACE_FORMS)
+def test_schema_tombi_lint_replace_forms(
+    lint_workspace: Callable[[str, str, str], None], _name: str, content: str
+) -> None:
+    lint_workspace("tox.toml", content, DEFAULT_TOMBI_CFG)

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -120,8 +120,9 @@ def _discover_replace_types() -> set[str]:
 def test_schema_covers_every_replace_type() -> None:
     """Guard: every `replace_type == "..."` in _replace.py needs a schema variant.
 
-    This catches the failure mode behind issue #3939, where a new replace form
-    (`if`) was added to the loader but never wired into the JSON schema.
+    This catches the failure mode behind issue #3939, where a new replace form (`if`) was added to the loader but never
+    wired into the JSON schema.
+
     """
     implemented = _discover_replace_types()
     schema = json.loads(SCHEMA_PATH.read_text())

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -177,6 +177,7 @@ def test_schema_covers_every_replace_type(
 
     Catches the failure mode behind issue #3939, where a new replace form (``if``) was added to the loader but never
     wired into the JSON schema.
+
     """
     in_schema = {
         name.removeprefix("replace_") for name in committed_schema["definitions"] if name.startswith("replace_")

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -6,24 +6,81 @@ import shutil
 import subprocess
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from tox.pytest import MonkeyPatch, ToxProjectCreator
 
-ROOT = Path(__file__).parents[3]
-SCHEMA_PATH = ROOT / "src" / "tox" / "tox.schema.json"
-REPLACE_PY = ROOT / "src" / "tox" / "config" / "loader" / "toml" / "_replace.py"
-DEFAULT_TOMBI_CFG = '[[schemas]]\npath = "tox.schema.json"\ninclude = ["tox.toml"]\n'
+
+class LintWorkspace(Protocol):
+    def __call__(self, filename: str, content: str, tombi_cfg: str = ...) -> None: ...
 
 
-@pytest.fixture
-def committed_schema() -> dict[str, Any]:
-    return json.loads(SCHEMA_PATH.read_text())
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    return Path(__file__).parents[3]
+
+
+@pytest.fixture(scope="session")
+def schema_path(repo_root: Path) -> Path:
+    return repo_root / "src" / "tox" / "tox.schema.json"
+
+
+@pytest.fixture(scope="session")
+def replace_py(repo_root: Path) -> Path:
+    return repo_root / "src" / "tox" / "config" / "loader" / "toml" / "_replace.py"
+
+
+@pytest.fixture(scope="session")
+def default_tombi_cfg() -> str:
+    return dedent("""\
+        [[schemas]]
+        path = "tox.schema.json"
+        include = ["tox.toml"]
+    """)
+
+
+@pytest.fixture(scope="session")
+def committed_schema(schema_path: Path) -> dict[str, Any]:
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="session")
+def implemented_replace_types(replace_py: Path) -> set[str]:
+    """Replace tokens parsed out of the loader implementation."""
+    return set(re.findall(r'replace_type == "([a-z]+)"', replace_py.read_text(encoding="utf-8")))
+
+
+@pytest.fixture(scope="session")
+def replace_form_content() -> dict[str, str]:
+    """Each replace form rendered as a minimal `tox.toml` snippet that exercises it."""
+    return {
+        "env": dedent("""\
+            [env_run_base]
+            deps = [{ replace = "env", name = "DEPS_PIN", default = "pytest" }]
+        """),
+        "ref": dedent("""\
+            [env_run_base]
+            deps = [{ replace = "ref", of = ["env_run_base", "deps"] }]
+        """),
+        "posargs": dedent("""\
+            [env_run_base]
+            commands = [["pytest", { replace = "posargs", default = ["tests"] }]]
+        """),
+        "glob": dedent("""\
+            [env_run_base]
+            deps = [{ replace = "glob", pattern = "requirements*.txt", extend = true }]
+        """),
+        "if": dedent("""\
+            [env_run_base]
+            commands = [
+              { replace = "if", condition = "env.CI", then = [["ruff", "check"]], extend = true },
+              ["pytest"],
+            ]
+        """),
+    }
 
 
 @pytest.fixture
@@ -34,11 +91,11 @@ def tombi_bin() -> str:
 
 
 @pytest.fixture
-def lint_workspace(tmp_path: Path, tombi_bin: str) -> Callable[[str, str, str], None]:
+def lint_workspace(tmp_path: Path, tombi_bin: str, schema_path: Path, default_tombi_cfg: str) -> LintWorkspace:
     """Stage a tox config + the committed schema and assert `tombi lint` succeeds."""
 
-    def _run(filename: str, content: str, tombi_cfg: str = DEFAULT_TOMBI_CFG) -> None:
-        shutil.copy2(SCHEMA_PATH, tmp_path / "tox.schema.json")
+    def _run(filename: str, content: str, tombi_cfg: str = default_tombi_cfg) -> None:
+        shutil.copy2(schema_path, tmp_path / "tox.schema.json")
         (tmp_path / filename).write_text(content)
         (tmp_path / "tombi.toml").write_text(tombi_cfg)
         result = subprocess.run(
@@ -88,90 +145,49 @@ def test_schema_allows_deps_array(committed_schema: dict[str, Any]) -> None:
     assert {"type": "array", "items": {"$ref": "#/definitions/subs"}} in deps_schema["oneOf"]
 
 
+@pytest.fixture
+def project_lint_case(request: pytest.FixtureRequest, repo_root: Path, default_tombi_cfg: str) -> tuple[str, str, str]:
+    """Resolve a parametrized lint case (`filename`, `content`, `tombi_cfg`) by id."""
+    if request.param == "tox.toml":
+        return "tox.toml", (repo_root / "tox.toml").read_text(), default_tombi_cfg
+    if request.param == "pyproject.toml":
+        cfg = dedent("""\
+            [[schemas]]
+            root = "tool.tox"
+            path = "tox.schema.json"
+            include = ["pyproject.toml"]
+        """)
+        content = dedent("""\
+            [tool.tox]
+            requires = ['tox>=4']
+            env_list = ['py']
+            skip_missing_interpreters = true
+
+            [tool.tox.env_run_base]
+            commands = [['pytest']]
+            deps = ['pytest', '-r requirements.txt']
+
+            [tool.tox.env.lint]
+            commands = [['ruff', 'check', '.']]
+        """)
+        return "pyproject.toml", content, cfg
+    raise ValueError(request.param)
+
+
 @pytest.mark.parametrize(
-    ("filename", "tombi_cfg", "content"),
-    [
-        pytest.param(
-            "tox.toml",
-            DEFAULT_TOMBI_CFG,
-            (ROOT / "tox.toml").read_text(),
-            id="tox.toml",
-        ),
-        pytest.param(
-            "pyproject.toml",
-            '[[schemas]]\nroot = "tool.tox"\npath = "tox.schema.json"\ninclude = ["pyproject.toml"]\n',
-            "[tool.tox]\nrequires = ['tox>=4']\nenv_list = ['py']\nskip_missing_interpreters = true\n\n"
-            "[tool.tox.env_run_base]\ncommands = [['pytest']]\ndeps = ['pytest', '-r requirements.txt']\n\n"
-            "[tool.tox.env.lint]\ncommands = [['ruff', 'check', '.']]\n",
-            id="pyproject.toml",
-        ),
-    ],
+    "project_lint_case",
+    [pytest.param("tox.toml", id="tox.toml"), pytest.param("pyproject.toml", id="pyproject.toml")],
+    indirect=True,
 )
-def test_schema_tombi_lint(
-    lint_workspace: Callable[[str, str, str], None],
-    filename: str,
-    tombi_cfg: str,
-    content: str,
-) -> None:
+def test_schema_tombi_lint(lint_workspace: LintWorkspace, project_lint_case: tuple[str, str, str]) -> None:
+    filename, content, tombi_cfg = project_lint_case
     lint_workspace(filename, content, tombi_cfg)
 
 
-REPLACE_FORMS = [
-    pytest.param(
-        "env",
-        dedent("""
-            [env_run_base]
-            deps = [{ replace = "env", name = "DEPS_PIN", default = "pytest" }]
-        """),
-        id="env",
-    ),
-    pytest.param(
-        "ref",
-        dedent("""
-            [env_run_base]
-            deps = [{ replace = "ref", of = ["env_run_base", "deps"] }]
-        """),
-        id="ref",
-    ),
-    pytest.param(
-        "posargs",
-        dedent("""
-            [env_run_base]
-            commands = [["pytest", { replace = "posargs", default = ["tests"] }]]
-        """),
-        id="posargs",
-    ),
-    pytest.param(
-        "glob",
-        dedent("""
-            [env_run_base]
-            deps = [{ replace = "glob", pattern = "requirements*.txt", extend = true }]
-        """),
-        id="glob",
-    ),
-    pytest.param(
-        "if",
-        dedent("""
-            [env_run_base]
-            commands = [
-              { replace = "if", condition = "env.CI", then = [["ruff", "check"]], extend = true },
-              ["pytest"],
-            ]
-        """),
-        id="if",
-    ),
-]
-REPLACE_FORM_NAMES = {param.values[0] for param in REPLACE_FORMS}
-
-
-@pytest.fixture
-def implemented_replace_types() -> set[str]:
-    """Replace tokens parsed out of the loader implementation."""
-    return set(re.findall(r'replace_type == "([a-z]+)"', REPLACE_PY.read_text()))
-
-
 def test_schema_covers_every_replace_type(
-    committed_schema: dict[str, Any], implemented_replace_types: set[str]
+    committed_schema: dict[str, Any],
+    implemented_replace_types: set[str],
+    replace_form_content: dict[str, str],
 ) -> None:
     """Guard: every ``replace_type == "..."`` in _replace.py needs a schema variant.
 
@@ -186,14 +202,23 @@ def test_schema_covers_every_replace_type(
         f"replace types in loader {implemented_replace_types} differ from schema definitions {in_schema}; "
         f"update src/tox/session/cmd/schema.py and regenerate tox.schema.json"
     )
-    assert implemented_replace_types == REPLACE_FORM_NAMES, (
-        f"replace types in loader {implemented_replace_types} differ from tombi-lint fixtures {REPLACE_FORM_NAMES}; "
-        f"add a sample to REPLACE_FORMS in this file"
+    assert implemented_replace_types == set(replace_form_content), (
+        f"replace types in loader {implemented_replace_types} differ from tombi-lint fixtures "
+        f"{set(replace_form_content)}; add a sample to the replace_form_content fixture"
     )
 
 
-@pytest.mark.parametrize(("_name", "content"), REPLACE_FORMS)
+@pytest.mark.parametrize(
+    "replace_form",
+    [
+        pytest.param("env", id="env"),
+        pytest.param("ref", id="ref"),
+        pytest.param("posargs", id="posargs"),
+        pytest.param("glob", id="glob"),
+        pytest.param("if", id="if"),
+    ],
+)
 def test_schema_tombi_lint_replace_forms(
-    lint_workspace: Callable[[str, str, str], None], _name: str, content: str
+    lint_workspace: LintWorkspace, replace_form_content: dict[str, str], replace_form: str
 ) -> None:
-    lint_workspace("tox.toml", content, DEFAULT_TOMBI_CFG)
+    lint_workspace("tox.toml", replace_form_content[replace_form])


### PR DESCRIPTION
Closes #3939.

The conditional `replace = "if"` form added in #3771 was never wired into the JSON schema or its generator, so editors that consume `tox.schema.json` (such as tombi) reject `commands = [{ replace = "if", ... }]` with `Expected a value of type Array, but found Table`. The same gap applied to `replace = "posargs"` and `replace = "glob"`, neither of which had a schema representation either. Only `env` and `ref` were partly modelled.

The fix replaces the loose two-branch `subs` definition with one explicit object per replace form (`replace_env`, `replace_ref`, `replace_posargs`, `replace_glob`, `replace_if`), discriminated by a `const` on `replace`. A `replace_object` union groups all of them and is referenced wherever a list item can extend its parent. The most important case is the items of every `list[Command]` field, which is what makes the extend-into-list pattern from the reproducer lint cleanly. 🔧 Encoding `then`/`else` as the literal `true` schema (rather than `{}`) keeps tombi happy while remaining valid draft-07.

To stop the same class of gap from shipping again, a guard test scrapes `replace_type == \"...\"` tokens from `_replace.py` and fails if any are missing a schema definition or a tombi-lint fixture. The existing tombi-lint suite now hard-fails when `tombi` is absent instead of silently skipping, and `tombi` is declared in the `test` dependency group. A future PR that introduces a sixth replace form cannot reach `main` without updating both the generator and the committed schema.