### PR TITLE
treat scalar string then/else as a single item in if-replace extend

### DIFF
--- a/docs/changelog/3969.bugfix.rst
+++ b/docs/changelog/3969.bugfix.rst
@@ -1,3 +1,2 @@
-Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when
-``then`` or ``else`` is a scalar string (e.g. ``then = "-v"``) by iterating the
-string character-by-character instead of appending it as a single element.
+Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when ``then`` or ``else`` is a scalar string
+(e.g. ``then = "-v"``) by iterating the string character-by-character instead of appending it as a single element.

--- a/docs/changelog/3969.bugfix.rst
+++ b/docs/changelog/3969.bugfix.rst
@@ -1,3 +1,4 @@
-Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when ``then`` or ``else`` is a scalar (e.g.
-``then = "-v"``) rather than a list: only a list result is spread into the parent now, any scalar is appended as a
-single element instead of being iterated (which split a string character-by-character and raised for numbers/booleans).
+Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when ``then`` or ``else`` is a scalar
+string (e.g. ``then = "-v"``): a non-empty scalar string is now appended as a single element instead of being iterated
+character-by-character, while a false ``if`` with no ``else`` (yielding ``""``) contributes nothing rather than an empty
+element, and list/set results are still spread into the parent.

--- a/docs/changelog/3969.bugfix.rst
+++ b/docs/changelog/3969.bugfix.rst
@@ -1,3 +1,3 @@
-Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when ``then`` or ``else`` is a scalar
-(e.g. ``then = "-v"``) rather than a list: only a list result is spread into the parent now, any scalar is appended as a
+Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when ``then`` or ``else`` is a scalar (e.g.
+``then = "-v"``) rather than a list: only a list result is spread into the parent now, any scalar is appended as a
 single element instead of being iterated (which split a string character-by-character and raised for numbers/booleans).

--- a/docs/changelog/3969.bugfix.rst
+++ b/docs/changelog/3969.bugfix.rst
@@ -1,2 +1,3 @@
-Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when ``then`` or ``else`` is a scalar string
-(e.g. ``then = "-v"``) by iterating the string character-by-character instead of appending it as a single element.
+Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when ``then`` or ``else`` is a scalar
+(e.g. ``then = "-v"``) rather than a list: only a list result is spread into the parent now, any scalar is appended as a
+single element instead of being iterated (which split a string character-by-character and raised for numbers/booleans).

--- a/docs/changelog/3969.bugfix.rst
+++ b/docs/changelog/3969.bugfix.rst
@@ -1,0 +1,3 @@
+Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when
+``then`` or ``else`` is a scalar string (e.g. ``then = "-v"``) by iterating the
+string character-by-character instead of appending it as a single element.

--- a/docs/changelog/3969.bugfix.rst
+++ b/docs/changelog/3969.bugfix.rst
@@ -1,4 +1,4 @@
-Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when ``then`` or ``else`` is a scalar
-string (e.g. ``then = "-v"``): a non-empty scalar string is now appended as a single element instead of being iterated
+Fix ``{ replace = "if" ... extend = true }`` corrupting the resulting list when ``then`` or ``else`` is a scalar string
+(e.g. ``then = "-v"``): a non-empty scalar string is now appended as a single element instead of being iterated
 character-by-character, while a false ``if`` with no ``else`` (yielding ``""``) contributes nothing rather than an empty
 element, and list/set results are still spread into the parent.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -2368,7 +2368,10 @@ You can reference other configurations via the ``ref`` replacement. This can eit
   In this case ``dest`` environments ``extras`` will be ``A``, ``dest``, ``B``.
 
 The ``extend`` flag controls if after replacement the value should be replaced as is in the host structure (when flag is
-false -- by default) or be extended into. This flag only operates when the host is a list.
+false -- by default) or be extended into. This flag only operates when the host is a list. A list (or set) result is
+spread into the host, while a scalar string result is appended as a single element -- so a scalar ``then``/``else``
+(e.g. ``then = "-v"``) adds one item rather than its individual characters, and a false ``if`` with no ``else`` adds
+nothing.
 
 When referencing Command-type configuration values (like ``list_dependencies_command``), the reference automatically
 extracts the command's argument list, making it compatible with TOML's structured ``commands`` format. For example:

--- a/src/tox/config/loader/toml/_replace.py
+++ b/src/tox/config/loader/toml/_replace.py
@@ -78,13 +78,14 @@ class Unroll:
             for val in value:  # apply replacement for every entry
                 got = self(val, depth, skip_str=skip_str)
                 if isinstance(val, dict) and val.get("replace") and val.get("extend"):
