### PR TITLE
🐛 fix(config): rebuild loader chains per config set

### DIFF
--- a/docs/changelog/3993.bugfix.rst
+++ b/docs/changelog/3993.bugfix.rst
@@ -1,0 +1,6 @@
+An environment serving as both a run environment and a package environment now behaves predictably:
+
+- one defined through a ``[testenv:...]``-style section and referenced by ``package_env`` inherits from
+  ``pkgenv``/``env_pkg_base`` as documented, instead of silently keeping run environment defaults;
+- one listed in ``env_list`` while referenced as a package environment is reported as a configuration conflict up front,
+  instead of failing late with ``cannot run packaging environment`` or silently disappearing from ``tox l``.

--- a/src/tox/config/source/api.py
+++ b/src/tox/config/source/api.py
@@ -22,7 +22,6 @@ class Source(ABC):
 
     def __init__(self, path: Path) -> None:
         self.path: Path = path  #: the path to the configuration source
-        self._section_to_loaders: dict[str, list[Loader[Any]]] = {}
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(path={self.path})"
@@ -44,16 +43,11 @@ class Source(ABC):
         :returns: the loaders to use
 
         """
+        # loaders are built fresh per config set: their parent chain depends on the base sections, and a section can
+        # be redefined with another base (a run env re-created as a package env); the config set is what gets cached
         section = self.transform_section(section)
-        key = section.key
-        if key in self._section_to_loaders:
-            yield from self._section_to_loaders[key]
-            return
-        loaders: list[Loader[Any]] = []
-        self._section_to_loaders[key] = loaders
         loader: Loader[Any] | None = self.get_loader(section, override_map)
         if loader is not None:
-            loaders.append(loader)
             yield loader
 
         if base is not None:
@@ -72,7 +66,6 @@ class Source(ABC):
                 if child is not None and loader is not None:
                     child.parent = loader
                 yield loader
-                loaders.append(loader)
 
     @abstractmethod
     def transform_section(self, section: Section) -> Section:

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -488,7 +488,7 @@ class EnvSelector:
             missing_active = self._cli_envs is not None and self._cli_envs.is_all
             package_tox_env: PackageToxEnv | None = None
             try:
-                package_tox_env = self._get_package_env(core_type, name, active.get(name, missing_active))
+                package_tox_env = self._get_package_env(core_type, name, run_env_name, active.get(name, missing_active))
                 self._pkg_env_counter[name] += 1
                 if (
                     child_name_type := self._register_child_packages(package_tox_env, run_env_name, active)
@@ -529,8 +529,16 @@ class EnvSelector:
             pass
         return name_type
 
-    def _get_package_env(self, packager: str, name: str, is_active: bool) -> PackageToxEnv:  # ruff:ignore[boolean-type-hint-positional-argument]
+    def _get_package_env(self, packager: str, name: str, run_env_name: str, is_active: bool) -> PackageToxEnv:  # ruff:ignore[boolean-type-hint-positional-argument]
         assert self._defined_envs_ is not None  # ruff:ignore[assert]
+        if name in set(cast("EnvList", self._state.conf.core["env_list"]).envs):
+            # an env cannot both be asked to run and serve as a builder - fail here with the full picture rather
+            # than late at execution with "cannot run packaging environment"
+            msg = (
+                f"{name} is listed in env_list but is used as a package environment by {run_env_name}; "
+                f"remove it from env_list or rename the package environment"
+            )
+            raise HandledError(msg)
         if name in self._defined_envs_:
             env = self._defined_envs_[name].env
             if isinstance(env, PackageToxEnv):

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from itertools import count
+from textwrap import dedent
 from typing import TYPE_CHECKING, Final
 
 import pytest
@@ -621,12 +622,12 @@ def test_pkg_env_rollback_keeps_shared_env(tox_project: ToxProjectCreator) -> No
     """One env's failed build must not destroy a package env other envs already use."""
     ini = """
     [tox]
-    env_list = a,b,c
     skip_missing_interpreters = false
     [testenv]
     package = wheel
     [testenv:a]
     package = sdist
+    [testenv:b]
     [testenv:c]
     wheel_build_env = b
     [testenv:.pkg]
@@ -634,7 +635,7 @@ def test_pkg_env_rollback_keeps_shared_env(tox_project: ToxProjectCreator) -> No
     """
     project = tox_project({"tox.ini": ini, "pyproject.toml": ""})
 
