### PR TITLE
✨ feat(virtualenv): auto-pin virtualenv for end-of-life Python

### DIFF
--- a/docs/changelog/3960.doc.rst
+++ b/docs/changelog/3960.doc.rst
@@ -1,0 +1,2 @@
+Fix nested list items being rendered with continued numbering instead of as sub-items in ``development.rst``,
+``onboarding.rst`` and ``explanation.rst``.

--- a/docs/changelog/3965.feature.rst
+++ b/docs/changelog/3965.feature.rst
@@ -1,0 +1,5 @@
+Derive :ref:`virtualenv_spec` automatically: when an environment targets a Python version the installed
+:pypi:`virtualenv` can no longer create (e.g. ``py38`` with virtualenv ``21.5+``), tox now pins the newest virtualenv
+that still supports it and bootstraps it for that environment only. The downgrade happens only when every ``base_python``
+candidate is unsupported, so environments targeting current interpreters are unaffected. This fixes ``py38`` (and other
+end-of-life interpreters) being silently skipped after a virtualenv upgrade - by :user:`gaborbernat`. (:issue:`3965`)

--- a/docs/changelog/3965.feature.rst
+++ b/docs/changelog/3965.feature.rst
@@ -1,5 +1,6 @@
 Derive :ref:`virtualenv_spec` automatically: when an environment targets a Python version the installed
 :pypi:`virtualenv` can no longer create (e.g. ``py38`` with virtualenv ``21.5+``), tox now pins the newest virtualenv
-that still supports it and bootstraps it for that environment only. The downgrade happens only when every ``base_python``
-candidate is unsupported, so environments targeting current interpreters are unaffected. This fixes ``py38`` (and other
-end-of-life interpreters) being silently skipped after a virtualenv upgrade - by :user:`gaborbernat`. (:issue:`3965`)
+that still supports it and bootstraps it for that environment only. The downgrade happens only when every
+``base_python`` candidate is unsupported, so environments targeting current interpreters are unaffected. This fixes
+``py38`` (and other end-of-life interpreters) being silently skipped after a virtualenv upgrade - by
+:user:`gaborbernat`. (:issue:`3965`)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -304,10 +304,10 @@ Navigate to `Actions > Prepare Release <https://github.com/tox-dev/tox/actions/w
 2. Select the branch (usually ``main``).
 3. Choose the version bump type:
 
-   4. ``auto`` (default) - Automatically bump minor if feature changelogs exist, otherwise bump patch.
-   5. ``major`` - Bump major version (e.g., 4.0.0 → 5.0.0).
-   6. ``minor`` - Bump minor version (e.g., 4.27.0 → 4.28.0).
-   7. ``patch`` - Bump patch version (e.g., 4.27.0 → 4.27.1).
+   - ``auto`` (default) - Automatically bump minor if feature changelogs exist, otherwise bump patch.
+   - ``major`` - Bump major version (e.g., 4.0.0 → 5.0.0).
+   - ``minor`` - Bump minor version (e.g., 4.27.0 → 4.28.0).
+   - ``patch`` - Bump patch version (e.g., 4.27.0 → 4.27.1).
 
 4. Click "Run workflow".
 

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -95,11 +95,10 @@ The primary tox states are:
 
    Steps 2 and 3 can be selectively skipped with CLI flags:
 
-   3. ``--skip-pkg-install`` skips step 3 only (packaging and package installation), while still installing
-      dependencies.
-   4. ``--skip-env-install`` skips both steps 2 and 3 entirely, reusing the environment as-is. This is useful when
-      working offline or when the environment is already fully set up from a previous run. See :ref:`skip-env-install`
-      for practical usage.
+   - ``--skip-pkg-install`` skips step 3 only (packaging and package installation), while still installing dependencies.
+   - ``--skip-env-install`` skips both steps 2 and 3 entirely, reusing the environment as-is. This is useful when
+     working offline or when the environment is already fully set up from a previous run. See :ref:`skip-env-install`
+     for practical usage.
 
    4. **Extra setup commands** (optional): run the :ref:`extra_setup_commands` specified. These execute after all
       installations complete but before test commands, and run during the ``--notest`` phase.
@@ -677,8 +676,14 @@ installed virtualenv supports all target Python versions, but breaks down at the
 only import one virtualenv version per process, projects that need both old and new Pythons in a single ``tox.toml`` hit
 a wall.
 
-The :ref:`virtualenv_spec` setting resolves this by decoupling the virtualenv used for environment creation from the one
-tox imports. When set, tox:
+tox closes this gap automatically: for each environment it checks the targeted :ref:`base_python` against the installed
+virtualenv's `version support timeline <https://virtualenv.pypa.io/en/latest/reference/compatibility.html>`_, and when
+that interpreter can no longer be created, it derives a :ref:`virtualenv_spec` pinning the newest virtualenv that still
+can. To stay conservative it only downgrades when *every* ``base_python`` candidate is unsupported -- otherwise tox may
+resolve to a creatable interpreter and no bootstrap is needed.
+
+The :ref:`virtualenv_spec` setting (whether derived or set explicitly) resolves this by decoupling the virtualenv used
+for environment creation from the one tox imports. When non-empty, tox:
 
 1. Creates a bootstrap venv (using the stdlib ``venv`` module) in ``.tox/.virtualenv-bootstrap/``.
 2. Installs the specified virtualenv version into that bootstrap venv via pip.
