### PR TITLE
Drop obsolete ty: ignore directives

### DIFF
--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -273,7 +273,7 @@ class EnvConfigSet(ConfigSet):
                 if isinstance(v, str):
                     return True
                 if isinstance(v, dict):
-                    return "value" in v and isinstance(v.get("value"), str)  # ty: ignore[invalid-argument-type] # https://github.com/astral-sh/ty/issues/2374
+                    return "value" in v and isinstance(v.get("value"), str)
                 return False
 
             if not (

--- a/src/tox/session/cmd/run/parallel.py
+++ b/src/tox/session/cmd/run/parallel.py
@@ -65,7 +65,7 @@ def parallel_flags(
         type=parse_num_processes,
         default=default_parallel,
         metavar="VAL",
-        **({"nargs": "?"} if no_args else {}),  # ty: ignore[invalid-argument-type] # https://github.com/astral-sh/ty/issues/2586
+        **({"nargs": "?"} if no_args else {}),
     )
     our.add_argument(
         "-o",


### PR DESCRIPTION
The two `# ty: ignore[invalid-argument-type]` directives referenced upstream ty issues ([#2374](https://github.com/astral-sh/ty/issues/2374) and [#2586](https://github.com/astral-sh/ty/issues/2586)) that have since been fixed. The latest `ty` now flags them as `unused-ignore-comment`, and since the check runs with `--error-on-warning`, the scheduled `type`/`type-min` jobs on main fail. Remove the now-unneeded directives.