-                    # ``got`` may be a string (e.g. an ``if`` replacement whose then/else is a
-                    # scalar string); iterating a str would split it character by character
-                    # and corrupt the resulting list. Treat a bare string as a single item.
-                    if isinstance(got, str):
-                        res_list.append(cast("TomlTypes", got))
-                    else:
+                    # ``extend`` spreads a list result into the parent; any non-list result
+                    # (e.g. an ``if`` replacement whose then/else is a scalar string) is a single
+                    # item. Extending a scalar would iterate it (splitting a str character by
+                    # character, raising for an int/bool) and corrupt the list.
+                    if isinstance(got, list):
                         res_list.extend(cast("list[Any]", got))
+                    else:
+                        res_list.append(cast("TomlTypes", got))
                 else:
                     res_list.append(got)
             value = res_list

--- a/src/tox/config/loader/toml/_replace.py
+++ b/src/tox/config/loader/toml/_replace.py
@@ -78,7 +78,13 @@ class Unroll:
             for val in value:  # apply replacement for every entry
                 got = self(val, depth, skip_str=skip_str)
                 if isinstance(val, dict) and val.get("replace") and val.get("extend"):
-                    res_list.extend(cast("list[Any]", got))
+                    # ``got`` may be a string (e.g. an ``if`` replacement whose then/else is a
+                    # scalar string); iterating a str would split it character by character
+                    # and corrupt the resulting list. Treat a bare string as a single item.
+                    if isinstance(got, str):
+                        res_list.append(cast("TomlTypes", got))
+                    else:
+                        res_list.extend(cast("list[Any]", got))
                 else:
                     res_list.append(got)
             value = res_list

--- a/src/tox/config/loader/toml/_replace.py
+++ b/src/tox/config/loader/toml/_replace.py
@@ -78,14 +78,15 @@ class Unroll:
             for val in value:  # apply replacement for every entry
                 got = self(val, depth, skip_str=skip_str)
                 if isinstance(val, dict) and val.get("replace") and val.get("extend"):
-                    # ``extend`` spreads a list result into the parent; any non-list result
-                    # (e.g. an ``if`` replacement whose then/else is a scalar string) is a single
-                    # item. Extending a scalar would iterate it (splitting a str character by
-                    # character, raising for an int/bool) and corrupt the list.
-                    if isinstance(got, list):
-                        res_list.extend(cast("list[Any]", got))
+                    # ``extend`` spreads an iterable result (list, set of extras, ...) into the
+                    # parent. A scalar string is the exception: iterating it would split it
+                    # character by character, so a non-empty one is appended as a single item while
+                    # an empty one (a false ``if`` with no ``else``, yielding "") contributes nothing.
+                    if isinstance(got, str):
+                        if got:
+                            res_list.append(cast("TomlTypes", got))
                     else:
-                        res_list.append(cast("TomlTypes", got))
+                        res_list.extend(cast("list[Any]", got))
                 else:
                     res_list.append(got)
             value = res_list

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -646,9 +646,10 @@ def test_config_in_toml_replace_if_extend_scalar_string(
 ) -> None:
     """Scalar-string then/else with extend=true must append as one item, not characters.
 
-    Regression for a bug where ``commands = [["echo", { replace = "if", condition = "env.Q",
-    then = "-v", else = "-q", extend = true }]]`` produced ``commands = echo - v`` because
-    ``list.extend(string)`` iterates over the string's characters.
+    Regression for a bug where ``commands = [["echo", { replace = "if", condition = "env.Q", then = "-v", else = "-q",
+    extend = true }]]`` produced ``commands = echo - v`` because ``list.extend(string)`` iterates over the string's
+    characters.
+
     """
     monkeypatch.delenv("V", raising=False)
     monkeypatch.delenv("Q", raising=False)
@@ -668,9 +669,7 @@ def test_config_in_toml_replace_if_extend_scalar_string(
         f"commands line should end with the literal arg {expected_arg!r}, got: {commands_line!r}"
     )
     # The buggy output looked like "echo - v" or "echo - q"; assert no per-char splitting.
