### PR TITLE
📦 build: use test dependency group in internal envs

### DIFF
--- a/tox.toml
+++ b/tox.toml
@@ -69,8 +69,7 @@ uv_seed = true
 [env.docs]
 description = "build documentation"
 base_python = [ "3.14" ]
-dependency_groups = [ "docs" ]
-extras = [ "testing" ]
+dependency_groups = [ "docs", "test" ]
 commands = [
   [
     "sphinx-build",


### PR DESCRIPTION
tox's own environments pulled their test dependencies through the `testing` extra, which duplicates what the `test` dependency group under `[dependency-groups]` already provides. 📦 This points the internal `docs` environment at that group so the dev workflow has one source of truth for test tooling.

The `docs` environment now lists `dependency_groups = [ "docs", "test" ]` in place of `extras = [ "testing" ]`. It was the only internal environment still reaching for the extra; `env_run_base` and `fast` already consume the `test` group.

The public `tox[testing]` extra stays in `[project.optional-dependencies]` unchanged, so plugin authors who install it for the `tox.pytest` fixtures keep working. The `completion` extra and its references stay as they are.
