### PR TITLE
docs: replace http://tox.readthedocs.org with https://tox.wiki

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,5 +7,5 @@ As a reminder, all contributors are expected to follow our [Code of Conduct][coc
 
 ## Development Documentation
 
-Our [development documentation](http://tox.readthedocs.org/en/latest/development.html#development) contains details on
+Our [development documentation](https://tox.wiki/en/latest/development.html) contains details on
 how to get started with contributing to `tox`, and details of our development processes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!-- Thank you for your contribution!
 
 Please, make sure you address all the checklists (for details on how see
-[development documentation](http://tox.readthedocs.org/en/latest/development.html#development))! -->
+[development documentation](https://tox.wiki/en/latest/development.html))! -->
 
 - [ ] ran the linter to address style issues (`tox -e fix`)
 - [ ] wrote descriptive pull request text

--- a/docs/changelog/3963.doc.rst
+++ b/docs/changelog/3963.doc.rst
@@ -1,0 +1,1 @@
+Replace stale ``http://tox.readthedocs.org`` URL with ``https://tox.wiki`` in ``pyproject.toml`` (``Homepage``), ``.github/CONTRIBUTING.md``, and ``.github/PULL_REQUEST_TEMPLATE.md``.

--- a/docs/changelog/3963.doc.rst
+++ b/docs/changelog/3963.doc.rst
@@ -1,1 +1,2 @@
-Replace stale ``http://tox.readthedocs.org`` URL with ``https://tox.wiki`` in ``pyproject.toml`` (``Homepage``), ``.github/CONTRIBUTING.md``, and ``.github/PULL_REQUEST_TEMPLATE.md``.
+Replace stale ``http://tox.readthedocs.org`` URL with ``https://tox.wiki`` in ``pyproject.toml`` (``Homepage``),
+``.github/CONTRIBUTING.md``, and ``.github/PULL_REQUEST_TEMPLATE.md``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ optional-dependencies.testing = [
 ]
 urls."Release Notes" = "https://tox.wiki/en/latest/changelog.html"
 urls.Documentation = "https://tox.wiki"
-urls.Homepage = "http://tox.readthedocs.org"
+urls.Homepage = "https://tox.wiki"
 urls.Source = "https://github.com/tox-dev/tox"
 urls.Tracker = "https://github.com/tox-dev/tox/issues"
 scripts.tox = "tox.run:run"


### PR DESCRIPTION
## What

Replace three stale `http://tox.readthedocs.org` URLs with the current canonical `https://tox.wiki` domain.

| File | Old URL | New URL |
|------|---------|--------|
| `pyproject.toml` | `http://tox.readthedocs.org` | `https://tox.wiki` |
| `.github/CONTRIBUTING.md` | `http://tox.readthedocs.org/en/latest/development.html#development` | `https://tox.wiki/en/latest/development.html` |
| `.github/PULL_REQUEST_TEMPLATE.md` | `http://tox.readthedocs.org/en/latest/development.html#development` | `https://tox.wiki/en/latest/development.html` |

## Why

`pyproject.toml` already correctly uses `https://tox.wiki` for the `Documentation` and `Release Notes` URLs — the `Homepage` entry and the two GitHub templates were left behind when the project migrated to the `tox.wiki` domain. This PR brings them in line with the rest of the project metadata.

## Verification

This is a documentation/metadata-only change. No code paths are affected.

- [x] ran the linter to address style issues (`tox -e fix`) — N/A for plain URL text changes in Markdown/TOML
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix — N/A (URL-only change, no code affected)
- [x] added news fragment in `docs/changelog` folder — added `docs/changelog/3963.doc.rst`
- [x] updated/extended the documentation — this IS the documentation change