### PR TITLE
🐛 fix(pkg): repair editable fallback and sdist-wheel root handling

### DIFF
--- a/docs/changelog/3992.bugfix.rst
+++ b/docs/changelog/3992.bugfix.rst
@@ -1,0 +1,6 @@
+Fix two packaging regressions:
+
+- ``package = editable`` on a build backend without PEP-660 support now falls back to ``editable-legacy`` with a warning
+  instead of crashing, also when the project metadata is static;
+- editable and wheel environments running after an ``sdist-wheel`` environment build from the project sources again,
+  instead of a stale temporary copy that made source edits invisible.

--- a/src/tox/config/of_type.py
+++ b/src/tox/config/of_type.py
@@ -31,6 +31,11 @@ class ConfigDefinition(ABC, Generic[T]):  # ruff:ignore[eq-without-hash]
     def __call__(self, conf: Config, loaders: list[Loader[T]], args: ConfigLoadArgs) -> T:
         raise NotImplementedError
 
+    @abstractmethod
+    def overwrite(self, value: T) -> None:
+        """Force the configuration to the given value, replacing any constant or already loaded one."""
+        raise NotImplementedError
+
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, ConfigDefinition):
             return False
@@ -61,6 +66,9 @@ class ConfigConstantDefinition(ConfigDefinition[T]):  # ruff:ignore[eq-without-h
         if callable(self.value):
             return cast("Callable[[], T]", self.value)()
         return self.value
+
+    def overwrite(self, value: T) -> None:
+        self.value = value
 
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, ConfigConstantDefinition):
@@ -128,6 +136,9 @@ class ConfigDynamicDefinition(ConfigDefinition[T]):  # ruff:ignore[eq-without-ha
                 value = self.post_process(value)
             self._cache = value
         return cast("T", self._cache)
+
+    def overwrite(self, value: T) -> None:
+        self._cache = value
 
     def __repr__(self) -> str:
         values = ((k, v) for k, v in vars(self).items() if k not in {"post_process", "_cache"} and v is not None)

--- a/src/tox/tox_env/python/virtual_env/package/pyproject.py
+++ b/src/tox/tox_env/python/virtual_env/package/pyproject.py
@@ -41,7 +41,6 @@ from .util import dependencies_with_extras, dependencies_with_extras_from_marker
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator, Sequence
 
-    from tox.config.of_type import ConfigConstantDefinition
     from tox.config.sets import EnvConfigSet
     from tox.execute.api import ExecuteStatus, Outcome
     from tox.tox_env.api import ToxEnvCreateArgs
@@ -130,6 +129,16 @@ class Pep517VenvPackager(PythonPackageToxEnv, ABC):
 
         self._root = value
         self._frontend_ = None  # force recreating the frontend with new root
+
+    @contextmanager
+    def root_at(self, value: Path) -> Iterator[None]:
+        """Point the builder at another source tree for the duration of one build, then restore the project root."""
+        previous = self.root
+        self.root = value
+        try:
+            yield
+        finally:
+            self.root = previous
 
     @staticmethod
     def id() -> str:
@@ -253,20 +262,7 @@ class Pep517VenvPackager(PythonPackageToxEnv, ABC):
         try:
             deps = self._load_deps(for_env)
         except BuildEditableNotSupportedError:
-            self.call_require_hooks.remove("editable")
-            targets = [e for e in self.builds.pop("editable") if e["package"] == "editable"]
-            names = ", ".join(sorted({t.env_name for t in targets if t.env_name}))
-
-            logging.error(  # ruff:ignore[error-instead-of-exception]
-                "package config for %s is editable, however the build backend %s does not support PEP-660, falling "
-                "back to editable-legacy - change your configuration to it",
-                names,
-                cast("Pep517VirtualEnvFrontend", self._frontend_).backend,
-            )
-            for env in targets:
-                cast("ConfigConstantDefinition[str]", env._defined["package"]).value = "editable-legacy"  # ruff:ignore[private-member-access]
-                self.builds["editable-legacy"].append(env)
-            self._run_state["setup"] = False  # force setup again as we need to provision wheel to get dependencies
+            self._fallback_to_editable_legacy()
             deps = self._load_deps(for_env)
         of_type: str = for_env["package"]
         if of_type == "editable-legacy":
@@ -293,7 +289,13 @@ class Pep517VenvPackager(PythonPackageToxEnv, ABC):
                 with w_env.display_context(self._has_display_suspended):
                     return w_env.perform_packaging(for_env)
             else:
-                self.setup()
+                try:
+                    self.setup()
+                except BuildEditableNotSupportedError:
+                    # deps resolved without the backend (e.g. static metadata), so the missing PEP-660 support
+                    # surfaces only at setup - fall back and re-dispatch as editable-legacy
+                    self._fallback_to_editable_legacy()
+                    return self.perform_packaging(for_env)
                 method = "build_editable" if of_type == "editable" else "build_wheel"
                 config_settings = self.conf[f"config_settings_{method}"]
                 with self._pkg_lock:
@@ -309,6 +311,21 @@ class Pep517VenvPackager(PythonPackageToxEnv, ABC):
             msg = f"cannot handle package type {of_type}"
             raise TypeError(msg)  # pragma: no cover
         return [package]
+
+    def _fallback_to_editable_legacy(self) -> None:
+        self.call_require_hooks.remove("editable")
+        targets = [e for e in self.builds.pop("editable") if e["package"] == "editable"]
+        names = ", ".join(sorted({t.env_name for t in targets if t.env_name}))
+        logging.error(
+            "package config for %s is editable, however the build backend %s does not support PEP-660, falling "
+            "back to editable-legacy - change your configuration to it",
+            names,
+            cast("Pep517VirtualEnvFrontend", self._frontend_).backend,
+        )
+        for env in targets:
+            env._defined["package"].overwrite("editable-legacy")  # ruff:ignore[private-member-access]
+            self.builds["editable-legacy"].append(env)
+        self._run_state["setup"] = False  # force setup again as we need to provision wheel to get dependencies
 
     def _build_wheel_via_sdist(self, for_env: EnvConfigSet) -> Path:
         """Build a wheel by first building an sdist, then building a wheel from it."""
