### PR TITLE
Run sequentially for run-parallel -p 0 instead of at CPU count

### DIFF
--- a/docs/changelog/3989.bugfix.rst
+++ b/docs/changelog/3989.bugfix.rst
@@ -1,2 +1,2 @@
-Make ``tox run-parallel -p 0`` turn parallelism off and run sequentially, as the ``-p`` help ("zero is turn off")
-and the legacy command already promise, instead of running at the CPU count - by :user:`chuenchen309`.
+Make ``tox run-parallel -p 0`` turn parallelism off and run sequentially, as the ``-p`` help ("zero is turn off") and
+the legacy command already promise, instead of running at the CPU count - by :user:`chuenchen309`.

--- a/docs/changelog/3989.bugfix.rst
+++ b/docs/changelog/3989.bugfix.rst
@@ -1,0 +1,2 @@
+Make ``tox run-parallel -p 0`` turn parallelism off and run sequentially, as the ``-p`` help ("zero is turn off")
+and the legacy command already promise, instead of running at the CPU count - by :user:`chuenchen309`.

--- a/src/tox/session/cmd/run/parallel.py
+++ b/src/tox/session/cmd/run/parallel.py
@@ -91,7 +91,7 @@ def run_parallel(state: State) -> int:
         raise SystemExit(msg)
     return execute(
         state,
-        max_workers=auto_detect_cpus() if option.parallel == 0 else option.parallel,
+        max_workers=1 if option.parallel == OFF_VALUE else option.parallel,
         has_spinner=option.parallel_no_spinner is False and option.parallel_live is False,
         live=option.parallel_live,
     )

--- a/tests/session/cmd/test_parallel.py
+++ b/tests/session/cmd/test_parallel.py
@@ -48,6 +48,16 @@ def test_parse_num_processes_minus_one() -> None:
         parse_num_processes("-1")
 
 
+def test_parallel_zero_turns_off(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+    # The -p help says "zero is turn off", so -p 0 must run sequentially (one
+    # worker) rather than auto-detecting the CPU count like -p auto.
+    execute = mocker.patch.object(parallel, "execute", return_value=0)
+    project = tox_project({"tox.ini": "[tox]\nno_package=true\nenv_list=a,b\n[testenv]\ncommands=python -c 'pass'\n"})
+    project.run("p", "-p", "0")
+
+    assert execute.call_args.kwargs["max_workers"] == 1
+
+
 def test_parallel_general(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch, mocker: MockerFixture) -> None:
     def setup(self: ToxEnv) -> None:
         if self.name == "f":


### PR DESCRIPTION
### Problem

`tox run-parallel -p 0` runs every environment at once (CPU count), even though the `-p` help says **"zero is turn off"**:

```
-p VAL, --parallel VAL   run tox environments in parallel, the argument controls
                         limit: all, auto - cpu count, some positive number,
                         zero is turn off
```

So `-p 0` behaves identically to `-p auto`, not as "off".

### Cause

`run_parallel` computed:

```python
max_workers=auto_detect_cpus() if option.parallel == 0 else option.parallel
```

`OFF_VALUE` is `0` and the legacy command already treats `parallel == 0` as sequential (`legacy.py`: `if option.parallel != 0:  # only 0 means sequential`), but `run_parallel` mapped `0` to the CPU count. This was a leftover from when the argument default *was* the CPU count; since #3109 made the default `"auto"`, `0` now only arrives from an explicit `-p 0`.

### Fix

Map `-p 0` to a single worker (sequential), matching the help text, `OFF_VALUE`, and the legacy path:

```python
max_workers=1 if option.parallel == OFF_VALUE else option.parallel
```

`-p all`/`-p auto`/`-p N` are unchanged.

### Testing

Added `test_parallel_zero_turns_off` (mocks `execute`, asserts `max_workers == 1` for `-p 0`); it fails on `main` (`max_workers` is the CPU count) and passes here. `tests/session/cmd/test_parallel.py` + legacy tests pass; `ruff` clean.

---

*Disclosure: authored by an AI coding agent (Claude Code) running on this account — it found the bug, wrote the repro and test, and this description. I review every change and am accountable for it; the verification is real and re-runnable from the diff.*