@@ -688,9 +693,9 @@ The bootstrap is content-addressed by a hash of the spec string, so different sp
 file lock protects against concurrent bootstrap creation (relevant in parallel mode). Once bootstrapped, subsequent runs
 skip directly to step 3.
 
-When ``virtualenv_spec`` is empty (the default), tox uses the imported virtualenv with zero overhead -- the subprocess
-path only activates when explicitly configured. The spec is included in the environment cache key, so changing it
-triggers automatic recreation.
+When ``virtualenv_spec`` resolves to empty, tox uses the imported virtualenv with zero overhead -- the subprocess path
+only activates for a non-empty spec. The spec is included in the environment cache key, so changing it (or a virtualenv
+upgrade that changes the derived value) triggers automatic recreation.
 
 This design mirrors tox's own auto-provisioning mechanism (``requires`` / ``min_version``), where tox bootstraps itself
 into a separate environment when the running installation doesn't meet the declared requirements.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -1771,8 +1771,8 @@ virtualenv, so a single ``tox.toml`` can mix end-of-life and current interpreter
          env_list = py38, py313
 
 Set :ref:`virtualenv_spec` explicitly only to override the automatically chosen pin. Prefer it over pinning virtualenv
-through the top-level ``requires``: ``requires`` swaps the virtualenv for the whole tox process, which then cannot create
-the newer interpreters, whereas ``virtualenv_spec`` is resolved per environment.
+through the top-level ``requires``: ``requires`` swaps the virtualenv for the whole tox process, which then cannot
+create the newer interpreters, whereas ``virtualenv_spec`` is resolved per environment.
 
 ***************************************
  Use tox with different build backends

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -985,7 +985,8 @@ logged as warnings and never block the recreation itself.
 *****************************************
 
 When a project must support both very old (e.g. Python 3.6) and very new (e.g. Python 3.15) interpreters, no single
-virtualenv release covers both. Use :ref:`virtualenv_spec` to pin a different virtualenv version per environment:
+virtualenv release covers both. tox handles this automatically -- each environment whose target Python the installed
+virtualenv can no longer create transparently bootstraps a compatible older virtualenv (see :ref:`virtualenv_spec`):
 
 .. tab:: TOML
 
@@ -996,9 +997,6 @@ virtualenv release covers both. Use :ref:`virtualenv_spec` to pin a different vi
          [env_run_base]
          deps = ["pytest"]
          commands = [["pytest"]]
-
-         [env."3.6"]
-         virtualenv_spec = "virtualenv<20.22.0"
 
 .. tab:: INI
 
@@ -1011,11 +1009,9 @@ virtualenv release covers both. Use :ref:`virtualenv_spec` to pin a different vi
          deps = pytest
          commands = pytest
 
-         [testenv:3.6]
-         virtualenv_spec = virtualenv<20.22.0
-
-The ``3.6`` environment uses an older virtualenv that still supports Python 3.6, while other environments use the
+The ``3.6`` environment automatically uses an older virtualenv that still supports Python 3.6, while the others use the
 default (imported) virtualenv. The first run bootstraps the pinned version; subsequent runs reuse the cached bootstrap.
+Set :ref:`virtualenv_spec` on an environment to override the version tox picks.
 
 .. _howto_generate_matrix:
 
@@ -1748,26 +1744,35 @@ See :ref:`generative-environment-list` for the full range syntax reference.
  Test end-of-life Python versions
 **********************************
 
-tox uses :pypi:`virtualenv` under the hood. Newer virtualenv versions drop support for older Python interpreters:
+tox uses :pypi:`virtualenv` under the hood, and newer virtualenv versions drop the ability to create environments for
+older Python interpreters:
 
 - `virtualenv 20.22.0 <https://virtualenv.pypa.io/en/latest/changelog.html#v20-22-0-2023-04-19>`_ dropped Python 3.6 and
   earlier
-- `virtualenv 20.27.0 <https://virtualenv.pypa.io/en/latest/changelog.html#v20-27-0-2024-10-17>`_ dropped Python 3.7
+- `virtualenv 21.5.0 <https://virtualenv.pypa.io/en/latest/changelog.html#v21-5-0-2026-06-13>`_ dropped Python 3.8 and
+  earlier
 
-To test against these versions, pin virtualenv:
+You do not need to configure anything for this: tox inspects the :ref:`base_python` of each environment and, when the
+installed virtualenv can no longer create that interpreter, automatically pins a compatible older virtualenv for that
+environment only (see :ref:`virtualenv_spec`). Environments targeting supported Pythons keep using the installed
+virtualenv, so a single ``tox.toml`` can mix end-of-life and current interpreters:
 
 .. tab:: TOML
 
     .. code-block:: toml
 
-         requires = ["virtualenv<20.22.0"]
+         env_list = ["py38", "py313"]  # py38 transparently bootstraps an older virtualenv, py313 does not
 
 .. tab:: INI
 
     .. code-block:: ini
 
          [tox]