@@ -327,20 +344,20 @@ class Pep517VenvPackager(PythonPackageToxEnv, ABC):
 
             # Step 3: Get wheel_build_env child and point it at extracted sdist
             child_env = cast("Pep517VenvPackager", self._wheel_build_envs[for_env["wheel_build_env"]])
-            child_env.root = sdist_source_root
-            child_env.call_require_hooks.add("wheel")
-            if child_env is self:
-                self._setup_build_requires("wheel")
-            else:
-                child_env.setup()
+            with child_env.root_at(sdist_source_root):
+                child_env.call_require_hooks.add("wheel")
+                if child_env is self:
+                    self._setup_build_requires("wheel")
+                else:
+                    child_env.setup()
 
-            # Step 4: Build the wheel
-            wheel_config: ConfigSettings = child_env.conf["config_settings_build_wheel"]
-            return child_env._frontend.build_wheel(  # ruff:ignore[private-member-access]
-                wheel_directory=child_env.pkg_dir,
-                metadata_directory=None,
-                config_settings=wheel_config,
-            ).wheel
+                # Step 4: Build the wheel
+                wheel_config: ConfigSettings = child_env.conf["config_settings_build_wheel"]
+                return child_env._frontend.build_wheel(  # ruff:ignore[private-member-access]
+                    wheel_directory=child_env.pkg_dir,
+                    metadata_directory=None,
+                    config_settings=wheel_config,
+                ).wheel
 
     @staticmethod
     def _find_sdist_root(extract_dir: Path) -> Path:

--- a/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_pyproject.py
@@ -682,3 +682,61 @@ def test_config_inspection_does_not_read_pyproject(tox_project: ToxProjectCreato
     result = project.run("c", "-e", "py", "-k", "env_name")
     result.assert_success()
     assert "[testenv:py]\nenv_name = py\n" in result.out
+
+
+def test_pyproject_no_build_editable_fallback_from_config(
+    tox_project: ToxProjectCreator, demo_pkg_inline: Path
+) -> None:
+    """The editable-legacy fallback must also work when package=editable comes from configuration (not --develop)."""
+    toml_cfg = dedent("""\
+        env_list = ["a", "b"]
+        [env_run_base]
+        package = "editable"
+    """)
+    proj = tox_project({"tox.toml": toml_cfg}, base=demo_pkg_inline)
+    proj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = proj.run("r", "-e", "a,b", "--notest")
+    result.assert_success()
+    warning = (
+        ".pkg: package config for a, b is editable, however the build backend build does not support PEP-660, "
+        "falling back to editable-legacy - change your configuration to it"
+    )
+    assert warning in result.out.splitlines()
+
+
+def test_pyproject_no_build_editable_fallback_static_meta(
+    tox_project: ToxProjectCreator, demo_pkg_inline: Path
+) -> None:
+    """The fallback must fire even when static metadata delays the missing PEP-660 detection to build time."""
+    toml = f"{(demo_pkg_inline / 'pyproject.toml').read_text()}[project]\nname='demo'\nversion='1.0'\n"
+    toml_cfg = dedent("""\
+        env_list = ["a"]
+        [env_run_base]
+        package = "editable"
+    """)
+    proj = tox_project({"tox.toml": toml_cfg, "pyproject.toml": toml}, base=demo_pkg_inline)
+    proj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+    result = proj.run("r", "-e", "a", "--notest")
+    result.assert_success()
+    warning = (
+        ".pkg: package config for a is editable, however the build backend build does not support PEP-660, "
+        "falling back to editable-legacy - change your configuration to it"
+    )
+    assert warning in result.out.splitlines()
+
+
+def test_build_wheel_via_sdist_restores_root(tox_project: ToxProjectCreator, demo_pkg_inline: Path) -> None:
+    """The sdist-based wheel build must not leave the builder pointed at the extracted sdist tree."""
+    toml_cfg = dedent("""\
+        env_list = ["a"]
+        [env_run_base]
+        package = "sdist-wheel"
+    """)
+    proj = tox_project({"tox.toml": toml_cfg}, base=demo_pkg_inline)
+    proj.patch_execute(lambda r: 0 if "install" in r.run_id else None)
+
+    result = proj.run("r", "-e", "a", "--notest")
+
+    result.assert_success()
+    pkg = cast("pyproject_pkg.Pep517VenvPackager", result.state.envs[".pkg"])
+    assert pkg.root == pkg.conf["package_root"]


### PR DESCRIPTION
Two packaging behaviors broke in ways a project only notices in production use. Setting `package = editable` in the configuration on a build backend without PEP-660 support crashed tox with an internal error, while the same setup through `--develop` degraded gracefully; the documented behavior is a warning and an automatic fall back to `editable-legacy`. That fallback now works from configuration too, including for projects with static metadata, where the missing backend support only becomes visible once the build starts.

Running an editable or wheel environment after an `sdist-wheel` environment silently produced a broken development install: the build happened from a temporary sdist extraction rather than the project sources, so later source edits were invisible in the environment, and the outcome changed with environment order. Builds after an `sdist-wheel` build now always use the project sources.

Both fixes ship with reproductions against the in-repo demo backend, and the temporary source swap for sdist-based builds is now scoped so it cannot leak past the one build that needs it.
