### PR TITLE
🔧 chore(type): drop stale ty invalid-assignment ignores

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,5 +178,5 @@ def setup(app: Sphinx) -> None:
         return prev_check(self, refnode)
 
     prev_check = ExternalLinksChecker.check_uri
-    ExternalLinksChecker.check_uri = check_uri  # ty: ignore[invalid-assignment] # monkey-patching instance method onto class
+    ExternalLinksChecker.check_uri = check_uri
     inject_into_ssl()

--- a/src/tox/report.py
+++ b/src/tox/report.py
@@ -52,7 +52,7 @@ class _LogThreadLocal(local):
             old_start(self)
 
         old_start = Thread.start
-        Thread.start = new_start  # ty: ignore[invalid-assignment]
+        Thread.start = new_start
         try:
             yield
         finally:


### PR DESCRIPTION
The `type` environment fails once `ty` resolves to 0.0.55, which no longer reports `invalid-assignment` on the two monkeypatch method assignments in `docs/conf.py` and `src/tox/report.py`. 🔧 With `--error-on-warning` set, the now-unused `# ty: ignore[invalid-assignment]` directives turn into `unused-ignore-comment` warnings and break the check. The local env had only kept passing because it cached an older `ty` (0.0.49).

Removing the obsolete suppressions clears the warnings without weakening type coverage, since the assignments type-check cleanly under the current `ty`.