### PR TITLE
✨ feat(python): match free-threaded and debug interpreter builds

### DIFF
--- a/docs/changelog/3986.bugfix.rst
+++ b/docs/changelog/3986.bugfix.rst
@@ -1,3 +1,3 @@
-Keep the free-threaded ``t`` suffix when deriving the base python spec from a path, so ``base_python`` pointing at a
-free-threaded interpreter matches ``py313t`` factors and is rejected by factors without the suffix, as documented - by
+Keep the free-threaded ``t`` suffix when deriving the base python spec from a path, so a ``base_python`` pointing at a
+free-threaded interpreter matches ``py313t`` factors and conflicts with factors that lack the suffix - by
 :user:`chuenchen309`.

--- a/docs/changelog/3986.bugfix.rst
+++ b/docs/changelog/3986.bugfix.rst
@@ -1,0 +1,3 @@
+Keep the free-threaded ``t`` suffix when deriving the base python spec from a path, so ``base_python`` pointing at a
+free-threaded interpreter matches ``py313t`` factors and is rejected by factors without the suffix, as documented - by
+:user:`chuenchen309`.

--- a/docs/changelog/3986.feature.rst
+++ b/docs/changelog/3986.feature.rst
@@ -1,0 +1,4 @@
+Support debug (``Py_DEBUG``) interpreters the way free-threaded builds are already handled. The ``py313d`` and
+``py313td`` factors select a debug build, a ``base_python`` pointing at one matches those factors and conflicts with
+factors that lack the suffix, and a debug build gets its own ``d``-tagged wheel build environment - by
+:user:`chuenchen309`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1623,6 +1623,14 @@ Python options
     ``True`` if the Python interpreter in the tox environment is a free-threaded CPython build,
     else ``False``.
 
+.. conf::
+    :keys: py_debug
+    :constant:
+    :version_added: 4.57
+
+    ``True`` if the Python interpreter in the tox environment is a debug (``Py_DEBUG``) build,
+    else ``False``.
+
 Python run
 ==========
 
@@ -3199,6 +3207,8 @@ or via ``{name}`` in INI.
       - Python implementation name in lowercase (e.g. ``cpython``, ``pypy``).
     - - ``{py_free_threaded}``
       - ``True`` if the environment Python is a free-threaded build, else ``False``.
+    - - ``{py_debug}``
+      - ``True`` if the environment Python is a debug (``Py_DEBUG``) build, else ``False``.
     - - ``{env:KEY}`` / ``{env:KEY:DEFAULT}``
       - Value of environment variable ``KEY``, with optional default.
     - - ``{posargs}`` / ``{posargs:DEFAULTS}``

--- a/src/tox/tox_env/python/api.py
+++ b/src/tox/tox_env/python/api.py
@@ -37,6 +37,7 @@ class PythonInfo:
     platform: str
     extra: dict[str, Any]
     free_threaded: bool = False
+    debug: bool = False
     machine: str | None = None
 
     @property
