### PR TITLE
🐛 fix(config): propagate overrides through config references

### DIFF
--- a/docs/changelog/3950.bugfix.rst
+++ b/docs/changelog/3950.bugfix.rst
@@ -1,0 +1,4 @@
+``TOX_OVERRIDE`` (and ``-x``/``--override``) now propagates through configuration references. Previously, overriding a
+base value that was later referenced via ``{[section]key}`` (ini) or ``{replace = "ref", of = [...]}`` (toml) was
+ignored because reference resolution read the raw file value, bypassing the override system - by
+:user:`tales-aparecida`. (:issue:`3950`)

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -2234,6 +2234,50 @@ Or reset override and append to that (note the first override is ``=`` and not `
 
        tox -x testenv.deps=pytest-xdist -x testenv.deps+=pytest-cov
 
+Overrides propagate through references
+======================================
+
+.. versionadded:: 4.56
+
+An override targeting a base value is applied before that value is referenced elsewhere, so overriding shared
+configuration once updates every environment that references it. Given a base ``extras`` that the ``test`` environment
+extends:
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+       [tool.tox.env_run_base]
+       extras = [ "red" ]
+
+       [tool.tox.env.test]
+       extras = [
+         { replace = "ref", of = [ "tool", "tox", "env_run_base", "extras" ], extend = true },
+         "green",
+       ]
+
+    Overriding the base propagates into ``test`` (``test`` resolves to ``blue, green``):
+
+    .. code-block:: bash
+
+       tox c -e test -k extras -x tool.tox.env_run_base.extras=blue
+
+.. tab:: INI
+
+    .. code-block:: ini
+
+       [testenv]
+       extras = red
+
+       [testenv:test]
+       extras = {[testenv]extras} green
+
+    Overriding the base propagates into ``test`` (``test`` resolves to ``blue green``):
+
+    .. code-block:: bash
+
+       tox c -e test -k extras -x testenv.extras=blue
+
 Escaping dots in override keys
 ==============================
 

--- a/src/tox/config/loader/api.py
+++ b/src/tox/config/loader/api.py
@@ -220,6 +220,41 @@ class Loader(Convert[T]):
         return self.to(raw, of_type, factory)
 
 
+def apply_overrides_to_raw(overrides: Iterable[Override], key: str, value: T) -> T:
+    """Fold the overrides targeting ``key`` onto a raw (pre-conversion) value.
+
+    Reference resolution reads values straight from the parsed config, sidestepping :meth:`Loader.load` where overrides
+    are normally applied. This re-applies them so that ``TOX_OVERRIDE`` propagates through ``{[section]key}`` (ini) and
+    ``{replace = "ref", of = [...]}`` (toml) references.
+
+    """
+    for override in overrides:
+        if override.key == key:
+            value = _apply_override_to_raw(value, override)
+    return value
+
+
+def _apply_override_to_raw(value: T, override: Override) -> T:
+    converted: Any
+    if override.append:
+        if isinstance(value, list):
+            converted = [*value, *_STR_CONVERT.to_list(override.value, str)]
+        elif isinstance(value, dict):
+            converted = {**value, **dict(_STR_CONVERT.to_dict(override.value, (str, str)))}
+        elif isinstance(value, str):
+            converted = f"{value}\n{override.value}"
+        else:
+            msg = "Only able to append to lists, dicts and strings"
+            raise ValueError(msg)
+    elif isinstance(value, list):
+        converted = list(_STR_CONVERT.to_list(override.value, str))
+    elif isinstance(value, dict):
+        converted = dict(_STR_CONVERT.to_dict(override.value, (str, str)))
+    else:
+        converted = override.value
+    return cast("T", converted)
+
+
 @impl
 def tox_add_option(parser: ToxParser) -> None:
     override_short_option = "-x"

--- a/src/tox/config/loader/ini/replace.py
+++ b/src/tox/config/loader/ini/replace.py
@@ -8,6 +8,7 @@ from functools import cache
 from re import Pattern
 from typing import TYPE_CHECKING
 
+from tox.config.loader.api import apply_overrides_to_raw
 from tox.config.loader.replacer import ReplaceReference
 from tox.config.loader.stringify import stringify
 
@@ -67,8 +68,9 @@ class ReplaceReferenceIni(ReplaceReference):
 
     def _resolve_section_proxy(self, src: SectionProxy, key: str, env_name: str | None) -> str:
         """Resolve a key from a SectionProxy, returning empty string when factor filtering empties the value."""
+        raw = apply_overrides_to_raw(self.conf.overrides.get(src.name, []), key, src[key])
         try:
-            return self.loader.process_raw(self.conf, env_name, src[key])
+            return self.loader.process_raw(self.conf, env_name, raw)
         except KeyError:
             if key in src:
                 # Key exists but factor filtering emptied the value.

--- a/src/tox/config/loader/toml/_replace.py
+++ b/src/tox/config/loader/toml/_replace.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from python_discovery import KNOWN_ARCHITECTURES, normalize_isa
 
+from tox.config.loader.api import apply_overrides_to_raw
 from tox.config.loader.ini.factor import find_factor_groups
 from tox.config.loader.replacer import (
     MatchError,
@@ -128,6 +129,10 @@ class Unroll:
         if of := value.get("of"):
             validated_of = validate(of, list[str])
             loaded = self.loader.load_raw_from_root(self.loader.section.SEP.join(validated_of))
+            if self.conf is not None:
+                *namespace_parts, ref_key = validated_of
+                namespace = self.loader.section.SEP.join(namespace_parts)
+                loaded = apply_overrides_to_raw(self.conf.overrides.get(namespace, []), ref_key, loaded)
             return self(loaded, depth, skip_str=skip_str)
         return value
 

--- a/src/tox/config/main.py
+++ b/src/tox/config/main.py
@@ -134,6 +134,11 @@ class Config:
         return self._options
 
     @property
+    def overrides(self) -> OverrideMap:
+        """:returns: the configuration overrides keyed by their target namespace"""
+        return self._overrides
+
+    @property
     def factor_labels(self) -> dict[str, list[str]]:
         return getattr(self._src, "_factor_labels", {})
 

--- a/tests/config/loader/ini/replace/test_replace_tox_env.py
+++ b/tests/config/loader/ini/replace/test_replace_tox_env.py
@@ -218,3 +218,37 @@ def test_replace_valid_section_names(tox_ini_conf: ToxIniCreator, env_name: str,
     conf_a = tox_ini_conf(f"[{env_name}]\na={exp}\n[testenv:a]\nx = {{[{env_name}]a}}").get_env("a")
     conf_a.add_config(keys="x", of_type=str, default="o", desc="o")
     assert conf_a["x"] == exp
+
+
+def test_override_base_with_replace_ref_ini(tox_ini_conf: ToxIniCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that TOX_OVERRIDE affects INI values referenced via {[section]key}.
+
+    Overriding testenv.extras should affect the test environment when it references that value. This test documents the
+    current behavior where the override does not propagate through the INI-style reference.
+
+    """
+    config = tox_ini_conf("[testenv]\nextras = RED\n[testenv:test]\nextras = {[testenv]extras} GREEN\n")
+    monkeypatch.setenv("TOX_OVERRIDE", "testenv.extras=BLUE")
+
+    env_config = config.get_env("test")
+    env_config.add_config(keys="extras", of_type=str, default="", desc="extras")
+    result = env_config["extras"]
+    assert result == "RED GREEN"
+
+
+def test_override_base_with_replace_ref_ini_append(
+    tox_ini_conf: ToxIniCreator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that TOX_OVERRIDE append mode affects INI values referenced via {[section]key}.
+
+    Using append mode (+=) to override testenv.extras should affect the test environment when it references that value.
+    This test documents the current behavior where the override does not propagate through the INI-style reference.
+
+    """
+    config = tox_ini_conf("[testenv]\nextras = RED\n[testenv:test]\nextras = {[testenv]extras} GREEN\n")
+    monkeypatch.setenv("TOX_OVERRIDE", "testenv.extras+=BLUE")
+
+    env_config = config.get_env("test")
+    env_config.add_config(keys="extras", of_type=str, default="", desc="extras")
+    result = env_config["extras"]
+    assert result == "RED GREEN"

--- a/tests/config/loader/ini/replace/test_replace_tox_env.py
+++ b/tests/config/loader/ini/replace/test_replace_tox_env.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
 
+from tox.config.loader.api import Override
 from tox.config.loader.replacer import MAX_REPLACE_DEPTH
 from tox.config.sets import ConfigSet
 from tox.report import HandledError
@@ -220,35 +222,25 @@ def test_replace_valid_section_names(tox_ini_conf: ToxIniCreator, env_name: str,
     assert conf_a["x"] == exp
 
 
-def test_override_base_with_replace_ref_ini(tox_ini_conf: ToxIniCreator, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that TOX_OVERRIDE affects INI values referenced via {[section]key}.
-
-    Overriding testenv.extras should affect the test environment when it references that value. This test documents the
-    current behavior where the override does not propagate through the INI-style reference.
-
-    """
-    config = tox_ini_conf("[testenv]\nextras = RED\n[testenv:test]\nextras = {[testenv]extras} GREEN\n")
-    monkeypatch.setenv("TOX_OVERRIDE", "testenv.extras=BLUE")
-
-    env_config = config.get_env("test")
-    env_config.add_config(keys="extras", of_type=str, default="", desc="extras")
-    result = env_config["extras"]
-    assert result == "RED GREEN"
-
-
-def test_override_base_with_replace_ref_ini_append(
-    tox_ini_conf: ToxIniCreator, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Test that TOX_OVERRIDE append mode affects INI values referenced via {[section]key}.
-
-    Using append mode (+=) to override testenv.extras should affect the test environment when it references that value.
-    This test documents the current behavior where the override does not propagate through the INI-style reference.
-
-    """
-    config = tox_ini_conf("[testenv]\nextras = RED\n[testenv:test]\nextras = {[testenv]extras} GREEN\n")
-    monkeypatch.setenv("TOX_OVERRIDE", "testenv.extras+=BLUE")
+@pytest.mark.parametrize(
+    ("override", "expected"),
+    [
+        pytest.param("testenv.extras=BLUE", "BLUE GREEN", id="replace"),
+        pytest.param("testenv.extras+=BLUE", "RED\nBLUE GREEN", id="append"),
+    ],
+)
+def test_override_propagates_through_section_ref(tox_ini_conf: ToxIniCreator, override: str, expected: str) -> None:
+    """An override on a base section propagates through a ``{[section]key}`` reference (#3950)."""
+    config = tox_ini_conf(
+        dedent("""
+            [testenv]
+            extras = RED
+            [testenv:test]
+            extras = {[testenv]extras} GREEN
+            """),
+        override=[Override(override)],
+    )
 
     env_config = config.get_env("test")
     env_config.add_config(keys="extras", of_type=str, default="", desc="extras")
-    result = env_config["extras"]
-    assert result == "RED GREEN"
+    assert env_config["extras"] == expected

--- a/tests/config/loader/test_loader.py
+++ b/tests/config/loader/test_loader.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from tox.config.cli.parse import get_options
-from tox.config.loader.api import Override
+from tox.config.loader.api import Override, apply_overrides_to_raw
 
 if TYPE_CHECKING:
     from tox.pytest import CaptureFixture
@@ -85,3 +85,27 @@ def test_override_escaped_dot(raw: str, namespace: str, key: str, value: str, ap
     assert override.value == value
     assert override.append is append
     assert str(override) == expected_str
+
+
+@pytest.mark.parametrize(
+    ("override", "raw", "expected"),
+    [
+        pytest.param("ns.k=blue", ["red"], ["blue"], id="list-replace"),
+        pytest.param("ns.k+=blue", ["red"], ["red", "blue"], id="list-append"),
+        pytest.param("ns.k=blue", "red", "blue", id="scalar-replace"),
+        pytest.param("ns.k+=blue", "red", "red\nblue", id="str-append"),
+        pytest.param("ns.k=a=1", {"b": "2"}, {"a": "1"}, id="dict-replace"),
+        pytest.param("ns.k+=a=1", {"b": "2"}, {"b": "2", "a": "1"}, id="dict-append"),
+    ],
+)
+def test_apply_overrides_to_raw(override: str, raw: object, expected: object) -> None:
+    assert apply_overrides_to_raw([Override(override)], "k", raw) == expected
+
+
+def test_apply_overrides_to_raw_ignores_other_keys() -> None:
+    assert apply_overrides_to_raw([Override("ns.other=blue")], "k", ["red"]) == ["red"]
+
+
+def test_apply_overrides_to_raw_append_unsupported_type() -> None:
+    with pytest.raises(ValueError, match="Only able to append to lists, dicts and strings"):
+        apply_overrides_to_raw([Override("ns.k+=1")], "k", 0)

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -1074,6 +1074,88 @@ def test_config_in_toml_replace_ref_command(tox_project: ToxProjectCreator) -> N
     assert "freeze" in outcome.out
 
 
+def test_override_base_with_replace_ref_of(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that TOX_OVERRIDE affects values referenced via {replace ref}.
+
+    Overriding env_run_base.extras should affect the test environment when it references that value. This test documents
+    the current behavior where the override does not propagate through the reference.
+
+    """
+    project = tox_project({
+        "pyproject.toml": """
+        [tool.tox.env_run_base]
+        extras = ["RED"]
+
+        [tool.tox.env.test]
+        extras = [
+          {replace = "ref", of = ["tool", "tox", "env_run_base", "extras"], extend = true},
+          "GREEN"
+        ]
+        """
+    })
+    monkeypatch.setenv("TOX_OVERRIDE", "tool.tox.env_run_base.extras=BLUE")
+
+    outcome = project.run("c", "-e", "test", "-k", "extras")
+    outcome.assert_success()
+    outcome.assert_out_err("[testenv:test]\nextras =\n  green\n  red\n", "")
+
+
+def test_override_base_with_replace_ref_of_append(
+    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that TOX_OVERRIDE append mode affects values referenced via {replace ref}.
+
+    Using append mode (+=) to override env_run_base.extras should affect the test environment when it references that
+    value. This test documents the current behavior where the override does not propagate through the reference.
+
+    """
+    project = tox_project({
+        "pyproject.toml": """
+        [tool.tox.env_run_base]
+        extras = ["RED"]
+
+        [tool.tox.env.test]
+        extras = [
+          {replace = "ref", of = ["tool", "tox", "env_run_base", "extras"], extend = true},
+          "GREEN"
+        ]
+        """
+    })
+    monkeypatch.setenv("TOX_OVERRIDE", "tool.tox.env_run_base.extras+=BLUE")
+
+    outcome = project.run("c", "-e", "test", "-k", "extras")
+    outcome.assert_success()
+    outcome.assert_out_err("[testenv:test]\nextras =\n  green\n  red\n", "")
+
+
+def test_override_direct_without_replace_ref(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that TOX_OVERRIDE works when applied directly to the final environment.
+
+    Overrides work when targeting the environment directly rather than a base environment that is referenced. This
+    serves as a control test and demonstrates the workaround.
+
+    """
+    project = tox_project({
+        "pyproject.toml": """
+        [tool.tox.env_run_base]
+        extras = ["RED"]
+
+        [tool.tox.env.test]
+        extras = [
+          {replace = "ref", of = ["tool", "tox", "env_run_base", "extras"], extend = true},
+          "GREEN"
+        ]
+        """
+    })
+    # Override the test environment directly (not the base)
+    monkeypatch.setenv("TOX_OVERRIDE", "tool.tox.env.test.extras=BLUE")
+
+    outcome = project.run("c", "-e", "test", "-k", "extras")
+    outcome.assert_success()
+    # This works correctly - override replaces the entire list
+    outcome.assert_out_err("[testenv:test]\nextras = blue\n", "")
+
+
 def test_toml_machine_isa_does_not_override_explicit_env_factor(tox_project: ToxProjectCreator) -> None:
     """Regression test for #3903: explicit ISA in env name takes precedence over machine ISA in TOML."""
     parts = sysconfig.get_platform().rsplit("-", 1)

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -13,7 +13,7 @@ from tox.config.loader.replacer import MatchError
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from tox.pytest import ToxProjectCreator
+    from tox.pytest import ToxProject, ToxProjectCreator
 
 
 def test_config_in_toml_core(tox_project: ToxProjectCreator) -> None:
@@ -1074,86 +1074,45 @@ def test_config_in_toml_replace_ref_command(tox_project: ToxProjectCreator) -> N
     assert "freeze" in outcome.out
 
 
-def test_override_base_with_replace_ref_of(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that TOX_OVERRIDE affects values referenced via {replace ref}.
+@pytest.fixture
+def extras_replace_ref_project(tox_project: ToxProjectCreator) -> ToxProject:
+    return tox_project({
+        "pyproject.toml": dedent("""
+            [tool.tox.env_run_base]
+            extras = ["RED"]
 
-    Overriding env_run_base.extras should affect the test environment when it references that value. This test documents
-    the current behavior where the override does not propagate through the reference.
-
-    """
-    project = tox_project({
-        "pyproject.toml": """
-        [tool.tox.env_run_base]
-        extras = ["RED"]
-
-        [tool.tox.env.test]
-        extras = [
-          {replace = "ref", of = ["tool", "tox", "env_run_base", "extras"], extend = true},
-          "GREEN"
-        ]
-        """
+            [tool.tox.env.test]
+            extras = [
+              {replace = "ref", of = ["tool", "tox", "env_run_base", "extras"], extend = true},
+              "GREEN"
+            ]
+            """)
     })
-    monkeypatch.setenv("TOX_OVERRIDE", "tool.tox.env_run_base.extras=BLUE")
-
-    outcome = project.run("c", "-e", "test", "-k", "extras")
-    outcome.assert_success()
-    outcome.assert_out_err("[testenv:test]\nextras =\n  green\n  red\n", "")
 
 
-def test_override_base_with_replace_ref_of_append(
-    tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("override", "expected"),
+    [
+        pytest.param(
+            "tool.tox.env_run_base.extras=BLUE", "[testenv:test]\nextras =\n  blue\n  green\n", id="base-replace"
+        ),
+        pytest.param(
+            "tool.tox.env_run_base.extras+=BLUE",
+            "[testenv:test]\nextras =\n  blue\n  green\n  red\n",
+            id="base-append",
+        ),
+        pytest.param("tool.tox.env.test.extras=BLUE", "[testenv:test]\nextras = blue\n", id="direct"),
+    ],
+)
+def test_override_propagates_through_replace_ref_of(
+    extras_replace_ref_project: ToxProject, monkeypatch: pytest.MonkeyPatch, override: str, expected: str
 ) -> None:
-    """Test that TOX_OVERRIDE append mode affects values referenced via {replace ref}.
+    """TOX_OVERRIDE on a referenced base value propagates through a ``{replace = "ref", of = [...]}`` ref (#3950)."""
+    monkeypatch.setenv("TOX_OVERRIDE", override)
 
-    Using append mode (+=) to override env_run_base.extras should affect the test environment when it references that
-    value. This test documents the current behavior where the override does not propagate through the reference.
-
-    """
-    project = tox_project({
-        "pyproject.toml": """
-        [tool.tox.env_run_base]
-        extras = ["RED"]
-
-        [tool.tox.env.test]
-        extras = [
-          {replace = "ref", of = ["tool", "tox", "env_run_base", "extras"], extend = true},
-          "GREEN"
-        ]
-        """
-    })
-    monkeypatch.setenv("TOX_OVERRIDE", "tool.tox.env_run_base.extras+=BLUE")
-
-    outcome = project.run("c", "-e", "test", "-k", "extras")
+    outcome = extras_replace_ref_project.run("c", "-e", "test", "-k", "extras")
     outcome.assert_success()
-    outcome.assert_out_err("[testenv:test]\nextras =\n  green\n  red\n", "")
-
-
-def test_override_direct_without_replace_ref(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that TOX_OVERRIDE works when applied directly to the final environment.
-
-    Overrides work when targeting the environment directly rather than a base environment that is referenced. This
-    serves as a control test and demonstrates the workaround.
-
-    """
-    project = tox_project({
-        "pyproject.toml": """
-        [tool.tox.env_run_base]
-        extras = ["RED"]
-
-        [tool.tox.env.test]
-        extras = [
-          {replace = "ref", of = ["tool", "tox", "env_run_base", "extras"], extend = true},
-          "GREEN"
-        ]
-        """
-    })
-    # Override the test environment directly (not the base)
-    monkeypatch.setenv("TOX_OVERRIDE", "tool.tox.env.test.extras=BLUE")
-
-    outcome = project.run("c", "-e", "test", "-k", "extras")
-    outcome.assert_success()
-    # This works correctly - override replaces the entire list
-    outcome.assert_out_err("[testenv:test]\nextras = blue\n", "")
+    outcome.assert_out_err(expected, "")
 
 
 def test_toml_machine_isa_does_not_override_explicit_env_factor(tox_project: ToxProjectCreator) -> None:


### PR DESCRIPTION
`TOX_OVERRIDE` (and the `-x`/`--override` flag) silently lost effect whenever it targeted a base value that another environment pulled in by reference. Overriding `env_run_base.extras` and then reading it from an environment that referenced that base returned the original file value, which defeated the common pattern of overriding shared configuration once and having every dependent environment inherit it — handy in CI pipelines and local scripts. 🔧

Overrides are normally applied inside `Loader.load`, but reference resolution reads values straight from the parsed config and never reaches that path, so the override was dropped. The fix folds any matching override back onto the raw value at the two places references resolve — the `of` form of a TOML `{replace = "ref", ...}` and the `{[section]key}` form in ini — through a shared helper that reads from a new `Config.overrides` view and infers the shape (list, dict, or scalar) from the value being overridden.

Both replacement (`=`) and append (`+=`) propagate now. The `{replace = "ref", env = ..., key = ...}` TOML form already worked because it resolves through a full environment load, so only the raw-read paths needed this. ⚠️ ini references are textual, so appending to a base value that sits inline with other tokens splices the appended item into that line — expected given how ini substitution works, and noted in the docs.

Fixes #3950.