-    outcome = project.run("l")
+    outcome = project.run("c", "-e", "a,b,c", "-k", "env_name")
 
     outcome.assert_success()
     envs = outcome.state.envs
@@ -676,3 +677,107 @@ def test_pkg_env_skip_from_plugin_hook(tox_project: ToxProjectCreator) -> None:
     outcome = project.run("l")
 
     outcome.assert_success()
+
+
+@pytest.mark.parametrize(
+    ("files", "expected_base", "expected_marker"),
+    [
+        pytest.param(
+            {
+                "tox.ini": dedent("""\
+                    [testenv]
+                    package = wheel
+                    package_env = mypkg
+                    set_env = MARKER=from_testenv
+                    [testenv:mypkg]
+                    package = skip
+                    [pkgenv]
+                    set_env = MARKER=from_pkgenv
+                """),
+                "pyproject.toml": "",
+            },
+            ["pkgenv"],
+            "from_pkgenv",
+            id="ini",
+        ),
+        pytest.param(
+            {
+                "tox.toml": dedent("""\
+                    [env_run_base]
+                    package = "wheel"
+                    package_env = "mypkg"
+                    set_env = { MARKER = "from_run_base" }
+                    [env.mypkg]
+                    package = "skip"
+                    [env_pkg_base]
+                    set_env = { MARKER = "from_pkg_base" }
+                """),
+                "pyproject.toml": "",
+            },
+            None,
+            "from_pkg_base",
+            id="toml",
+        ),
+    ],
+)
+def test_pkg_env_redefined_uses_pkg_base(
+    tox_project: ToxProjectCreator,
+    files: dict[str, str],
+    expected_base: list[str] | None,
+    expected_marker: str,
+) -> None:
+    """An env first built as a run env and then redefined as a package env must load the package base chain."""
+    project = tox_project(files)
+
+    outcome = project.run("c", "-e", "mypkg,py", "-k", "set_env", "base")
+
+    outcome.assert_success()
+    pkg_conf = outcome.state.conf.get_env("mypkg")
+    if expected_base is not None:
+        assert pkg_conf["base"] == expected_base
+    assert pkg_conf["set_env"].load("MARKER") == expected_marker
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        pytest.param(
+            {
+                "tox.ini": dedent("""\
+                    [tox]
+                    env_list = mypkg, py
+                    [testenv]
+                    package = wheel
+                    package_env = mypkg
+                    [testenv:mypkg]
+                    package = skip
+                """),
+                "pyproject.toml": "",
+            },
+            id="ini",
+        ),
+        pytest.param(
+            {
+                "tox.toml": dedent("""\
+                    env_list = ["mypkg", "py"]
+                    [env_run_base]
+                    package = "wheel"
+                    package_env = "mypkg"
+                    [env.mypkg]
+                    package = "skip"
+                """),
+                "pyproject.toml": "",
+            },
+            id="toml",
+        ),
+    ],
+)
+def test_pkg_env_in_env_list_fails(tox_project: ToxProjectCreator, files: dict[str, str]) -> None:
+    """An env cannot be asked to run and serve as a package environment; the conflict is reported, not hidden."""
+    project = tox_project(files)
+
+    outcome = project.run("l")
+
+    outcome.assert_failed()
+    msg = "mypkg is listed in env_list but is used as a package environment by py; remove it from env_list or rename"
+    assert msg in outcome.out, outcome.out


### PR DESCRIPTION
Package environments could silently run with the wrong configuration. When an environment serves as both a run environment and a package environment, tox kept the run environment's settings: `set_env`, `deps`, and `pass_env` came from `[testenv]`/`env_run_base` instead of the documented `[pkgenv]`/`env_pkg_base`, and the `base` setting disappeared from `tox c` output. Package builds picked up whatever the run defaults said, with no warning. The configuration now resolves through the package inheritance chain in every case, for both INI and TOML; the internal shortcut responsible could only serve stale data, so it is gone rather than patched around.

One spelling of this dual role is a contradiction rather than a customization: an environment listed in `env_list`, which asks tox to run it, while another environment names it as its builder. That combination used to fail late with `cannot run packaging environment` on `tox run` and vanish without a trace from `tox l`. It now fails as soon as environments are defined, with a message naming both roles and both environments, so the conflict is diagnosable from any command. Customizing a builder through a `[testenv:mypkg]`-style section keeps working, that path is the supported one and is what the inheritance fix above repairs.