@@ -59,6 +60,7 @@ PY_FACTORS_RE = re.compile(
     (?:
     (?P<version>[2-9]\.?[0-9]?[0-9]?)                      # the version; one of: MAJORMINOR, MAJOR.MINOR
     (?P<threaded>t?)                                       # version followed by t for free-threading
+    (?P<debug>d?)                                          # version followed by d for a debug build
     )?$
     """,
     re.VERBOSE,
@@ -69,6 +71,7 @@ PY_FACTORS_RE_EXPLICIT_VERSION = re.compile(
     ( (?P<impl> cpython | pypy ) - )?   # optional interpreter prefix with dash
     (?P<version> [23] \. [0-9]+ )        # explicit major.minor version (Python 2.x or 3.x)
     (?P<threaded> t? )                   # optional free-threaded suffix
+    (?P<debug> d? )                      # optional debug-build suffix
     $
     """,
     re.VERBOSE,
@@ -149,6 +152,7 @@ class Python(ToxEnv, ABC):
         self.conf.add_constant("py_dot_ver", "<python major>.<python minor>", value=self.py_dot_ver)
         self.conf.add_constant("py_impl", "python implementation", value=self.py_impl)
         self.conf.add_constant("py_free_threaded", "is no-gil interpreted", value=self.py_free_threaded)
+        self.conf.add_constant("py_debug", "is a debug build", value=self.py_debug)
 
     def _default_set_env(self) -> dict[str, str]:
         env = super()._default_set_env()
@@ -162,6 +166,9 @@ class Python(ToxEnv, ABC):
 
     def py_free_threaded(self) -> bool:
         return self.base_python.free_threaded
+
+    def py_debug(self) -> bool:
+        return self.base_python.debug
 
     def py_impl(self) -> str:
         return self.base_python.impl_lower
@@ -223,17 +230,13 @@ class Python(ToxEnv, ABC):
     def extract_base_python(cls, env_name: str) -> str | None:
         candidates: list[str] = []
         if match := PY_FACTORS_RE_EXPLICIT_VERSION.match(env_name):
-            found = match.groupdict()
-            candidates.append(f"{'pypy' if found['impl'] == 'pypy' else ''}{found['version']}{found['threaded']}")
+            candidates.append(cls._explicit_version_spec(match.groupdict()))
         else:
             for factor in env_name.split("-"):
                 if match := PY_FACTORS_RE.match(factor):
                     candidates.append(factor)
                 elif match := PY_FACTORS_RE_EXPLICIT_VERSION.match(factor):
-                    found = match.groupdict()
-                    candidates.append(
-                        f"{'pypy' if found['impl'] == 'pypy' else ''}{found['version']}{found['threaded']}"
-                    )
+                    candidates.append(cls._explicit_version_spec(match.groupdict()))
         if candidates:
             if len(candidates) > 1:
                 msg = f"conflicting factors {', '.join(candidates)} in {env_name}"
@@ -241,15 +244,21 @@ class Python(ToxEnv, ABC):
             return next(iter(candidates))
         return None
 
+    @staticmethod
+    def _explicit_version_spec(found: dict[str, str | None]) -> str:
+        prefix = "pypy" if found["impl"] == "pypy" else ""
+        return f"{prefix}{found['version']}{found['threaded']}{found['debug']}"
+
     @classmethod
     def _python_spec_for_sys_executable(cls) -> PythonSpec:
         implementation = sys.implementation.name
         version = sys.version_info
         bits = "64" if sys.maxsize > 2**32 else "32"
         threaded = "t" if sysconfig.get_config_var("Py_GIL_DISABLED") == 1 else ""
+        debug = "d" if sysconfig.get_config_var("Py_DEBUG") else ""
         parts = sysconfig.get_platform().rsplit("-", 1)
         machine_suffix = f"-{isa}" if len(parts) > 1 and (isa := parts[-1]) else ""
-        string_spec = f"{implementation}{version.major}{version.minor}{threaded}-{bits}{machine_suffix}"
+        string_spec = f"{implementation}{version.major}{version.minor}{threaded}{debug}-{bits}{machine_suffix}"
         return PythonSpec.from_string_spec(string_spec)
 
     @classmethod
@@ -277,7 +286,16 @@ class Python(ToxEnv, ABC):
                         spec_base = cls.python_spec_for_path(path)
                 if any(
                     getattr(spec_base, key) != getattr(spec_name, key)
-                    for key in ("implementation", "major", "minor", "micro", "architecture", "machine", "free_threaded")
+                    for key in (
+                        "implementation",
+                        "major",
+                        "minor",
+                        "micro",
+                        "architecture",
+                        "machine",
+                        "free_threaded",
+                        "debug",
+                    )
                     if getattr(spec_name, key) is not None
                 ):
                     msg = f"env name {env_name} conflicting with base python {base_python}"
@@ -403,6 +421,7 @@ class Python(ToxEnv, ABC):
             "sysplatform": self.base_python.platform,
             "extra_version_info": None,
             "free_threaded": self.base_python.free_threaded,
+            "debug": self.base_python.debug,
             "machine": self.base_python.machine,
         }
 

