### PR TITLE
🐛 fix(cache): self-heal wrong-shape tox-info content

### DIFF
--- a/docs/changelog/3996.bugfix.rst
+++ b/docs/changelog/3996.bugfix.rst
@@ -1,0 +1,2 @@
+A corrupted environment status file (``.tox-info.json``) now always triggers an environment recreation instead of
+crashing tox with an internal error for some corruption shapes.

--- a/src/tox/tox_env/info.py
+++ b/src/tox/tox_env/info.py
@@ -25,7 +25,8 @@ class Info:
             value = json.loads(self._path.read_text())
         except (ValueError, OSError):
             value = {}
-        self._content = value
+        # a corrupted file must trigger recreation rather than crash, whatever shape the corruption takes
+        self._content = value if isinstance(value, dict) else {}
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(path={self._path})"
@@ -47,8 +48,9 @@ class Info:
 
         """
         old = self._content.get(section)
-        if sub_section is not None and old is not None:
-            old = old.get(sub_section)
+        if sub_section is not None:
+            # a non-dict section is corruption: treat it as absent so it gets replaced below
+            old = old.get(sub_section) if isinstance(old, dict) else None
 
         if old == value:
             yield True, old
@@ -61,10 +63,10 @@ class Info:
                 if not raised:  # only update when the body did not raise
                     if sub_section is None:
                         self._content[section] = value
-                    elif self._content.get(section) is None:
-                        self._content[section] = {sub_section: value}
-                    else:
+                    elif isinstance(self._content.get(section), dict):
                         self._content[section][sub_section] = value
+                    else:
+                        self._content[section] = {sub_section: value}
                     self._write()
 
     def reset(self) -> None:

--- a/tests/tox_env/test_info.py
+++ b/tests/tox_env/test_info.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+import pytest
 
 from tox.tox_env.info import Info
 
@@ -9,3 +12,29 @@ def test_info_repr() -> None:
     at_loc = Path().absolute()
     info_object = Info(at_loc)
     assert repr(info_object) == f"Info(path={at_loc / '.tox-info.json'})"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("null", id="null root"),
+        pytest.param('["a"]', id="list root"),
+        pytest.param('"text"', id="string root"),
+    ],
+)
+def test_info_non_dict_root_self_heals(tmp_path: Path, content: str) -> None:
+    (tmp_path / ".tox-info.json").write_text(content)
+
+    with Info(tmp_path).compare({"python": "3.14"}, "ToxEnv") as (eq, old):
+        assert (eq, old) == (False, None)
+
+    assert json.loads((tmp_path / ".tox-info.json").read_text()) == {"ToxEnv": {"python": "3.14"}}
+
+
+def test_info_non_dict_section_self_heals(tmp_path: Path) -> None:
+    (tmp_path / ".tox-info.json").write_text('{"PythonRun": "garbage"}')
+
+    with Info(tmp_path).compare(["six"], "PythonRun", "deps") as (eq, old):
+        assert (eq, old) == (False, None)
+
+    assert json.loads((tmp_path / ".tox-info.json").read_text()) == {"PythonRun": {"deps": ["six"]}}


### PR DESCRIPTION
tox keeps a small status file inside every environment to decide when a rebuild is due. When that file got corrupted, the outcome depended on what the corruption looked like: unreadable JSON healed itself with a rebuild, while readable-but-wrong content, a truncated write or an edited file, crashed tox with an internal error and exit code 2.

Every corruption shape now leads to the same place: the stored state counts as gone, the environment is recreated, and the run continues.
