### PR TITLE
Do not let a lone quote in a set_env value swallow the marker

### DIFF
--- a/docs/changelog/3988.bugfix.rst
+++ b/docs/changelog/3988.bugfix.rst
@@ -1,2 +1,2 @@
-Stop a lone quote in a ``set_env`` value (e.g. an apostrophe in ``can't``) from swallowing the ``;`` platform
-marker, which silently set the variable unconditionally with the marker text left in the value - by :user:`chuenchen309`.
+Stop a lone quote in a ``set_env`` value (e.g. an apostrophe in ``can't``) from swallowing the ``;`` platform marker,
+which silently set the variable unconditionally with the marker text left in the value - by :user:`chuenchen309`.

--- a/docs/changelog/3988.bugfix.rst
+++ b/docs/changelog/3988.bugfix.rst
@@ -1,0 +1,2 @@
+Stop a lone quote in a ``set_env`` value (e.g. an apostrophe in ``can't``) from swallowing the ``;`` platform
+marker, which silently set the variable unconditionally with the marker text left in the value - by :user:`chuenchen309`.

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -126,25 +126,23 @@ class SetEnv:
     @staticmethod
     def _split_value_marker(value: str) -> tuple[str, str]:
         # Parse value; marker format (PEP-496 style)
-        # Handle escaped semicolons (\;) and quoted strings. Quotes keep a ";"
-        # inside a quoted value from being read as the marker separator, but
-        # only when balanced -- a lone quote (e.g. an apostrophe in the value)
-        # must not swallow the marker, so retry ignoring quotes if one is left
-        # open.
+        # Handle escaped semicolons (\;) and quoted strings. Quotes keep a ";" inside a quoted value from being read
+        # as the marker separator, but only when balanced -- a lone quote (e.g. an apostrophe in the value) must not
+        # swallow the marker, so retry ignoring quotes if one is left open.
         for respect_quotes in (True, False):
             in_quotes = False
             quote_char = ""
-            i = 0
-            while i < len(value):
-                char = value[i]
-                if respect_quotes and char in {'"', "'"} and (i == 0 or value[i - 1] != "\\"):
+            index = 0
+            while index < len(value):
+                char = value[index]
+                if respect_quotes and char in {'"', "'"} and (index == 0 or value[index - 1] != "\\"):
                     if not in_quotes:
                         in_quotes, quote_char = True, char
                     elif char == quote_char:
                         in_quotes = False
-                elif char == ";" and not in_quotes and (i == 0 or value[i - 1] != "\\"):
-                    return value[:i].strip().replace("\\;", ";"), value[i + 1 :].strip()
-                i += 1
+                elif char == ";" and not in_quotes and (index == 0 or value[index - 1] != "\\"):
+                    return value[:index].strip().replace("\\;", ";"), value[index + 1 :].strip()
+                index += 1
             if not in_quotes:
                 break  # quotes balanced or absent: the first pass is authoritative
         return value.replace("\\;", ";"), ""

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -126,20 +126,27 @@ class SetEnv:
     @staticmethod
     def _split_value_marker(value: str) -> tuple[str, str]:
         # Parse value; marker format (PEP-496 style)
-        # Handle escaped semicolons (\;) and quoted strings
-        in_quotes = False
-        quote_char = ""
-        i = 0
-        while i < len(value):
-            char = value[i]
-            if char in {'"', "'"} and (i == 0 or value[i - 1] != "\\"):
-                if not in_quotes:
-                    in_quotes, quote_char = True, char
-                elif char == quote_char:
-                    in_quotes = False
-            elif char == ";" and not in_quotes and (i == 0 or value[i - 1] != "\\"):
-                return value[:i].strip().replace("\\;", ";"), value[i + 1 :].strip()
-            i += 1
+        # Handle escaped semicolons (\;) and quoted strings. Quotes keep a ";"
+        # inside a quoted value from being read as the marker separator, but
+        # only when balanced -- a lone quote (e.g. an apostrophe in the value)
+        # must not swallow the marker, so retry ignoring quotes if one is left
+        # open.
+        for respect_quotes in (True, False):
+            in_quotes = False
+            quote_char = ""
+            i = 0
+            while i < len(value):
+                char = value[i]
+                if respect_quotes and char in {'"', "'"} and (i == 0 or value[i - 1] != "\\"):
+                    if not in_quotes:
+                        in_quotes, quote_char = True, char
+                    elif char == quote_char:
+                        in_quotes = False
+                elif char == ";" and not in_quotes and (i == 0 or value[i - 1] != "\\"):
+                    return value[:i].strip().replace("\\;", ";"), value[i + 1 :].strip()
+                i += 1
+            if not in_quotes:
+                break  # quotes balanced or absent: the first pass is authoritative
         return value.replace("\\;", ";"), ""
 
     def load(self, item: str, args: ConfigLoadArgs | None = None) -> str:

--- a/tests/config/test_set_env.py
+++ b/tests/config/test_set_env.py
@@ -327,6 +327,20 @@ def test_set_env_environment_with_file_and_expanded_substitution(
             id="ini-marker-false",
         ),
         pytest.param(
+            "ini",
+            f"[testenv]\npackage=skip\nset_env=CONDITIONAL=can't; sys_platform == '{sys.platform}'",
+            True,
+            "can't",
+            id="ini-marker-true-apostrophe-value",
+        ),
+        pytest.param(
+            "ini",
+            "[testenv]\npackage=skip\nset_env=CONDITIONAL=can't; sys_platform == 'nonexistent'",
+            False,
+            None,
+            id="ini-marker-false-apostrophe-value",
+        ),
+        pytest.param(
             "toml",
             f'[env_run_base]\npackage="skip"\nset_env.CONDITIONAL = {{ value = "value", '
             f"marker = \"sys_platform == '{sys.platform}'\" }}",


### PR DESCRIPTION
`set_env` supports a `;` platform marker after a value (e.g. `set_env=LDFLAGS=-L/usr/local/lib ; sys_platform == "darwin"`, per the docs). `_split_value_marker` tracks quotes so a `;` inside a quoted value is not read as the separator — but a single unbalanced quote defeats it: an apostrophe in the value (`can't`) opens a quote that never closes, so the marker `;` and everything after it are treated as still inside quotes. The marker is silently dropped and the variable is set unconditionally, with the marker text left in the value:

```
set_env =
    K = can't ; sys_platform == "darwin"   # on linux: wrongly set to "can't ; sys_platform == \"darwin\""
```

The fix retries the scan ignoring quotes when a quote is left open, so a lone quote no longer suppresses the marker while a balanced quoted `;` (e.g. `-k "a ; b" ; marker`) still does.

- [x] ran the linter (ruff `v0.15.21`, `check` + `format --check`) — clean
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix (`test_set_env_marker` gains apostrophe-value cases, true and false; they fail before and pass after; full `test_set_env.py` and `tests/config/` stay green — 6631 passed)
- [x] added news fragment in `docs/changelog`
- [ ] documentation — the `;`-marker behavior is already documented; this only makes the parser match it

---

*Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, wrote and ran the repro and the tests, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*

