### PR TITLE
🐛 fix(pep723): honor metadata behind a BOM, fail cleanly on bad blocks

### DIFF
--- a/docs/changelog/3997.bugfix.rst
+++ b/docs/changelog/3997.bugfix.rst
@@ -1,0 +1,3 @@
+PEP 723 scripts saved with a UTF-8 byte order mark now have their inline metadata honored (previously
+``requires-python`` and ``dependencies`` were silently ignored), and a script with invalid metadata reports a clear
+configuration error instead of an internal one.

--- a/src/tox/tox_env/python/pep723.py
+++ b/src/tox/tox_env/python/pep723.py
@@ -119,7 +119,12 @@ class Pep723Mixin(Python, RunToxEnv):
             if (size := full_path.stat().st_size) > _MAX_SCRIPT_BYTES:
                 msg = f"script file {full_path} is {size} bytes, exceeds the {_MAX_SCRIPT_BYTES} byte limit"
                 raise Fail(msg)
-            self._script_metadata = _parse_script_metadata(full_path.read_text(encoding="utf-8"))
+            try:
+                # utf-8-sig: a BOM would otherwise hide a metadata block starting on the first line
+                self._script_metadata = _parse_script_metadata(full_path.read_text(encoding="utf-8-sig"))
+            except ValueError as exc:  # config error, not a tox defect - includes TOMLDecodeError
+                msg = f"invalid inline script metadata in {full_path}: {exc}"
+                raise Fail(msg) from exc
         return self._script_metadata
 
     def _resolve_script_path(self) -> Path | None:

--- a/tests/tox_env/python/virtual_env/test_pep723.py
+++ b/tests/tox_env/python/virtual_env/test_pep723.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
@@ -92,24 +93,44 @@ def test_skip_env_install(tox_project: ToxProjectCreator) -> None:
 
 
 @pytest.mark.parametrize(
-    ("script", "error_fragment"),
+    "script",
     [
         pytest.param(
-            '# /// script\n# requires-python = ">=3.12"\n# ///\n\n# /// script\n# dependencies = []\n# ///\n',
-            "multiple",
+            dedent("""\
+                # /// script
+                # requires-python = ">=3.12"
+                # ///
+
+                # /// script
+                # dependencies = []
+                # ///
+            """),
             id="multiple-script-blocks",
         ),
         pytest.param(
-            "# /// script\n# requires-python = not valid toml\n# ///\n",
-            "Invalid",
+            dedent("""\
+                # /// script
+                # requires-python = not valid toml
+                # ///
+            """),
             id="malformed-toml",
+        ),
+        pytest.param(
+            dedent("""\
+                # /// script
+                # dependencies = [broken
+                # ///
+                print('ok')
+            """),
+            id="unclosed-list",
         ),
     ],
 )
-def test_invalid_script_metadata(tox_project: ToxProjectCreator, script: str, error_fragment: str) -> None:
+def test_invalid_script_metadata(tox_project: ToxProjectCreator, script: str) -> None:
     result, _ = _run(tox_project, {"tox.ini": _tox_ini(), "check.py": script})
     result.assert_failed()
-    assert error_fragment in result.out
+    assert "invalid inline script metadata" in result.out, result.out
+    assert "internal error" not in result.out
 
 
 def test_missing_script_file(tox_project: ToxProjectCreator) -> None:
@@ -155,3 +176,21 @@ def test_script_file_too_large_rejected(tox_project: ToxProjectCreator, mocker: 
     result = proj.run("r", "-e", "check", "--discover", sys.executable)
     result.assert_failed()
     assert "exceeds the 1 byte limit" in result.out
+
+
+def test_metadata_honored_with_bom(tox_project: ToxProjectCreator) -> None:
+    """A UTF-8 BOM (common Windows editor artifact) must not silently disable the metadata block."""
+    script = "\ufeff" + dedent("""\
+        # /// script
+        # requires-python = ">=99.0"
+        # ///
+        print("ok")
+    """)
+    tox_toml = dedent("""\
+        [env.check]
+        runner = "virtualenv-pep-723"
+        script = "check.py"
+    """)
+    result, _ = _run(tox_project, {"tox.toml": tox_toml, "check.py": script})
+    result.assert_failed()
+    assert "does not satisfy requires-python" in result.out


### PR DESCRIPTION
A PEP 723 script saved with a UTF-8 byte order mark, the default for several Windows editors, ran as if it had no inline metadata at all: `requires-python` went unenforced and declared dependencies never installed, with nothing in the output hinting why. The metadata block is now recognized behind a BOM.

A script whose metadata block holds invalid TOML, or that declares two metadata blocks, crashed tox with a raw traceback and exit code 2. Both are mistakes in the script, so they now produce a one-line configuration error naming the file, with exit code 1.
