### PR TITLE
🐛 fix(pylock): install exactly what the lock file specifies

### DIFF
--- a/docs/changelog/3994.bugfix.rst
+++ b/docs/changelog/3994.bugfix.rst
@@ -1,0 +1,7 @@
+``pylock.toml`` installs now match the lock file:
+
+- a package locked once per Python range installs only the version matching the environment's interpreter;
+- packages locked to a local directory, VCS repository, or archive install from that source instead of resolving the
+  name against the package index;
+- locked hashes are verified when every entry carries one;
+- changing a pip environment variable such as ``PIP_INDEX_URL`` reinstalls, as it already did for ``deps``.

--- a/src/tox/tox_env/python/pip/pip_install.py
+++ b/src/tox/tox_env/python/pip/pip_install.py
@@ -216,14 +216,15 @@ class Pip(PythonInstallerListDependencies):
         raise Recreate(msg)
 
     def _install_pylock(self, pylock: Pylock, section: str, of_type: str) -> None:
-        requirements = pylock.requirements()
-        new_reqs = sorted(str(r) for r in requirements)
-        with self._env.cache.compare(new_reqs, section, of_type) as (eq, old):
+        new_reqs = sorted(pylock.install_lines())
+        cache_value = {"req": new_reqs, "env": self._install_env_vars()}
+        with self._env.cache.compare(cache_value, section, of_type) as (eq, old):
             if not eq:
-                if old is not None and (missing := sorted(set(old) - set(new_reqs))):
+                old_req: list[str] = old["req"] if isinstance(old, dict) else (old or [])
+                if missing := sorted(set(old_req) - set(new_reqs)):
                     msg = f"pylock dependencies removed: {' '.join(missing)}"
                     raise Recreate(msg)
-                if new_deps := sorted(set(new_reqs) - set(old or [])):
+                if new_deps := sorted(set(new_reqs) - set(old_req)) or new_reqs:
                     req_file = Path(self._env.env_dir) / "pylock.txt"
                     req_file.write_text("\n".join(new_deps))
                     self._execute_installer(["--no-deps", "-r", str(req_file)], of_type)

--- a/src/tox/tox_env/python/pylock.py
+++ b/src/tox/tox_env/python/pylock.py
@@ -6,12 +6,14 @@ from typing import TYPE_CHECKING
 
 from packaging.pylock import Package, PylockValidationError
 from packaging.pylock import Pylock as PackagingPylock
-from packaging.requirements import Requirement
 
 from tox.tox_env.errors import Fail
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
+
+    from packaging.pylock import PackageArchive, PackageVcs
 
 if sys.version_info >= (3, 11):  # pragma: no cover
     import tomllib
@@ -26,7 +28,8 @@ class Pylock:
     groups: frozenset[str] = frozenset()
     marker_env: dict[str, str] = field(default_factory=dict)
 
-    def requirements(self) -> list[Requirement]:
+    def install_lines(self) -> list[str]:
+        """Return pip requirement lines for the packages this environment locks."""
         with self.path.open("rb") as fh:
             data = tomllib.load(fh)
         try:
@@ -34,23 +37,61 @@ class Pylock:
         except PylockValidationError as exc:
             msg = f"invalid pylock file {self.path}: {exc}"
             raise Fail(msg) from exc
+        entries = [self._to_entry(pkg) for pkg in parsed.packages if self._is_active(pkg)]
+        if all(hashes for _, hashes in entries):
+            # pip's hash-checking mode is all-or-nothing for a requirements file: verify when every line can carry
+            # a hash, otherwise fall back to unverified installs (directory/VCS sources cannot be hashed)
+            return [f"{line} {' '.join(f'--hash={h}' for h in hashes)}" for line, hashes in entries]
+        return [line for line, _ in entries]
+
+    def _is_active(self, pkg: Package) -> bool:
         env: dict[str, str | frozenset[str]] = {**self.marker_env}
         if self.extras:
             env["extras"] = self.extras
         if self.groups:
             env["dependency_groups"] = self.groups
