### PR TITLE
docs: Use double backquotes for git command in `development.rst`

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -38,7 +38,7 @@ section. This section contains only highlights; it's not a substitute for readin
     generated HTML files under :file:`.tox/docs_out/html/`. The required changelog entry can be viewed at the "Release
     History" link at the left.
   - ``tox -e fix`` to lint code, documentation and any other changes to the repo. This will also fix the code and write
-    out the changed files; you can update your commit with `git commit --amend`.
+    out the changed files; you can update your commit with ``git commit --amend``.
 
 *****************
  Getting started


### PR DESCRIPTION
Shell commands should be wrapped in double backquotes instead of single backquotes, for consistency with the rest of the document.

<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->

- [x] ran the linter to address style issues (`tox -e fix`)
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