-         requires = virtualenv<20.22.0
+         env_list = py38, py313
+
+Set :ref:`virtualenv_spec` explicitly only to override the automatically chosen pin. Prefer it over pinning virtualenv
+through the top-level ``requires``: ``requires`` swaps the virtualenv for the whole tox process, which then cannot create
+the newer interpreters, whereas ``virtualenv_spec`` is resolved per environment.
 
 ***************************************
  Use tox with different build backends

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -546,12 +546,12 @@ for configuration in this order:
 1. If ``--conf`` is specified, it uses that file directly.
 2. Otherwise, it walks up from CWD looking for:
 
-   3. ``tox.toml`` which uses `TomlSource <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/toml_.py>`_.
-   4. ``pyproject.toml`` (with ``[tool.tox]``) which uses `PyProjectTomlSource
-      <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/pyproject.py>`_.
-   5. ``tox.ini`` which uses `IniSource <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/ini.py>`_.
-   6. ``setup.cfg`` (with ``[tox:tox]``) which uses `SetupCfgSource
-      <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/setup_cfg.py>`_.
+   - ``tox.toml`` which uses `TomlSource <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/toml_.py>`_.
+   - ``pyproject.toml`` (with ``[tool.tox]``) which uses `PyProjectTomlSource
+     <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/pyproject.py>`_.
+   - ``tox.ini`` which uses `IniSource <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/ini.py>`_.
+   - ``setup.cfg`` (with ``[tox:tox]``) which uses `SetupCfgSource
+     <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/setup_cfg.py>`_.
 
 3. If nothing is found, it creates an empty `IniSource
    <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/ini.py>`_ at CWD.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1907,15 +1907,22 @@ Python virtual environment
     :keys: virtualenv_spec
     :default: ""
     :version_added: 4.42
+    :version_changed: 4.56
 
     A :pep:`440` version specifier for virtualenv (e.g. ``virtualenv<20.22.0``). When set, tox bootstraps the specified
     virtualenv version into an isolated environment and drives it via subprocess, instead of using the imported
     virtualenv library. This enables environments targeting Python versions that are incompatible with the virtualenv
     installed alongside tox.
 
+    Left empty (the default), tox derives the value automatically: it inspects the environment's :ref:`base_python` and,
+    only when the installed virtualenv can no longer *create* that interpreter, pins the newest virtualenv that still
+    can. The pin is applied for that environment alone, so environments targeting supported Pythons keep using the
+    imported virtualenv with zero overhead. tox downgrades only when every ``base_python`` candidate is unsupported by
+    the installed virtualenv -- if any candidate would resolve to a creatable interpreter, no pin is applied. Set the
+    value explicitly to override this choice.
+
     The bootstrap environment is cached under ``.tox/.virtualenv-bootstrap/`` (keyed by a hash of the spec string) and
-    reused across runs. Concurrent access is protected by a file lock. When the spec is empty (the default), tox uses
-    the imported virtualenv with zero overhead.
+    reused across runs. Concurrent access is protected by a file lock.
 
     .. tab:: TOML
 

