### PR TITLE
🐛 fix(pip): stable rendering of set options in install cache

### DIFF
--- a/docs/changelog/3995.bugfix.rst
+++ b/docs/changelog/3995.bugfix.rst
@@ -1,0 +1,2 @@
+Re-running tox no longer rebuilds an environment at random when ``deps`` uses ``--no-binary`` or ``--only-binary`` with
+more than one package name.

--- a/src/tox/tox_env/python/pip/req_file.py
+++ b/src/tox/tox_env/python/pip/req_file.py
@@ -126,7 +126,7 @@ class PythonDeps(RequirementsFile):
             if not self.requirements and opts_dict:
                 msg = "no dependencies"
                 raise ValueError(msg)
-            result_opts: list[str] = [f"{key}={value}" for key, value in opts_dict.items()]
+            result_opts = _render_options(opts_dict)
             result_req = [str(req) for req in self.requirements]
             self._unroll = result_opts, result_req
         return self._unroll
@@ -239,7 +239,7 @@ class PythonConstraints(RequirementsFile):
             if not self.requirements and opts_dict:
                 msg = "no dependencies"
                 raise ValueError(msg)
-            result_opts: list[str] = [f"{key}={value}" for key, value in opts_dict.items()]
+            result_opts = _render_options(opts_dict)
             result_req = [str(req) for req in self.requirements]
             self._unroll = result_opts, result_req
         return self._unroll
@@ -294,6 +294,13 @@ ONE_ARG_ESCAPE = {
     "-e",
     "--editable",
 }
+
+
+def _render_options(options: dict[str, object]) -> list[str]:
+    # set-valued options (e.g. no_binary) render sorted so the value is stable across hash seeds - the install
+    # cache compares these strings and an order change would force a spurious recreate
+    return [f"{key}={','.join(sorted(value)) if isinstance(value, set) else value}" for key, value in options.items()]
+
 
 __all__ = (
     "ONE_ARG",

--- a/tests/tox_env/python/pip/test_req_file.py
+++ b/tests/tox_env/python/pip/test_req_file.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from argparse import Namespace
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
@@ -110,3 +111,16 @@ def test_constraints_factory_invalid_type(tmp_path: Path) -> None:
     ) as exc_info:
         PythonConstraints.factory(tmp_path, {"key": "val"})
     assert "got dict: {'key': 'val'}" in str(exc_info.value)
+
+
+def test_deps_unroll_binary_options_deterministic(tmp_path: Path) -> None:
+    """Set-valued options must render in a stable order, or the install cache breaks across hash seeds."""
+    raw = dedent("""\
+        --no-binary six,packaging
+        pkg
+    """)
+    python_deps = PythonDeps(raw=raw, root=tmp_path)
+
+    options, _ = python_deps.unroll()
+
+    assert options == ["no_binary=packaging,six"]


### PR DESCRIPTION
Projects using `deps = --no-binary six,packaging` (or `--only-binary` with several names) saw tox rebuild the whole environment on a rerun, sometimes, with the log claiming the install flags changed when nothing had. Whether it happened depended on interpreter process randomization, so CI runs flipped between instant reruns and full rebuilds of the same configuration.

The remembered form of these options is now stable, so an unchanged configuration always compares equal and reruns stay incremental. tox-dev/tox#3974 fixed the same instability for the pip command line; this closes the remaining path through the environment cache.