-        return [
-            self._to_requirement(pkg)
-            for pkg in parsed.packages
-            if pkg.marker is None or pkg.marker.evaluate(env, context="lock_file")
-        ]
+        if pkg.marker is not None and not pkg.marker.evaluate(env, context="lock_file"):
+            return False
+        full_version = self.marker_env.get("python_full_version")
+        if pkg.requires_python is not None and full_version is not None:
+            return pkg.requires_python.contains(full_version, prereleases=True)
+        return True
 
-    @staticmethod
-    def _to_requirement(pkg: Package) -> Requirement:
-        req_str = str(pkg.name)
-        if pkg.version is not None:
-            req_str += f"=={pkg.version}"
-        return Requirement(req_str)
+    def _to_entry(self, pkg: Package) -> tuple[str, list[str]]:
+        """Render a locked package as a pip requirement line plus the hashes that can verify it."""
+        if pkg.directory is not None:
+            uri = self._to_uri(pkg.directory.path, pkg.directory.subdirectory)
+            return (f"-e {uri}" if pkg.directory.editable else f"{pkg.name} @ {uri}"), []
+        if pkg.vcs is not None:
+            return f"{pkg.name} @ {self._to_vcs_url(pkg.vcs)}", []
+        if pkg.archive is not None:
+            return f"{pkg.name} @ {self._to_archive_url(pkg.archive)}", _hash_options(pkg.archive.hashes)
+        line = str(pkg.name) if pkg.version is None else f"{pkg.name}=={pkg.version}"
+        hashes = [
+            h for dist in (pkg.sdist, *(pkg.wheels or [])) if dist is not None for h in _hash_options(dist.hashes)
+        ]
+        return line, hashes
+
+    def _to_uri(self, path: str | Path, subdirectory: str | None = None) -> str:
+        # PEP 751 stores paths relative to the lock file; the subdirectory is the project root within it
+        target = self.path.parent / path
+        if subdirectory is not None:
+            target /= subdirectory
+        return target.resolve().as_uri()
+
+    def _to_vcs_url(self, vcs: PackageVcs) -> str:
+        location = vcs.url if vcs.url is not None else self._to_uri(vcs.path or ".")
+        revision = vcs.commit_id or vcs.requested_revision
+        url = f"{vcs.type}+{location}" if revision is None else f"{vcs.type}+{location}@{revision}"
+        return url if vcs.subdirectory is None else f"{url}#subdirectory={vcs.subdirectory}"
+
+    def _to_archive_url(self, archive: PackageArchive) -> str:
+        url = archive.url if archive.url is not None else self._to_uri(archive.path or ".")
+        return url if archive.subdirectory is None else f"{url}#subdirectory={archive.subdirectory}"
+
+
+def _hash_options(hashes: Mapping[str, str] | None) -> list[str]:
+    return [f"{algorithm}:{value}" for algorithm, value in (hashes or {}).items()]
 
 
 __all__ = [

--- a/tests/tox_env/python/test_pylock.py
+++ b/tests/tox_env/python/test_pylock.py
@@ -12,7 +12,7 @@ from tox.tox_env.python.pylock import Pylock
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from tox.pytest import ToxProjectCreator
+    from tox.pytest import ToxProject, ToxProjectCreator
 
 PYLOCK_TOML = dedent("""\
     lock-version = "1.0"
@@ -61,7 +61,9 @@ def test_pylock_install(tox_project: ToxProjectCreator) -> None:
     assert found_calls == [
         ("py", "install_pylock", ["python", "-I", "-m", "pip", "install", "--no-deps", "-r", req_file]),
     ]
-    assert (project.path / ".tox" / "py" / "pylock.txt").read_text() == "alpha==1.0.0\nbeta==2.0.0"
+    assert (
+        project.path / ".tox" / "py" / "pylock.txt"
+    ).read_text() == "alpha==1.0.0 --hash=sha256:abc123\nbeta==2.0.0 --hash=sha256:def456"
 
 
 def test_pylock_empty(tox_project: ToxProjectCreator) -> None:
@@ -246,7 +248,9 @@ def test_pylock_filters_by_extras(tox_project: ToxProjectCreator) -> None:
     result = project.run("r", "-e", "py")
 
     result.assert_success()
-    assert (project.path / ".tox" / "py" / "pylock.txt").read_text() == "alpha==1.0.0\nsphinx==7.0.0"
+    assert (
+        project.path / ".tox" / "py" / "pylock.txt"
+    ).read_text() == "alpha==1.0.0 --hash=sha256:abc\nsphinx==7.0.0 --hash=sha256:def"
 
 
 def test_pylock_filters_by_dependency_groups(tox_project: ToxProjectCreator) -> None:
@@ -301,7 +305,9 @@ def test_pylock_filters_by_dependency_groups(tox_project: ToxProjectCreator) -> 
     result = project.run("r", "-e", "py")
 
     result.assert_success()
-    assert (project.path / ".tox" / "py" / "pylock.txt").read_text() == "alpha==1.0.0\nruff==0.5.0"
+    assert (
+        project.path / ".tox" / "py" / "pylock.txt"
+    ).read_text() == "alpha==1.0.0 --hash=sha256:abc\nruff==0.5.0 --hash=sha256:def"
 
 
 def test_pylock_filters_by_platform_marker(tox_project: ToxProjectCreator) -> None:
@@ -372,9 +378,7 @@ def test_pylock_requirements(tmp_path: Path) -> None:
     lock_file.write_text(PYLOCK_TOML)
     pylock = Pylock(path=lock_file)
 
-    result = [str(r) for r in pylock.requirements()]
-
-    assert result == ["alpha==1.0.0", "beta==2.0.0"]
+    assert pylock.install_lines() == ["alpha==1.0.0 --hash=sha256:abc123", "beta==2.0.0 --hash=sha256:def456"]
 
 
 def test_pylock_requirements_filters_extras(tmp_path: Path) -> None:
@@ -408,11 +412,11 @@ def test_pylock_requirements_filters_extras(tmp_path: Path) -> None:
     """),
     )
 
