### PR TITLE
💰 Surface the org itself in the FUNDING config

### DIFF
--- a/.github/FUNDING.yaml
+++ b/.github/FUNDING.yaml
@@ -1,5 +1,5 @@
 github:
-- gaborbernat
-- tox-dev
+  - gaborbernat
+  - tox-dev
 tidelift: "pypi/tox"
 thanks_dev: u/gh/gaborbernat

--- a/.github/FUNDING.yaml
+++ b/.github/FUNDING.yaml
@@ -1,3 +1,5 @@
-github: gaborbernat
+github:
+- gaborbernat
+- tox-dev
 tidelift: "pypi/tox"
 thanks_dev: u/gh/gaborbernat


### PR DESCRIPTION
This will effectively show both @gaborbernat and @tox-dev GH sponsors links in the widget. GH allows having 4 human accounts + 1 org listed in the config and the org is rendered on a dedicated line.