### PR TITLE
🐛 fix(cli): honor tox c -o, clean devenv ALL error, correct provision pin

### DIFF
--- a/docs/changelog/3998.bugfix.rst
+++ b/docs/changelog/3998.bugfix.rst
@@ -1,0 +1,5 @@
+Fix three command line defects:
+
+- ``tox c -o FILE`` writes the default (ini) format to the file like the json and toml formats, without color codes;
+- ``tox devenv -e ALL`` reports that exactly one environment is required instead of crashing;
+- ``--no-provision FILE`` records the pinned version for a ``tox==X`` requirement instead of an empty string.

--- a/src/tox/provision.py
+++ b/src/tox/provision.py
@@ -119,9 +119,9 @@ def provision(state: State) -> int | bool:
         msg = f"provisioning explicitly disabled within {sys.executable}, but {miss_msg}"
         if isinstance(no_provision, str):
             msg += f" and wrote to {no_provision}"
-            min_version = str(next(i.specifier for i in requires if i.name == "tox")).split("=")
+            tox_specifier = next(i.specifier for i in requires if i.name == "tox")
             requires_dict = {
-                "minversion": min_version[1] if len(min_version) >= 2 else None,  # ruff:ignore[magic-value-comparison]
+                "minversion": next((s.version for s in tox_specifier if s.operator in {">=", "=="}), None),
                 "requires": [str(i) for i in requires],
             }
             Path(no_provision).write_text(

--- a/src/tox/session/cmd/devenv.py
+++ b/src/tox/session/cmd/devenv.py
@@ -32,6 +32,10 @@ def devenv(state: State) -> int:
     opt.no_test = True
     opt.package_only = False
     opt.install_pkg = None
+    if opt.env.is_all or len(list(opt.env)) != 1:
+        found = ", ".join(opt.env) or "ALL"
+        msg = f"exactly one target environment allowed in devenv mode but found {found}"
+        raise HandledError(msg)
     opt.fail_fast = False
     opt.skip_pkg_install = False
     loader = MemoryLoader(  # these configuration values are loaded from in-memory always (no file conf)

--- a/src/tox/session/cmd/show_config/ini.py
+++ b/src/tox/session/cmd/show_config/ini.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import sys
+from pathlib import Path
 from textwrap import indent
 from typing import TYPE_CHECKING
 
@@ -9,7 +11,7 @@ from colorama import Fore
 from tox.config.loader.stringify import stringify
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from tox.config.sets import ConfigSet
     from tox.session.state import State
@@ -17,62 +19,45 @@ if TYPE_CHECKING:
 
 
 def show_config_ini(state: State) -> int:
-    is_colored = state.conf.options.is_colored
+    output_file = state.conf.options.output_file
+    # color belongs to the terminal only - a file must hold plain text
+    is_colored = state.conf.options.is_colored and output_file is None
     keys: list[str] = state.conf.options.list_keys_only
-    is_first = True
+    # the terminal streams each line as its value materializes (evaluation can be slow); a file is written whole
+    lines: list[str] = []
+    emit: Callable[[str], None] = lines.append if output_file is not None else _write_line
     has_exception = False
+    is_first = True
 
-    def _print_env(tox_env: ToxEnv) -> None:
-        nonlocal is_first, has_exception
-        if is_first:
-            is_first = False
-        else:
-            print()  # ruff:ignore[print]
-        _print_section_header(is_colored, f"[testenv:{tox_env.conf.name}]")
+    def _emit_env(tox_env: ToxEnv) -> None:
+        nonlocal has_exception, is_first
+        if not is_first:
+            emit("")
+        is_first = False
+        emit(_colored(f"[testenv:{tox_env.conf.name}]", Fore.YELLOW, enabled=is_colored))
         if not keys:
-            _print_key_value(is_colored, "type", type(tox_env).__name__)
-        if _print_conf(is_colored, tox_env.conf, keys):
+            emit(_key_value("type", type(tox_env).__name__, is_colored=is_colored))
+        if _emit_conf(emit, tox_env.conf, keys, is_colored=is_colored):
             has_exception = True
 
-    show_everything = state.conf.options.env.is_all
-    done: set[str] = set()
     for name in state.envs.iter(package=True):
-        done.add(name)
-        _print_env(state.envs[name])
+        _emit_env(state.envs[name])
 
-    if show_everything or state.conf.options.show_core:
-        print()  # ruff:ignore[print]
-        _print_section_header(is_colored, "[tox]")
-        if _print_conf(is_colored, state.conf.core, keys):
+    if state.conf.options.env.is_all or state.conf.options.show_core:
+        emit("")
+        emit(_colored("[tox]", Fore.YELLOW, enabled=is_colored))
+        if _emit_conf(emit, state.conf.core, keys, is_colored=is_colored):
             has_exception = True
+    if output_file is not None:
+        Path(output_file).write_text("\n".join(lines) + "\n", encoding="utf-8")
     return -1 if has_exception else 0
 
 
-def _colored(is_colored: bool, color: int, msg: str) -> str:  # ruff:ignore[boolean-type-hint-positional-argument]
-    return f"{color}{msg}{Fore.RESET}" if is_colored else msg
+def _write_line(line: str) -> None:
+    sys.stdout.write(line + "\n")
 
 
-def _print_section_header(is_colored: bool, name: str) -> None:  # ruff:ignore[boolean-type-hint-positional-argument]
-    print(_colored(is_colored, Fore.YELLOW, name))  # ruff:ignore[print]
-
-
-def _print_comment(is_colored: bool, comment: str) -> None:  # ruff:ignore[boolean-type-hint-positional-argument]
-    print(_colored(is_colored, Fore.CYAN, comment))  # ruff:ignore[print]
-
-
-def _print_key_value(is_colored: bool, key: str, value: str, multi_line: bool = False) -> None:  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
-    print(_colored(is_colored, Fore.GREEN, key), end="")  # ruff:ignore[print]
-    print(" =", end="")  # ruff:ignore[print]
-    if multi_line:
-        print()  # ruff:ignore[print]
-        value_str = indent(value, prefix="  ")
-    else:
-        print(" ", end="")  # ruff:ignore[print]
-        value_str = value
-    print(value_str)  # ruff:ignore[print]
-
-
-def _print_conf(is_colored: bool, conf: ConfigSet, keys: Iterable[str]) -> bool:  # ruff:ignore[boolean-type-hint-positional-argument]
+def _emit_conf(emit: Callable[[str], None], conf: ConfigSet, keys: Iterable[str], *, is_colored: bool) -> bool:
     has_exception = False
     for key in keys or conf:
         if key not in conf:
@@ -84,12 +69,27 @@ def _print_conf(is_colored: bool, conf: ConfigSet, keys: Iterable[str]) -> bool:
         except Exception as exception:  # because e.g. the interpreter cannot be found
             if os.environ.get("_TOX_SHOW_CONFIG_RAISE"):  # pragma: no branch
                 raise  # pragma: no cover
-            as_str, multi_line = _colored(is_colored, Fore.LIGHTRED_EX, f"# Exception: {exception!r}"), False
+            as_str, multi_line = _colored(f"# Exception: {exception!r}", Fore.LIGHTRED_EX, enabled=is_colored), False
             has_exception = True
         if multi_line and "\n" not in as_str:
             multi_line = False
-        _print_key_value(is_colored, key, as_str, multi_line=multi_line)
+        emit(_key_value(key, as_str, is_colored=is_colored, multi_line=multi_line))
     unused = conf.unused()
     if unused and not keys:
-        _print_comment(is_colored, f"# !!! unused: {', '.join(unused)}")
+        emit(_colored(f"# !!! unused: {', '.join(unused)}", Fore.CYAN, enabled=is_colored))
     return has_exception
+
+
+def _key_value(key: str, value: str, *, is_colored: bool, multi_line: bool = False) -> str:
+    if multi_line:
+        return f"{_colored(key, Fore.GREEN, enabled=is_colored)} =\n{indent(value, prefix='  ')}"
+    return f"{_colored(key, Fore.GREEN, enabled=is_colored)} = {value}"
+
+
+def _colored(msg: str, color: int, *, enabled: bool) -> str:
+    return f"{color}{msg}{Fore.RESET}" if enabled else msg
+
+
+__all__ = [
+    "show_config_ini",
+]

--- a/tests/session/cmd/test_devenv.py
+++ b/tests/session/cmd/test_devenv.py
@@ -33,3 +33,10 @@ def test_devenv_ok(tox_project: ToxProjectCreator, enable_pip_pypi_access: str |
 def test_devenv_help(tox_project: ToxProjectCreator) -> None:
     outcome = tox_project({"tox.ini": ""}).run("d", "-h")
     outcome.assert_success()
+
+
+def test_devenv_fail_all_target(tox_project: ToxProjectCreator) -> None:
+    outcome = tox_project({"tox.ini": "[tox]\nenv_list=a,b"}).run("d", "-e", "ALL")
+    outcome.assert_failed()
+    msg = "ROOT: HandledError| exactly one target environment allowed in devenv mode but found ALL\n"
+    outcome.assert_out_err(msg, "")

--- a/tests/session/cmd/test_show_config.py
+++ b/tests/session/cmd/test_show_config.py
@@ -438,3 +438,14 @@ def test_core_on_platform(tox_project: ToxProjectCreator) -> None:
     result = project.run("c", "-e", "py", "--core", "-k", "on_platform")
     result.assert_success()
     assert result.out == f"[testenv:py]\n\n[tox]\non_platform = {sys.platform}\n"
+
+
+def test_show_config_ini_output_file(tox_project: ToxProjectCreator) -> None:
+    """The default format honors -o like the json and toml formats do."""
+    project = tox_project({"tox.toml": '[env_run_base]\npackage = "skip"\n'})
+
+    outcome = project.run("c", "-e", "py", "-k", "env_name", "-o", "out.txt")
+
+    outcome.assert_success()
+    assert (project.path / "out.txt").read_text() == "[testenv:py]\nenv_name = py\n"
+    assert not outcome.out

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -18,9 +18,9 @@ from packaging.requirements import Requirement
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
+    from build import DistributionType
     from devpi_process import Index, IndexServer
 
-    from build import DistributionType
     from tox.execute.request import ExecuteRequest
     from tox.pytest import MonkeyPatch, TempPathFactory, ToxProjectCreator
 

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -18,9 +18,9 @@ from packaging.requirements import Requirement
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
-    from build import DistributionType
     from devpi_process import Index, IndexServer
 
+    from build import DistributionType
     from tox.execute.request import ExecuteRequest
     from tox.pytest import MonkeyPatch, TempPathFactory, ToxProjectCreator
 
@@ -406,3 +406,14 @@ def test_provision_colored_passed_to_subprocess(tox_project: ToxProjectCreator) 
     assert captured_cmd is not None, "provision command not captured"
     assert "--colored" in captured_cmd, f"--colored not in command: {captured_cmd}"
     assert "yes" in captured_cmd, f"'yes' not in command: {captured_cmd}"
+
+
+def test_provision_no_recreate_json_pinned_tox(tox_project: ToxProjectCreator) -> None:
+    """A == pin on tox lands in the report as the version, not an empty string."""
+    project = tox_project({"tox.ini": "[tox]\nrequires = tox==999\nskipsdist=true\n"})
+
+    result = project.run("c", "-e", "py", "--no-provision", "out.json")
+
+    result.assert_failed()
+    requires = json.loads((project.path / "out.json").read_text())
+    assert requires == {"minversion": "999", "requires": ["tox==999", "tox"]}


### PR DESCRIPTION
Three command line rough edges. `tox c -o out.txt` claimed to write the configuration to a file but silently printed to the terminal in the default format; only `--format json` and `--format toml` honored the flag. The default format now writes the file too, as plain text without terminal color codes. Terminal output is untouched: it still streams each line as its value materializes, which matters on projects where evaluating an environment takes time.

`tox devenv -e ALL` crashed with a raw `StopIteration` traceback; it now reports that devenv needs exactly one target environment, the same message other invalid selections get.

`tox --no-provision out.json` with a pinned requirement like `requires = tox==999` wrote `"minversion": ""` into the machine-readable report; it now records the pinned version.
