### PR TITLE
🐛 fix(config): restore skip_missing_interpreters default to False

### DIFF
--- a/docs/changelog/3965.bugfix.rst
+++ b/docs/changelog/3965.bugfix.rst
@@ -1,0 +1,4 @@
+The default value of ``skip_missing_interpreters`` changed from ``True`` to ``False`` — missing interpreters now fail
+the run by default, matching tox 3 behavior. The tox 4 rewrite unintentionally changed this default. To restore the
+previous (incorrect) behavior, set ``skip_missing_interpreters = true`` in your tox configuration or pass
+``--skip-missing-interpreters`` on the command line.

--- a/src/tox/tox_env/python/runner.py
+++ b/src/tox/tox_env/python/runner.py
@@ -226,7 +226,7 @@ def add_skip_missing_interpreters_to_core(core: CoreConfigSet, options: Parsed) 
 
     core.add_config(
         keys=["skip_missing_interpreters"],
-        default=True,
+        default=False,
         of_type=bool,
         post_process=skip_missing_interpreters_post_process,
         desc="skip running missing interpreters",

--- a/tests/tox_env/python/test_python_runner.py
+++ b/tests/tox_env/python/test_python_runner.py
@@ -167,6 +167,12 @@ def test_config_skip_missing_interpreters(
     assert result.code == (0 if expected else 1)
 
 
+def test_skip_missing_interpreters_default_is_false(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.toml": 'env_list = ["py4"]'})
+    result = project.run()
+    assert result.code == 1
+
+
 SYS_PY_VER = "".join(str(i) for i in sys.version_info[0:2]) + (
     "t" if sysconfig.get_config_var("Py_GIL_DISABLED") == 1 else ""
 )


### PR DESCRIPTION
The tox 4 rewrite unintentionally changed the default of `skip_missing_interpreters` from `False` to `True`. This means tox reports success even when configured environments can't find their Python interpreter — a typo in `env_list` or a genuinely missing interpreter goes unnoticed.

This restores the tox 3 behavior: missing interpreters fail the run by default. Users who rely on the current behavior can set `skip_missing_interpreters = true` in their tox config or pass `--skip-missing-interpreters` on the command line.