--- a/src/tox/tox_env/python/package.py
+++ b/src/tox/tox_env/python/package.py
@@ -113,11 +113,13 @@ class PythonPackageToxEnv(Python, PackageToxEnv, ABC):
                 default_pkg_py.version_no_dot == run_py.version_no_dot
                 and default_pkg_py.impl_lower == run_py.impl_lower
                 and default_pkg_py.free_threaded == run_py.free_threaded
+                and default_pkg_py.debug == run_py.debug
             ):
                 return self.conf.name
 
             threaded = "t" if run_py.free_threaded else ""
-            return f"{self.conf.name}-{run_py.impl_lower}{run_py.version_no_dot}{threaded}"
+            debug = "d" if run_py.debug else ""
+            return f"{self.conf.name}-{run_py.impl_lower}{run_py.version_no_dot}{threaded}{debug}"
 
         run_env.conf.add_config(
             keys=["wheel_build_env"],

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -197,6 +197,7 @@ class VirtualEnv(Python, ABC):
             platform=interpreter.platform,
             extra={"executable": Path(sys_exe).resolve()},
             free_threaded=interpreter.free_threaded,
+            debug=interpreter.debug_build,
             machine=getattr(interpreter, "machine", None),
         )
 
@@ -255,8 +256,9 @@ class VirtualEnv(Python, ABC):
         info = cls.get_virtualenv_py_info(path)
         machine_suffix = f"-{m}" if (m := getattr(info, "machine", None)) else ""
         threaded = "t" if getattr(info, "free_threaded", False) else ""
+        debug = "d" if getattr(info, "debug_build", False) else ""
         return PythonSpec.from_string_spec(
-            f"{info.implementation}{info.version_info.major}{info.version_info.minor}{threaded}"
+            f"{info.implementation}{info.version_info.major}{info.version_info.minor}{threaded}{debug}"
             f"-{info.architecture}{machine_suffix}"
         )
 

--- a/src/tox/tox_env/python/virtual_env/api.py
+++ b/src/tox/tox_env/python/virtual_env/api.py
@@ -254,8 +254,10 @@ class VirtualEnv(Python, ABC):
         """
         info = cls.get_virtualenv_py_info(path)
         machine_suffix = f"-{m}" if (m := getattr(info, "machine", None)) else ""
+        threaded = "t" if getattr(info, "free_threaded", False) else ""
         return PythonSpec.from_string_spec(
-            f"{info.implementation}{info.version_info.major}{info.version_info.minor}-{info.architecture}{machine_suffix}"
+            f"{info.implementation}{info.version_info.major}{info.version_info.minor}{threaded}"
+            f"-{info.architecture}{machine_suffix}"
         )
 
     @staticmethod

--- a/src/tox/tox_env/python/virtual_env/subprocess_adapter.py
+++ b/src/tox/tox_env/python/virtual_env/subprocess_adapter.py
@@ -27,6 +27,7 @@ print(json.dumps({
     "platform": sys.platform,
     "system_executable": sys.executable,
     "free_threaded": sysconfig.get_config_var("Py_GIL_DISABLED") == 1,
+    "debug_build": bool(sysconfig.get_config_var("Py_DEBUG")),
     "sysconfig_platform": sysconfig.get_platform(),
 }))
 """
@@ -52,6 +53,7 @@ class SubprocessPythonInfo:
     platform: str
     system_executable: str
     free_threaded: bool
+    debug_build: bool = False
     sysconfig_platform: str | None = None
 
     @property
@@ -152,6 +154,7 @@ def probe_python(python_path: str) -> SubprocessPythonInfo | None:
         platform=raw["platform"],
         system_executable=raw["system_executable"],
         free_threaded=raw["free_threaded"],