-    assert " - " not in commands_line, (
-        f"commands line has per-character splitting: {commands_line!r}"
-    )
+    assert " - " not in commands_line, f"commands line has per-character splitting: {commands_line!r}"
 
 
 @pytest.mark.parametrize(

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -632,6 +632,48 @@ def test_config_in_toml_replace_if_extend(tox_project: ToxProjectCreator, monkey
 
 
 @pytest.mark.parametrize(
+    ("set_q", "expected_arg"),
+    [
+        pytest.param(True, "-v", id="then_string_selected"),
+        pytest.param(False, "-q", id="else_string_selected"),
+    ],
+)
+def test_config_in_toml_replace_if_extend_scalar_string(
+    tox_project: ToxProjectCreator,
+    monkeypatch: pytest.MonkeyPatch,
+    set_q: bool,
+    expected_arg: str,
+) -> None:
+    """Scalar-string then/else with extend=true must append as one item, not characters.
+
+    Regression for a bug where ``commands = [["echo", { replace = "if", condition = "env.Q",
+    then = "-v", else = "-q", extend = true }]]`` produced ``commands = echo - v`` because
+    ``list.extend(string)`` iterates over the string's characters.
+    """
+    monkeypatch.delenv("V", raising=False)
+    monkeypatch.delenv("Q", raising=False)
+    if set_q:
+        # Condition is env.Q; setting it flips the condition true (then branch).
+        monkeypatch.setenv("Q", "1")
+    # else: env.Q is unset, so the condition is false and the else branch ("-q") runs.
+    toml = """\
+    [tool.tox.env.A]
+    commands = [["echo", { replace = "if", condition = "env.Q", then = "-v", else = "-q", extend = true }]]
+    """
+    project = tox_project({"pyproject.toml": toml})
+    outcome = project.run("c", "-e", "A", "-k", "commands")
+    outcome.assert_success()
+    commands_line = outcome.out.split("commands = ", 1)[1].rstrip()
+    assert commands_line.endswith(expected_arg), (
+        f"commands line should end with the literal arg {expected_arg!r}, got: {commands_line!r}"
+    )
+    # The buggy output looked like "echo - v" or "echo - q"; assert no per-char splitting.
+    assert " - " not in commands_line, (
+        f"commands line has per-character splitting: {commands_line!r}"
+    )
+
+
+@pytest.mark.parametrize(
     ("condition_toml", "error_match"),
     [
         pytest.param(

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -672,6 +672,32 @@ def test_config_in_toml_replace_if_extend_scalar_string(
     assert " - " not in commands_line, f"commands line has per-character splitting: {commands_line!r}"
 
 
+def test_config_in_toml_replace_if_extend_no_match_contributes_nothing(
+    tox_project: ToxProjectCreator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A false ``if`` with no ``else`` and extend=true adds nothing, not an empty element.
+
+    Regression for a bug where such an entry yielded ``commands = ''`` (failing as "'' is not list")
+    because the empty-string no-match result was appended instead of spread away.
+
+    """
+    monkeypatch.delenv("Q", raising=False)
+    toml = """\
+    [tool.tox.env.A]
+    commands = [
+        ["echo", "hi"],
+        { replace = "if", condition = "env.Q", then = [["echo", "bye"]], extend = true },
+    ]
+    """
+    project = tox_project({"pyproject.toml": toml})
+    outcome = project.run("c", "-e", "A", "-k", "commands")
+    outcome.assert_success()
+    commands_line = outcome.out.split("commands = ", 1)[1].rstrip()
+    assert "echo hi" in commands_line
+    assert "bye" not in commands_line
+
+
 @pytest.mark.parametrize(
     ("condition_toml", "error_match"),
     [

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -678,8 +678,8 @@ def test_config_in_toml_replace_if_extend_no_match_contributes_nothing(
 ) -> None:
     """A false ``if`` with no ``else`` and extend=true adds nothing, not an empty element.
 
-    Regression for a bug where such an entry yielded ``commands = ''`` (failing as "'' is not list")
-    because the empty-string no-match result was appended instead of spread away.
+    Regression for a bug where such an entry yielded ``commands = ''`` (failing as "'' is not list") because the
+    empty-string no-match result was appended instead of spread away.
 
     """
     monkeypatch.delenv("Q", raising=False)


### PR DESCRIPTION
Fixes a bug where `{ replace = "if" ... extend = true }` corrupts the result list when `then` or `else` is a scalar string. `list.extend(string)` iterates the string and appends each character individually, so a project using:

```toml
[tool.tox.env_run_base]
commands = [["echo", { replace = "if", condition = "env.Q", then = "-v", else = "-q", extend = true }]]
```

got `commands = echo - v` (with a space between `-` and `v`, each char as a separate element) instead of the intended `commands = echo -v`.

The fix detects when the result of an extended replace is a plain string and appends it as one element instead of iterating it. Two regression tests verify the then and else branches. The existing `extend=true` test (with list-valued then/else) still passes.