-    with_extras = [str(r) for r in Pylock(path=lock_file, extras=frozenset({"docs"})).requirements()]
-    assert with_extras == ["alpha==1.0.0", "sphinx==7.0.0"]
+    with_extras = Pylock(path=lock_file, extras=frozenset({"docs"})).install_lines()
+    assert with_extras == ["alpha==1.0.0 --hash=sha256:abc", "sphinx==7.0.0 --hash=sha256:def"]
 
-    without_extras = [str(r) for r in Pylock(path=lock_file).requirements()]
-    assert without_extras == ["alpha==1.0.0"]
+    without_extras = Pylock(path=lock_file).install_lines()
+    assert without_extras == ["alpha==1.0.0 --hash=sha256:abc"]
 
 
 def test_pylock_requirements_invalid(tmp_path: Path) -> None:
@@ -427,7 +431,7 @@ def test_pylock_requirements_invalid(tmp_path: Path) -> None:
     pylock = Pylock(path=lock_file)
 
     with pytest.raises(Fail, match="invalid pylock file"):
-        pylock.requirements()
+        pylock.install_lines()
 
 
 @pytest.mark.slow
@@ -456,7 +460,7 @@ def test_pylock_install_integration(
                 url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30f4c7e48bb4cb87/six-1.17.0-py2.py3-none-any.whl"
 
                 [packages.wheels.hashes]
-                sha256 = "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8ez91c67d35ad282f3"
+                sha256 = "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
             """),
         },
     )
@@ -464,3 +468,144 @@ def test_pylock_install_integration(
 
     result.assert_success()
     assert "1.17.0" in result.out
+
+
+@pytest.fixture
+def pylock_run_base() -> str:
+    return dedent("""\
+        [env_run_base]
+        skip_install = true
+        pylock = "pylock.toml"
+    """)
+
+
+def _pylock_txt(project: ToxProject) -> str:
+    return (project.path / ".tox" / "py" / "pylock.txt").read_text()
+
+
+@pytest.mark.parametrize(
+    ("lock", "expected"),
+    [
+        pytest.param(
+            dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "example-pkg"
+                version = "1.0"
+                requires-python = "<3.9"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/example_pkg-1.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "aaa111"
+
+                [[packages]]
+                name = "example-pkg"
+                version = "2.0"
+                requires-python = ">=3.9"
+
+                [[packages.wheels]]
+                url = "https://files.example.com/example_pkg-2.0-py3-none-any.whl"
+
+                [packages.wheels.hashes]
+                sha256 = "bbb222"
+            """),
+            "example-pkg==2.0 --hash=sha256:bbb222",
+            id="requires-python selects the matching entry",
+        ),
+        pytest.param(
+            dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "my-local-pkg"
+
+                [packages.directory]
+                path = "sub/my_local_pkg"
+            """),
+            "my-local-pkg @ {project_uri}/sub/my_local_pkg",
+            id="directory installs from the locked path",
+        ),
+        pytest.param(
+            dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "my-local-pkg"
+
+                [packages.directory]
+                path = "."
+                editable = true
+            """),
+            "-e {project_uri}",
+            id="editable directory installs with -e",
+        ),
+        pytest.param(
+            dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "my-vcs-pkg"
+
+                [packages.vcs]
+                type = "git"
+                url = "https://example.com/repo.git"
+                commit-id = "abc123"
+            """),
+            "my-vcs-pkg @ git+https://example.com/repo.git@abc123",
+            id="vcs installs from the locked commit",
+        ),
+        pytest.param(
+            dedent("""\
+                lock-version = "1.0"
+                created-by = "test-tool"
+
+                [[packages]]
+                name = "my-archive-pkg"
+                version = "1.0"
+
+                [packages.archive]
+                url = "https://example.com/my-archive-pkg-1.0.tar.gz"
+
+                [packages.archive.hashes]
+                sha256 = "abc123"
+            """),
+            "my-archive-pkg @ https://example.com/my-archive-pkg-1.0.tar.gz --hash=sha256:abc123",
+            id="archive installs from the locked url with its hash",
+        ),
+    ],
+)
+def test_pylock_locked_sources_install_as_locked(
+    tox_project: ToxProjectCreator, pylock_run_base: str, lock: str, expected: str
+) -> None:
+    project = tox_project({"tox.toml": pylock_run_base, "pylock.toml": lock})
+    project.patch_execute()
+
+    result = project.run("r", "-e", "py")
+
+    result.assert_success()
+    assert _pylock_txt(project) == expected.format(project_uri=project.path.as_uri())
+
+
+def test_pylock_reinstall_on_resolution_env_change(tox_project: ToxProjectCreator, pylock_run_base: str) -> None:
+    """Changing a pip resolution environment variable invalidates the pylock install cache."""
+    project = tox_project({"tox.toml": pylock_run_base, "pylock.toml": PYLOCK_TOML})
+    execute_calls = project.patch_execute()
+    result = project.run("r", "-e", "py")
+    result.assert_success()
+    assert len(execute_calls.call_args_list) == 1
+
+    (project.path / "tox.toml").write_text(
+        f'{pylock_run_base}set_env = {{ PIP_INDEX_URL = "https://mirror.invalid/simple" }}\n'
+    )
+    execute_calls.reset_mock()
+    result_second = project.run("r", "-e", "py")
+
+    result_second.assert_success()
+    assert len(execute_calls.call_args_list) == 1


### PR DESCRIPTION
A `pylock.toml` could install something other than what it locks. A package locked twice, once per Python range, installed both versions and pip aborted. A package locked to a local directory, a VCS repository, or an archive was reduced to its bare name and resolved against the package index, so a same-named package on PyPI would install in place of the locked source, quietly. Every hash in the lock file was ignored, and changing an index setting like `PIP_INDEX_URL` did not trigger a reinstall the way it does for `deps`.

Installs now follow the lock: entries are chosen by the environment's interpreter version, locked sources install from where the lock points (with editable installs and subdirectories honored, and relative paths taken from the lock file's location), and hashes pass to pip whenever every installed entry carries one, turning on pip's verification. A lock mixing in sources that cannot be hashed, like a local directory, installs unverified as before, because pip's checking mode is all-or-nothing per install.

Projects whose lock files already carry hashes get verification without any configuration change; a lock whose hashes are wrong will now fail the install, which is the protection a lock file promises.