+        debug_build=raw.get("debug_build", False),
         sysconfig_platform=raw.get("sysconfig_platform"),
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,9 @@ from tox.tox_env.python.virtual_env.api import VirtualEnv
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
+    from build import DistributionType
     from pytest_mock import MockerFixture
 
-    from build import DistributionType
     from tox.config.loader.api import Override
 
 pytest_plugins = "tox.pytest"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,9 @@ from tox.tox_env.python.virtual_env.api import VirtualEnv
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
-    from build import DistributionType
     from pytest_mock import MockerFixture
 
+    from build import DistributionType
     from tox.config.loader.api import Override
 
 pytest_plugins = "tox.pytest"
@@ -67,7 +67,9 @@ if sys.implementation.name == "pypy":
 
 
 class PatchPrevPy(Protocol):
-    def __call__(self, has_prev: bool, free_threaded: bool | None = None) -> tuple[str, str, bool]: ...
+    def __call__(
+        self, has_prev: bool, free_threaded: bool | None = None, debug: bool | None = None
+    ) -> tuple[str, str, bool]: ...
 
 
 class ToxIniCreator(Protocol):
@@ -107,12 +109,13 @@ def demo_pkg_inline() -> Path:
 
 @pytest.fixture
 def patch_prev_py(mocker: MockerFixture) -> PatchPrevPy:
-    def _func(has_prev: bool, free_threaded: bool | None = None) -> tuple[str, str, bool]:
+    def _func(has_prev: bool, free_threaded: bool | None = None, debug: bool | None = None) -> tuple[str, str, bool]:
         ver = sys.version_info[0:2]
         prev_ver = "".join(str(i) for i in (ver[0], ver[1] - 1))
         prev_py = f"py{prev_ver}"
         impl = sys.implementation.name.lower()
         is_free_threaded = sysconfig.get_config_var("Py_GIL_DISABLED") == 1 if free_threaded is None else free_threaded
+        is_debug = bool(sysconfig.get_config_var("Py_DEBUG")) if debug is None else debug
 
         def get_python(self: VirtualEnv, base_python: list[str]) -> PythonInfo | None:  # noqa: ARG001
             if base_python[0] == "py31" or (base_python[0] == prev_py and not has_prev):
@@ -129,6 +132,7 @@ def patch_prev_py(mocker: MockerFixture) -> PatchPrevPy:
                 platform=sys.platform,
                 extra={"executable": Path(sys.executable)},
                 free_threaded=is_free_threaded,
+                debug=is_debug,
                 machine=sysconfig.get_platform().rsplit("-", 1)[-1] or None,
             )
 

--- a/tests/session/cmd/test_legacy.py
+++ b/tests/session/cmd/test_legacy.py
@@ -176,6 +176,7 @@ def test_legacy_cli_flags(tox_project: ToxProjectCreator, mocker: MockerFixture)
     interpreter.architecture = 64
     interpreter.platform = "darwin"
     interpreter.free_threaded = False
+    interpreter.debug_build = False
     interpreter.version_info.major = 3
     interpreter.version_info.minor = 14
     interpreter.version_info.micro = 0

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -35,7 +35,12 @@ def replace_py(repo_root: Path) -> Path:
 
 @pytest.fixture(scope="session")
 def default_tombi_cfg() -> str:
+    # empty catalog: tombi's bundled pyproject.json schema $refs an external partial-tox.json it cannot
+    # fetch under --offline, so leaving the default catalog on turns that miss into an error-on-warnings failure
     return dedent("""\
+        [schema.catalog]
+        paths = []
+
         [[schemas]]
         path = "tox.schema.json"
         include = ["tox.toml"]
@@ -152,6 +157,9 @@ def project_lint_case(request: pytest.FixtureRequest, repo_root: Path, default_t
         return "tox.toml", (repo_root / "tox.toml").read_text(), default_tombi_cfg
     if request.param == "pyproject.toml":
         cfg = dedent("""\
+            [schema.catalog]
+            paths = []
+
             [[schemas]]
             root = "tool.tox"
             path = "tox.schema.json"

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -121,6 +121,7 @@ def test_result_json_sequential(
         "version": py_info.version,
         "version_info": list(py_info.version_info),
         "free_threaded": py_info.free_threaded,
+        "debug": py_info.debug_build,
         "machine": py_info.machine,
     }
     packaging_setup = get_cmd_exit_run_id(log_report, ".pkg", "setup")

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -11,6 +11,7 @@ import pytest
 
 from tox.tox_env.errors import Fail
 from tox.tox_env.python.api import Python
+from tox.tox_env.python.virtual_env.api import VirtualEnv
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -559,6 +560,40 @@ def test_python_spec_for_sys_executable(
     assert spec.architecture == arch
     assert spec.free_threaded == bool(free_threaded)
     assert spec.machine == expected_machine
+
+
+@pytest.mark.parametrize(
+    ("impl", "major", "minor", "arch", "free_threaded", "machine"),
+    [
+        ("cpython", 3, 13, 64, True, "x86_64"),
+        ("cpython", 3, 13, 64, False, "x86_64"),
+        ("cpython", 3, 12, 64, None, None),
+    ],
+)
+def test_python_spec_for_path(
+    impl: str,
+    major: int,
+    minor: int,
+    arch: int,
+    free_threaded: bool | None,
+    machine: str | None,
+    mocker: MockerFixture,
+) -> None:
+    info = SimpleNamespace(
+        implementation=impl,
+        version_info=SimpleNamespace(major=major, minor=minor, micro=5),
+        architecture=arch,
+        free_threaded=free_threaded,
+        machine=machine,
+    )
+    mocker.patch.object(VirtualEnv, "get_virtualenv_py_info", return_value=info)
+    spec = VirtualEnv.python_spec_for_path(Path("/does/not/matter"))
+    assert spec.implementation == impl
+    assert spec.major == major
+    assert spec.minor == minor
+    assert spec.architecture == arch
+    assert spec.free_threaded == bool(free_threaded)
+    assert spec.machine == machine
 
 
 _PY_VER = f"{sys.version_info[0]}.{sys.version_info[1]}"

--- a/tests/tox_env/python/test_python_api.py
+++ b/tests/tox_env/python/test_python_api.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+from virtualenv.discovery.py_spec import PythonSpec
 
 from tox.tox_env.errors import Fail
 from tox.tox_env.python.api import Python
@@ -143,6 +144,38 @@ def test_build_wheel_in_free_threaded_pkg_env(
     ]
 
 
+def test_build_wheel_in_debug_pkg_env(
+    tox_project: ToxProjectCreator,
+    patch_prev_py: PatchPrevPy,
+    demo_pkg_inline: Path,
+    mocker: MockerFixture,
+) -> None:
+    def _fake_session(env_dir: list[str], **_: object) -> MagicMock:
+        bin_dir = Path(env_dir[0]) / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        (bin_dir / "python").symlink_to(sys.executable)
+        mock = MagicMock()
+        mock.creator.bin_dir = bin_dir
+        mock.creator.script_dir = bin_dir
+        return mock
+
+    mocker.patch("tox.tox_env.python.virtual_env.api.session_via_cli", side_effect=_fake_session)
+    prev_ver, impl, _ = patch_prev_py(True, debug=True)
+    prev_py = f"py{prev_ver}"
+    prj = tox_project({"tox.ini": f"[tox]\nenv_list= {prev_py}\n[testenv]\npackage=wheel"})
+    execute_calls = prj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = prj.run("-r", "--root", str(demo_pkg_inline), "--workdir", str(prj.path / ".tox"))
+    result.assert_success()
+    calls = [(i[0][0].conf.name, i[0][3].run_id) for i in execute_calls.call_args_list]
+    assert calls == [
+        (f".pkg-{impl}{prev_ver}d", "_optional_hooks"),
+        (f".pkg-{impl}{prev_ver}d", "get_requires_for_build_wheel"),
+        (f".pkg-{impl}{prev_ver}d", "build_wheel"),
+        (f"py{prev_ver}", "install_package"),
+        (f".pkg-{impl}{prev_ver}d", "_exit"),
+    ]
+
+
 def test_diff_msg_added_removed_changed() -> None:
     before = {"A": "1", "F": "8", "C": "3", "D": "4", "E": "6"}
     after = {"G": "9", "B": "2", "C": "3", "D": "5", "E": "7"}
@@ -213,6 +246,19 @@ def test_diff_msg_no_diff() -> None:
         ("tests-3.10", "3.10"),
         ("tests-3.10t", "3.10t"),
         ("foo-3.14-bar", "3.14"),
+        ("py311d", "py311d"),
+        ("py311td", "py311td"),
+        ("py3.12d", "py3.12d"),
+        ("cpython3.8d", "cpython3.8d"),
+        ("functional-py310d", "py310d"),
+        ("bar-pypy2d-foo", "pypy2d"),
+        ("3.10d", "3.10d"),
+        ("3.10td", "3.10td"),
+        ("pypy-3.10d", "pypy3.10d"),
+        ("3.10d-tests", "3.10d"),
+        ("pyd", None),
+        ("graalpyd", None),
+        ("django-32d", None),
     ],
     ids=lambda a: "|".join(a) if isinstance(a, list) else str(a),
 )