--- a/docs/tox_conf.py
+++ b/docs/tox_conf.py
@@ -24,6 +24,7 @@ class ToxConfig(SphinxDirective):
     option_spec: ClassVar[dict[str, Callable[[str], Any]]] = {
         "keys": unchanged_required,
         "version_added": unchanged,
+        "version_changed": unchanged,
         "version_deprecated": unchanged,
         "default": unchanged,
         "constant": flag,
@@ -70,6 +71,10 @@ class ToxConfig(SphinxDirective):
         if "version_added" in self.options:
             line += Text(" 📢 added in ")
             ver = self.options["version_added"]
+            line += literal(ver, ver)
+        if "version_changed" in self.options:
+            line += Text(" 🔄 changed in ")
+            ver = self.options["version_changed"]
             line += literal(ver, ver)
         if "version_deprecated" in self.options:
             line += Text(" ⚠️ deprecated in ")

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -504,7 +504,7 @@
         },
         "virtualenv_spec": {
           "type": "string",
-          "description": "PEP 440 version spec for virtualenv (e.g. virtualenv<20.22.0). When set, tox bootstraps this version in an isolated environment and runs it via subprocess, enabling Python versions incompatible with the installed virtualenv."
+          "description": "PEP 440 version spec for virtualenv (e.g. virtualenv<20.22.0). When set, tox bootstraps this version in an isolated environment and runs it via subprocess, enabling Python versions incompatible with the installed virtualenv. Left empty it is derived automatically: tox pins an older virtualenv only when the installed one can no longer create the targeted Python version."
         },
         "skip_install": {
           "type": "boolean",

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -300,6 +300,7 @@ def _auto_virtualenv_spec(base_pythons: list[str], installed: str) -> str:
     Returns an empty string unless *every* candidate in ``base_pythons`` targets a Python the installed virtualenv can
     no longer create an environment for -- only then is a downgrade guaranteed to be required, since tox picks the first
     candidate that resolves on the host and any supported candidate offers a path to success without bootstrapping.
+
     """
     installed_version = Version(installed)
     floors: list[Version] = []

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -136,7 +136,6 @@ class VirtualEnv(Python, ABC):
     def _create_subprocess_session(self, spec: str, env: dict[str, str]) -> SubprocessSession:
         from .subprocess_adapter import ensure_bootstrap, probe_python  # noqa: PLC0415
 
-        bootstrap_python = ensure_bootstrap(cast("Path", self.core["work_dir"]), spec)
         try_first_with = getattr(self.options, "discover", None)
         interpreter: SubprocessPythonInfo | None = None
         for base_python in cast("list[str]", self.conf["base_python"]):
@@ -145,7 +144,9 @@ class VirtualEnv(Python, ABC):
                 continue
             if (interpreter := probe_python(executable)) is not None:
                 break
-        return SubprocessSession(self.env_dir, bootstrap_python, env, interpreter)
+        # only pay the bootstrap cost once an interpreter is found; a missing one skips without it
+        bootstrap = ensure_bootstrap(cast("Path", self.core["work_dir"]), spec) if interpreter is not None else None
+        return SubprocessSession(self.env_dir, bootstrap, env, interpreter)
 
     def _create_imported_session(self, env: dict[str, str]) -> Session:
         env_dir = [str(self.env_dir)]

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -25,6 +25,7 @@ from tox.tox_env.python.pip.pip_install import Pip
 from tox.tox_env.python.virtual_env.subprocess_adapter import SubprocessCreator, SubprocessPythonInfo, SubprocessSession
 
 if TYPE_CHECKING:
+    from python_discovery import PyInfoCache
     from virtualenv.create.creator import Creator
     from virtualenv.create.describe import Describe
     from virtualenv.discovery.py_info import PythonInfo as VirtualenvPythonInfo
@@ -137,9 +138,10 @@ class VirtualEnv(Python, ABC):
         from .subprocess_adapter import ensure_bootstrap, probe_python  # noqa: PLC0415
 
         try_first_with = getattr(self.options, "discover", None)
+        cache = _shared_app_data()
         interpreter: SubprocessPythonInfo | None = None
         for base_python in cast("list[str]", self.conf["base_python"]):
-            resolved = get_interpreter(base_python, try_first_with=try_first_with, env=env)
+            resolved = get_interpreter(base_python, try_first_with=try_first_with, cache=cache, env=env)
             if resolved is None or (executable := resolved.system_executable) is None:
                 continue
             if (interpreter := probe_python(executable)) is not None:
@@ -268,31 +270,16 @@ class VirtualEnv(Python, ABC):
         from virtualenv.discovery import cached_py_info  # noqa: PLC0415
         from virtualenv.discovery.py_info import PythonInfo as VirtualenvPythonInfo  # noqa: PLC0415
 
-        result = cached_py_info.from_exe(
-            VirtualenvPythonInfo,
-            app_data.make_app_data(None, read_only=False, env=os.environ),
-            str(path),
-        )
+        result = cached_py_info.from_exe(VirtualenvPythonInfo, _shared_app_data(), str(path))
         if result is None:
             msg = f"could not query python information for {path}"
             raise RuntimeError(msg)
         return result
 
 
-@dataclass(frozen=True)
-class _VirtualenvDrop:
-    """A virtualenv release that dropped the ability to create environments for older Python versions."""
-
-    dropped_in: Version
-    newest_unsupported: tuple[int, int]
-
-
-# virtualenv releases that dropped the ability to *create* environments for a target Python, with the newest
-# (major, minor) each stopped supporting -- https://virtualenv.pypa.io/en/latest/reference/compatibility.html
-_VIRTUALENV_DROPS: tuple[_VirtualenvDrop, ...] = (
-    _VirtualenvDrop(Version("21.5.0"), (3, 8)),
-    _VirtualenvDrop(Version("20.22.0"), (3, 6)),
-)
+def _shared_app_data() -> PyInfoCache:
+    """Interpreter metadata cache, shared so tox discovery reuses what virtualenv already probed (and vice versa)."""
+    return app_data.make_app_data(None, read_only=False, env=os.environ)
 
 
 def _auto_virtualenv_spec(base_pythons: list[str], installed: str) -> str:
@@ -309,7 +296,7 @@ def _auto_virtualenv_spec(base_pythons: list[str], installed: str) -> str:
         spec = PythonSpec.from_string_spec(base_python)
         if spec.major is None or spec.minor is None:
             return ""  # target version is unknown, so we cannot be sure creation would fail
-        target = (spec.major, spec.minor)
+        target = _PyVersion(major=spec.major, minor=spec.minor)
         floor = min((d.dropped_in for d in _VIRTUALENV_DROPS if target <= d.newest_unsupported), default=None)
         if floor is None or installed_version < floor:
             return ""  # the installed virtualenv can still create this target
@@ -317,3 +304,27 @@ def _auto_virtualenv_spec(base_pythons: list[str], installed: str) -> str:
     if not floors:
         return ""
     return f"virtualenv<{min(floors)}"
+
+
+@dataclass(frozen=True, kw_only=True, order=True)
+class _PyVersion:
+    """A ``(major, minor)`` Python version, ordered oldest-to-newest."""
+
+    major: int
+    minor: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class _VirtualenvDrop:
+    """A virtualenv release that dropped the ability to create environments for older Python versions."""
+
+    newest_unsupported: _PyVersion
+    dropped_in: Version
+
+
+# virtualenv releases that dropped the ability to *create* environments for a target Python, with the newest
+# (major, minor) each stopped supporting -- https://virtualenv.pypa.io/en/latest/reference/compatibility.html
+_VIRTUALENV_DROPS: tuple[_VirtualenvDrop, ...] = (
+    _VirtualenvDrop(newest_unsupported=_PyVersion(major=3, minor=8), dropped_in=Version("21.5.0")),
+    _VirtualenvDrop(newest_unsupported=_PyVersion(major=3, minor=6), dropped_in=Version("20.22.0")),
+)

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -6,10 +6,13 @@ import os
 import sys
 from abc import ABC
 from contextlib import redirect_stderr
+from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from packaging.version import Version
+from python_discovery import get_interpreter
 from virtualenv import __version__ as virtualenv_version
 from virtualenv import app_data, session_via_cli
 from virtualenv.discovery.py_spec import PythonSpec
@@ -19,7 +22,7 @@ from tox.execute.local_sub_process import LocalSubProcessExecutor
 from tox.tox_env.errors import Skip
 from tox.tox_env.python.api import Python, PythonInfo, VersionInfo
 from tox.tox_env.python.pip.pip_install import Pip
-from tox.tox_env.python.virtual_env.subprocess_adapter import SubprocessCreator, SubprocessSession
+from tox.tox_env.python.virtual_env.subprocess_adapter import SubprocessCreator, SubprocessPythonInfo, SubprocessSession
 
 if TYPE_CHECKING:
     from virtualenv.create.creator import Creator
@@ -27,6 +30,7 @@ if TYPE_CHECKING:
     from virtualenv.discovery.py_info import PythonInfo as VirtualenvPythonInfo
     from virtualenv.run.session import Session
 
+    from tox.config.main import Config
     from tox.execute.api import Execute
     from tox.tox_env.api import ToxEnvCreateArgs
 
@@ -72,11 +76,15 @@ class VirtualEnv(Python, ABC):
         self.conf.add_config(
             keys=["virtualenv_spec"],
             of_type=str,
-            default="",
+            default=self._default_virtualenv_spec,
             desc="PEP 440 version spec for virtualenv (e.g. virtualenv<20.22.0). When set, tox bootstraps this "
             "version in an isolated environment and runs it via subprocess, enabling Python versions "
-            "incompatible with the installed virtualenv.",
+            "incompatible with the installed virtualenv. Left empty it is derived automatically: tox pins an "
+            "older virtualenv only when the installed one can no longer create the targeted Python version.",
         )
+
+    def _default_virtualenv_spec(self, conf: Config, name: str | None) -> str:  # noqa: ARG002
+        return _auto_virtualenv_spec(self.conf["base_python"], virtualenv_version)
 
     @property
     def executor(self) -> Execute:
@@ -129,8 +137,14 @@ class VirtualEnv(Python, ABC):
         from .subprocess_adapter import ensure_bootstrap, probe_python  # noqa: PLC0415
 
         bootstrap_python = ensure_bootstrap(cast("Path", self.core["work_dir"]), spec)
-        base_pythons: list[str] = self.conf["base_python"]
-        interpreter = next((info for bp in base_pythons if (info := probe_python(bp)) is not None), None)
+        try_first_with = getattr(self.options, "discover", None)
+        interpreter: SubprocessPythonInfo | None = None
+        for base_python in cast("list[str]", self.conf["base_python"]):
+            resolved = get_interpreter(base_python, try_first_with=try_first_with, env=env)
+            if resolved is None or (executable := resolved.system_executable) is None:
+                continue
+            if (interpreter := probe_python(executable)) is not None:
+                break
         return SubprocessSession(self.env_dir, bootstrap_python, env, interpreter)
 
     def _create_imported_session(self, env: dict[str, str]) -> Session:
@@ -262,3 +276,42 @@ class VirtualEnv(Python, ABC):
             msg = f"could not query python information for {path}"
             raise RuntimeError(msg)
         return result
+
+
+@dataclass(frozen=True)
+class _VirtualenvDrop:
+    """A virtualenv release that dropped the ability to create environments for older Python versions."""
+
+    dropped_in: Version
+    newest_unsupported: tuple[int, int]
+
+
+# virtualenv releases that dropped the ability to *create* environments for a target Python, with the newest
+# (major, minor) each stopped supporting -- https://virtualenv.pypa.io/en/latest/reference/compatibility.html
+_VIRTUALENV_DROPS: tuple[_VirtualenvDrop, ...] = (
+    _VirtualenvDrop(Version("21.5.0"), (3, 8)),
+    _VirtualenvDrop(Version("20.22.0"), (3, 6)),
+)
+
+
+def _auto_virtualenv_spec(base_pythons: list[str], installed: str) -> str:
+    """Pin an older virtualenv when the installed one cannot create the targeted Python.
+
+    Returns an empty string unless *every* candidate in ``base_pythons`` targets a Python the installed virtualenv can
+    no longer create an environment for -- only then is a downgrade guaranteed to be required, since tox picks the first
+    candidate that resolves on the host and any supported candidate offers a path to success without bootstrapping.
+    """
+    installed_version = Version(installed)
+    floors: list[Version] = []
+    for base_python in base_pythons:
+        spec = PythonSpec.from_string_spec(base_python)
+        if spec.major is None or spec.minor is None:
+            return ""  # target version is unknown, so we cannot be sure creation would fail
+        target = (spec.major, spec.minor)
+        floor = min((d.dropped_in for d in _VIRTUALENV_DROPS if target <= d.newest_unsupported), default=None)
+        if floor is None or installed_version < floor:
+            return ""  # the installed virtualenv can still create this target
+        floors.append(floor)
+    if not floors:
+        return ""
+    return f"virtualenv<{min(floors)}"

--- a/src/tox/tox_env/python/virtual_env/subprocess_adapter.py
+++ b/src/tox/tox_env/python/virtual_env/subprocess_adapter.py
@@ -101,7 +101,7 @@ class SubprocessSession:
     def __init__(
         self,
         env_dir: Path,
-        bootstrap_python: Path,
+        bootstrap_python: Path | None,
         env_vars: dict[str, str],
         interpreter: SubprocessPythonInfo | None,
     ) -> None:
@@ -111,6 +111,9 @@ class SubprocessSession:
         self._creator = SubprocessCreator(env_dir, interpreter) if interpreter is not None else None
 
     def run(self) -> None:
+        if self._bootstrap_python is None:
+            msg = "no interpreter discovered"
+            raise RuntimeError(msg)
         cmd = [str(self._bootstrap_python), "-m", "virtualenv", str(self._env_dir)]
         try:
             result = subprocess.run(cmd, env=self._env_vars, capture_output=True, text=True, check=False)

--- a/tests/tox_env/python/virtual_env/test_virtualenv_api.py
+++ b/tests/tox_env/python/virtual_env/test_virtualenv_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, PropertyMock
 
@@ -11,7 +12,7 @@ from virtualenv import __version__ as virtualenv_version
 from virtualenv import session_via_cli
 from virtualenv.config.cli.parser import VirtualEnvOptions
 
-from tox.tox_env.python.virtual_env.api import VirtualEnv
+from tox.tox_env.python.virtual_env.api import VirtualEnv, _auto_virtualenv_spec  # noqa: PLC2701
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -279,3 +280,108 @@ def test_get_virtualenv_py_info_raises_on_none(mocker: MockerFixture) -> None:
     mocker.patch("virtualenv.discovery.cached_py_info.from_exe", return_value=None)
     with pytest.raises(RuntimeError, match="could not query python information for"):
         VirtualEnv.get_virtualenv_py_info(Path("/no/such/python"))
+
+
+@pytest.mark.parametrize(
+    ("base_pythons", "installed", "expected"),
+    [
+        pytest.param(["py38"], "21.5.1", "virtualenv<21.5.0", id="py38-new-virtualenv-pins"),
+        pytest.param(["py38"], "20.26.0", "", id="py38-old-virtualenv-already-works"),
+        pytest.param(["py37"], "21.5.1", "virtualenv<21.5.0", id="py37-new-virtualenv-pins"),
+        pytest.param(["py39"], "21.5.1", "", id="py39-supported"),
+        pytest.param(["py313"], "21.5.1", "", id="py313-supported"),
+        pytest.param(["py38", "py39"], "21.5.1", "", id="mixed-one-supported-no-pin"),
+        pytest.param(["py38", "py37"], "21.5.1", "virtualenv<21.5.0", id="all-unsupported-pins"),
+        pytest.param(["py38", "py36"], "21.5.1", "virtualenv<20.22.0", id="most-restrictive-floor"),
+        pytest.param(["py36"], "20.26.0", "virtualenv<20.22.0", id="py36-needs-older-virtualenv"),
+        pytest.param(["py36"], "20.21.0", "", id="py36-old-virtualenv-already-works"),
+        pytest.param(["py3"], "21.5.1", "", id="underspecified-minor-unknown"),
+        pytest.param(["/usr/bin/python3.8"], "21.5.1", "", id="bare-path-version-unknown"),
+        pytest.param(["python3.8"], "21.5.1", "virtualenv<21.5.0", id="command-form-pins"),
+    ],
+)
+def test_auto_virtualenv_spec(base_pythons: list[str], installed: str, expected: str) -> None:
+    assert _auto_virtualenv_spec(base_pythons, installed) == expected
+
+
+def test_auto_virtualenv_spec_no_candidates() -> None:
+    assert not _auto_virtualenv_spec([], "21.5.1")
+
+
+def test_virtualenv_spec_auto_pins_eol_python(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+    mocker.patch("tox.tox_env.python.virtual_env.api.virtualenv_version", "21.5.1")
+    proj = tox_project({
+        "tox.toml": dedent(
+            """\
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print(1)"]]
+            """,
+        ),
+    })
+    result = proj.run("c", "-e", "py38", "-k", "virtualenv_spec")
+    result.assert_success()
+    assert "virtualenv_spec = virtualenv<21.5.0" in result.out
+
+
+def test_virtualenv_spec_auto_empty_for_supported_python(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+    mocker.patch("tox.tox_env.python.virtual_env.api.virtualenv_version", "21.5.1")
+    proj = tox_project({
+        "tox.toml": dedent(
+            """\
+            [env_run_base]
+            package = "skip"
+            commands = [["python", "-c", "print(1)"]]
+            """,
+        ),
+    })
+    result = proj.run("c", "-e", "py313", "-k", "virtualenv_spec")
+    result.assert_success()
+    assert "virtualenv_spec =\n" in result.out or "virtualenv_spec = \n" in result.out
+
+
+def test_virtualenv_spec_subprocess_interpreter_unresolved(
+    tox_project: ToxProjectCreator,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter.ensure_bootstrap",
+        return_value=Path(sys.executable),
+    )
+    mocker.patch("tox.tox_env.python.virtual_env.api.get_interpreter", return_value=None)
+    proj = tox_project({
+        "tox.toml": dedent(
+            """\
+            [env_run_base]
+            package = "skip"
+            virtualenv_spec = "virtualenv<20.22.0"
+            """,
+        ),
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_failed()
+    assert "could not find python interpreter" in result.out
+
+
+def test_virtualenv_spec_subprocess_probe_fails(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.subprocess_adapter.ensure_bootstrap",
+        return_value=Path(sys.executable),
+    )
+    mocker.patch(
+        "tox.tox_env.python.virtual_env.api.get_interpreter",
+        return_value=MagicMock(system_executable=sys.executable),
+    )
+    mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.probe_python", return_value=None)
+    proj = tox_project({
+        "tox.toml": dedent(
+            """\
+            [env_run_base]
+            package = "skip"
+            virtualenv_spec = "virtualenv<20.22.0"
+            """,
+        ),
+    })
+    result = proj.run("r", "-e", "py")
+    result.assert_failed()
+    assert "could not find python interpreter" in result.out

--- a/tests/tox_env/python/virtual_env/test_virtualenv_api.py
+++ b/tests/tox_env/python/virtual_env/test_virtualenv_api.py
@@ -12,9 +12,11 @@ from virtualenv import __version__ as virtualenv_version
 from virtualenv import session_via_cli
 from virtualenv.config.cli.parser import VirtualEnvOptions
 
-from tox.tox_env.python.virtual_env.api import VirtualEnv, _auto_virtualenv_spec  # noqa: PLC2701
+from tox.tox_env.python.virtual_env.api import VirtualEnv
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pytest_mock import MockerFixture
 
     from tox.execute import ExecuteRequest
@@ -282,6 +284,32 @@ def test_get_virtualenv_py_info_raises_on_none(mocker: MockerFixture) -> None:
         VirtualEnv.get_virtualenv_py_info(Path("/no/such/python"))
 
 
+@pytest.fixture
+def resolve_virtualenv_spec(
+    tox_project: ToxProjectCreator,
+    mocker: MockerFixture,
+) -> Callable[[list[str], str], str]:
+    def _resolve(base_pythons: list[str], installed: str) -> str:
+        mocker.patch("tox.tox_env.python.virtual_env.api.virtualenv_version", installed)
+        candidates = ", ".join(f'"{base_python}"' for base_python in base_pythons)
+        proj = tox_project({
+            "tox.toml": dedent(
+                f"""\
+                [env.foo]
+                package = "skip"
+                base_python = [{candidates}]
+                commands = [["python", "-c", "print(1)"]]
+                """,
+            ),
+        })
+        result = proj.run("c", "-e", "foo", "-k", "virtualenv_spec")
+        result.assert_success()
+        line = next(ln for ln in result.out.splitlines() if ln.strip().startswith("virtualenv_spec ="))
+        return line.split("=", 1)[1].strip()
+
+    return _resolve
+
+
 @pytest.mark.parametrize(
     ("base_pythons", "installed", "expected"),
     [
@@ -298,80 +326,36 @@ def test_get_virtualenv_py_info_raises_on_none(mocker: MockerFixture) -> None:
         pytest.param(["py3"], "21.5.1", "", id="underspecified-minor-unknown"),
         pytest.param(["/usr/bin/python3.8"], "21.5.1", "", id="bare-path-version-unknown"),
         pytest.param(["python3.8"], "21.5.1", "virtualenv<21.5.0", id="command-form-pins"),
+        pytest.param([], "21.5.1", "", id="no-candidates"),
     ],
 )
-def test_auto_virtualenv_spec(base_pythons: list[str], installed: str, expected: str) -> None:
-    assert _auto_virtualenv_spec(base_pythons, installed) == expected
+def test_virtualenv_spec_auto(
+    resolve_virtualenv_spec: Callable[[list[str], str], str],
+    base_pythons: list[str],
+    installed: str,
+    expected: str,
+) -> None:
+    assert resolve_virtualenv_spec(base_pythons, installed) == expected
 
 
-def test_auto_virtualenv_spec_no_candidates() -> None:
-    assert not _auto_virtualenv_spec([], "21.5.1")
-
-
-def test_virtualenv_spec_auto_pins_eol_python(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
-    mocker.patch("tox.tox_env.python.virtual_env.api.virtualenv_version", "21.5.1")
-    proj = tox_project({
-        "tox.toml": dedent(
-            """\
-            [env_run_base]
-            package = "skip"
-            commands = [["python", "-c", "print(1)"]]
-            """,
-        ),
-    })
-    result = proj.run("c", "-e", "py38", "-k", "virtualenv_spec")
-    result.assert_success()
-    assert "virtualenv_spec = virtualenv<21.5.0" in result.out
-
-
-def test_virtualenv_spec_auto_empty_for_supported_python(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
-    mocker.patch("tox.tox_env.python.virtual_env.api.virtualenv_version", "21.5.1")
-    proj = tox_project({
-        "tox.toml": dedent(
-            """\
-            [env_run_base]
-            package = "skip"
-            commands = [["python", "-c", "print(1)"]]
-            """,
-        ),
-    })
-    result = proj.run("c", "-e", "py313", "-k", "virtualenv_spec")
-    result.assert_success()
-    assert "virtualenv_spec =\n" in result.out or "virtualenv_spec = \n" in result.out
-
-
-def test_virtualenv_spec_subprocess_interpreter_unresolved(
+@pytest.mark.parametrize(
+    "resolves",
+    [
+        pytest.param(False, id="interpreter-unresolved"),
+        pytest.param(True, id="resolved-but-probe-fails"),
+    ],
+)
+def test_virtualenv_spec_subprocess_missing_interpreter(
     tox_project: ToxProjectCreator,
     mocker: MockerFixture,
+    resolves: bool,
 ) -> None:
     mocker.patch(
         "tox.tox_env.python.virtual_env.subprocess_adapter.ensure_bootstrap",
         return_value=Path(sys.executable),
     )
-    mocker.patch("tox.tox_env.python.virtual_env.api.get_interpreter", return_value=None)
-    proj = tox_project({
-        "tox.toml": dedent(
-            """\
-            [env_run_base]
-            package = "skip"
-            virtualenv_spec = "virtualenv<20.22.0"
-            """,
-        ),
-    })
-    result = proj.run("r", "-e", "py")
-    result.assert_failed()
-    assert "could not find python interpreter" in result.out
-
-
-def test_virtualenv_spec_subprocess_probe_fails(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
-    mocker.patch(
-        "tox.tox_env.python.virtual_env.subprocess_adapter.ensure_bootstrap",
-        return_value=Path(sys.executable),
-    )
-    mocker.patch(
-        "tox.tox_env.python.virtual_env.api.get_interpreter",
-        return_value=MagicMock(system_executable=sys.executable),
-    )
+    resolved = MagicMock(system_executable=sys.executable) if resolves else None
+    mocker.patch("tox.tox_env.python.virtual_env.api.get_interpreter", return_value=resolved)
     mocker.patch("tox.tox_env.python.virtual_env.subprocess_adapter.probe_python", return_value=None)
     proj = tox_project({
         "tox.toml": dedent(

--- a/tests/tox_env/python/virtual_env/test_virtualenv_api.py
+++ b/tests/tox_env/python/virtual_env/test_virtualenv_api.py
@@ -350,7 +350,7 @@ def test_virtualenv_spec_subprocess_missing_interpreter(
     mocker: MockerFixture,
     resolves: bool,
 ) -> None:
-    mocker.patch(
+    ensure_bootstrap = mocker.patch(
         "tox.tox_env.python.virtual_env.subprocess_adapter.ensure_bootstrap",
         return_value=Path(sys.executable),
     )
@@ -369,3 +369,4 @@ def test_virtualenv_spec_subprocess_missing_interpreter(
     result = proj.run("r", "-e", "py")
     result.assert_failed()
     assert "could not find python interpreter" in result.out
+    ensure_bootstrap.assert_not_called()  # a missing interpreter must skip without bootstrapping


### PR DESCRIPTION
`virtualenv` 21.5 dropped the ability to create environments for Python 3.8 and earlier. A tox installed next to a recent `virtualenv` then silently skips `py38` environments even when a 3.8 interpreter is available, which surprised users who relied on tox to keep testing on those interpreters (#3965). 🐍

tox now derives `virtualenv_spec` from each environment's `base_python`. It compares the targeted interpreter against the installed `virtualenv`'s compatibility timeline, and when that interpreter can no longer be created, it pins the newest `virtualenv` that still can and bootstraps it for that environment alone. ✨ To stay conservative the downgrade happens only when every `base_python` candidate is unsupported: because resolution is first-found-wins, a mixed list like `[py38, py39]` may still land on a creatable interpreter, so no pin is applied there. An explicit `virtualenv_spec` always takes precedence over the derived value.

The subprocess path now resolves factor specs such as `py38` to a real interpreter through `python-discovery` before probing, which is what lets the bootstrapped `virtualenv` actually create the environment rather than failing on a non-executable `py38` argument. Environments targeting supported Pythons keep using the imported `virtualenv` with zero overhead, so a single config can mix end-of-life and current interpreters without manual pinning.