### PR TITLE
👷 ci(schemastore): sync fork before pushing branch

### DIFF
--- a/.github/workflows/update-schemastore.yaml
+++ b/.github/workflows/update-schemastore.yaml
@@ -19,10 +19,12 @@ jobs:
           persist-credentials: false
       - name: Fork and clone SchemaStore
         run: gh repo fork SchemaStore/schemastore --clone -- /tmp/schemastore
-      - name: Create or reset branch from upstream
+      - name: Sync fork's master with upstream
+        run: gh repo sync "$(gh api user --jq .login)/schemastore" -b master
+      - name: Create or reset branch from synced fork
         run: |
-          git fetch upstream master
-          git switch -C "$BRANCH" upstream/master
+          git fetch origin master
+          git switch -C "$BRANCH" origin/master
         working-directory: /tmp/schemastore
       - name: Update schema and check for changes
         id: diff


### PR DESCRIPTION
The `Update SchemaStore` run for the `4.54.0` tag failed at the push step with `refusing to allow a Personal Access Token to create or update workflow .github/workflows/auto-update.yml without workflow scope`. The `SCHEMASTORE_TOKEN` PAT carries `repo` scope only, which is correct for our use case, so the workflow itself has to stop pushing upstream workflow file changes through the fork.

The root cause is that `gh repo fork --clone` does not sync the fork when it already exists, so `upstream/master` was ahead of `origin/master` by upstream commits that touched `.github/workflows/auto-update.yml`. Force-pushing the `update-tox-schema` branch — built from `upstream/master` — carried those workflow edits into the fork, which trips GitHub's workflow-scope guard.

The fix calls `gh repo sync` on the fork's `master` first (the Sync API path only requires `repo` scope), then bases the working branch off `origin/master`. The resulting push contains a single new commit touching `src/schemas/json/tox.json`, so no workflow files cross the boundary.