@@ -514,13 +560,13 @@ commands = [["python", "-c", "print('ok')"]]
 
 
 @pytest.mark.parametrize(
-    ("impl", "major", "minor", "arch", "free_threaded", "platform_str", "expected_machine"),
+    ("impl", "major", "minor", "arch", "free_threaded", "debug", "platform_str", "expected_machine"),
     [
-        ("cpython", 3, 12, 64, None, "linux-x86_64", "x86_64"),
-        ("cpython", 3, 13, 64, True, "linux-aarch64", "arm64"),
-        ("cpython", 3, 13, 64, False, "win-amd64", "x86_64"),
-        ("pypy", 3, 9, 32, None, "win32", None),
-        ("cpython", 3, 12, 64, None, "macosx-14.0-arm64", "arm64"),
+        ("cpython", 3, 12, 64, None, False, "linux-x86_64", "x86_64"),
+        ("cpython", 3, 13, 64, True, True, "linux-aarch64", "arm64"),
+        ("cpython", 3, 13, 64, False, True, "win-amd64", "x86_64"),
+        ("pypy", 3, 9, 32, None, False, "win32", None),
+        ("cpython", 3, 12, 64, None, False, "macosx-14.0-arm64", "arm64"),
     ],
 )
 def test_python_spec_for_sys_executable(
@@ -529,6 +575,7 @@ def test_python_spec_for_sys_executable(
     minor: int,
     arch: int,
     free_threaded: bool | None,
+    debug: bool,
     platform_str: str,
     expected_machine: str,
     mocker: MockerFixture,
@@ -538,6 +585,8 @@ def test_python_spec_for_sys_executable(
     def get_config_var(name: str) -> object:
         if name == "Py_GIL_DISABLED":
             return free_threaded
+        if name == "Py_DEBUG":
+            return debug
         return get_config_var_(name)
 
     version_info = SimpleNamespace(major=major, minor=minor, micro=5, releaselevel="final", serial=0)
@@ -559,15 +608,17 @@ def test_python_spec_for_sys_executable(
     assert spec.minor == minor
     assert spec.architecture == arch
     assert spec.free_threaded == bool(free_threaded)
+    assert spec.debug is (True if debug else None)
     assert spec.machine == expected_machine
 
 
 @pytest.mark.parametrize(
-    ("impl", "major", "minor", "arch", "free_threaded", "machine"),
+    ("impl", "major", "minor", "arch", "free_threaded", "debug_build", "machine"),
     [
-        ("cpython", 3, 13, 64, True, "x86_64"),
-        ("cpython", 3, 13, 64, False, "x86_64"),
-        ("cpython", 3, 12, 64, None, None),
+        ("cpython", 3, 13, 64, True, False, "x86_64"),
+        ("cpython", 3, 13, 64, False, True, "x86_64"),
+        ("cpython", 3, 13, 64, True, True, "x86_64"),
+        ("cpython", 3, 12, 64, None, False, None),
     ],
 )
 def test_python_spec_for_path(
@@ -576,6 +627,7 @@ def test_python_spec_for_path(
     minor: int,
     arch: int,
     free_threaded: bool | None,
+    debug_build: bool,
     machine: str | None,
     mocker: MockerFixture,
 ) -> None:
@@ -584,6 +636,7 @@ def test_python_spec_for_path(
         version_info=SimpleNamespace(major=major, minor=minor, micro=5),
         architecture=arch,
         free_threaded=free_threaded,
+        debug_build=debug_build,
         machine=machine,
     )
     mocker.patch.object(VirtualEnv, "get_virtualenv_py_info", return_value=info)
@@ -593,7 +646,27 @@ def test_python_spec_for_path(
     assert spec.minor == minor
     assert spec.architecture == arch
     assert spec.free_threaded == bool(free_threaded)
+    assert spec.debug is (True if debug_build else None)
     assert spec.machine == machine
+
+
+@pytest.mark.parametrize(
+    ("env", "base_debug", "conflicts"),
+    [
+        ("py313d", True, False),
+        ("py313d", False, True),
+        ("py313", True, False),
+    ],
+)
+def test_validate_base_python_debug(env: str, base_debug: bool, conflicts: bool, mocker: MockerFixture) -> None:
+    spec = PythonSpec.from_string_spec(f"cpython313{'d' if base_debug else ''}-64-x86_64")
+    mocker.patch.object(VirtualEnv, "python_spec_for_path", return_value=spec)
+    base_python = [str(Path("/opt/python3.13").absolute())]
+    if conflicts:
+        with pytest.raises(Fail, match=f"env name {env} conflicting with base python"):
+            VirtualEnv._validate_base_python(env, base_python, False)  # noqa: SLF001
+    else:
+        assert VirtualEnv._validate_base_python(env, base_python, False) == base_python  # noqa: SLF001
 
 
 _PY_VER = f"{sys.version_info[0]}.{sys.version_info[1]}"


### PR DESCRIPTION
tox compares the interpreter's free-threaded flag when it decides whether an env name conflicts with its `base_python`, but the two code paths that build the base spec disagreed. The `sys.executable` arm appended the `t` suffix while `python_spec_for_path` dropped it. 🐛 So any `base_python` given as a path reported non-free-threaded, and the contract documented in #3391 broke both ways. A `py313t` env refused a real free-threaded build, and a plain `py313` ran on one unnoticed. The second case is the risky one, since a silent accept is what the conflict check exists to catch.

The free-threaded fix restores the suffix in `python_spec_for_path` from the `free_threaded` flag it already reads. From there the same gap opens for debug (`Py_DEBUG`) builds, which python-discovery 1.4.4 (tox-dev/python-discovery#96) taught the spec grammar but tox had not wired up. ✨ Debug now threads through wherever free-threaded already does: the `py313d` and `py313td` factors, both spec-building arms, the base-python conflict check, the wheel build env tag, and the `{py_debug}` constant. Debug stays opt-in, so a factor with no marker still matches either build, in line with python-discovery's own semantics.

A `base_python` pointing at a free-threaded or debug interpreter now matches the corresponding factor and conflicts with one that omits it. The `test_schema.py` change is unrelated housekeeping. tombi 1.2.1 bundles a pyproject schema that references an external `partial-tox.json` it cannot fetch under `--offline`, so the schema-lint fixtures empty the remote catalog and validate only the local tox schema.
