### PR TITLE
🐛 fix(run): honor the fail-fast contract, resilient teardown

### DIFF
--- a/docs/changelog/3999.bugfix.rst
+++ b/docs/changelog/3999.bugfix.rst
@@ -1,0 +1,8 @@
+Restore the documented fail-fast contract and make cleanup resilient:
+
+- ``--fail-fast`` in parallel mode lets already running environments finish and report their real outcomes, instead of
+  interrupting them after a second and mislabeling them as skipped;
+- environments canceled by fail fast before starting report as skipped;
+- the overall exit code under fail fast is the first failed environment's exit code, as documented;
+- one environment failing to clean up no longer prevents the remaining environments from cleaning up (which could leave
+  tox hanging on exit).

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -22,6 +22,7 @@ from tox.execute import Outcome
 from tox.journal import write_journal
 from tox.report import HandledError
 from tox.session.cmd.run.single import ToxEnvRunResult, run_one
+from tox.tox_env.errors import Fail
 from tox.util.graph import stable_topological_sort
 from tox.util.spinner import MISS_DURATION, Spinner
 
@@ -149,7 +150,9 @@ def env_run_create_flags(parser: ArgumentParser, mode: str) -> None:
         )
 
 
-def report(start: float, runs: list[ToxEnvRunResult], is_colored: bool, verbosity: int) -> int:  # ruff:ignore[boolean-type-hint-positional-argument]
+def report(
+    start: float, runs: list[ToxEnvRunResult], *, is_colored: bool, verbosity: int, fail_fast: bool = False
+) -> int:
     def _print(color_: int, message: str) -> None:
         if verbosity:
             print(f"{color_ if is_colored else ''}{message}{Fore.RESET if is_colored else ''}")  # ruff:ignore[print]
@@ -173,6 +176,14 @@ def report(start: float, runs: list[ToxEnvRunResult], is_colored: bool, verbosit
     _print(Fore.RED, f"  evaluation failed :( ({duration:.2f} seconds)")
     if len(runs) == 1:
         return runs[0].code if not runs[0].skipped else 1
+    if fail_fast:
+        # under fail fast the run stops at the first failure, whose code is the documented overall exit code
+        first_failed = next(
+            (r for r in runs if not r.skipped and not r.ignore_outcome and not r.unavailable and r.code != Outcome.OK),
+            None,
+        )
+        if first_failed is not None:
+            return first_failed.code
     return 1
 
 
@@ -275,8 +286,10 @@ def execute(state: State, max_workers: int | None, has_spinner: bool, live: bool
         exit_code = report(
             state.conf.options.start,
             ordered_results,
-            state.conf.options.is_colored,
-            state.conf.options.verbosity,
+            is_colored=state.conf.options.is_colored,
+            verbosity=state.conf.options.verbosity,
+            fail_fast=state.conf.options.fail_fast
+            or any(cast("RunToxEnv", state.envs[env]).conf["fail_fast"] for env in to_run_list),
         )
         if has_previous:
             signal(SIGINT, previous)
@@ -344,9 +357,16 @@ def _queue_and_wait(  # ruff:ignore[too-many-arguments]
     finally:
         try:
             for name in to_run_list:
-                state.envs[name].teardown()
+                _tear_down(state.envs[name])
         finally:
             done.set()
+
+
+def _tear_down(tox_env: ToxEnv) -> None:
+    try:
+        tox_env.teardown()
+    except (Fail, OSError):  # one environment failing to clean up must not leak the others' resources
+        logger.warning("failed to tear down environment %s", tox_env.conf.name, exc_info=True)
 
 
 def _do_queue_and_wait(  # ruff:ignore[complex-structure, too-many-arguments, too-many-statements, too-many-branches]
@@ -376,6 +396,7 @@ def _do_queue_and_wait(  # ruff:ignore[complex-structure, too-many-arguments, to
             )
 
         env_list: list[str] = []
+        stop_scheduling = False
         fail_fast_enabled = options.parsed.fail_fast or any(
             cast("RunToxEnv", state.envs[env]).conf["fail_fast"] for env in to_run_list
         )
@@ -413,11 +434,11 @@ def _do_queue_and_wait(  # ruff:ignore[complex-structure, too-many-arguments, to
                             result = completed_future.result()
                         except CancelledError:
                             tox_env_done.teardown()
-                            name = tox_env_done.conf.name
+                            was_interrupted = interrupt.is_set()
                             result = ToxEnvRunResult(
-                                name=name,
-                                skipped=False,
-                                code=-3,
+                                name=tox_env_done.conf.name,
+                                skipped=not was_interrupted,
+                                code=-3 if was_interrupted else -2,
                                 outcomes=[],
                                 duration=MISS_DURATION,
                             )
@@ -425,15 +446,18 @@ def _do_queue_and_wait(  # ruff:ignore[complex-structure, too-many-arguments, to
                         completed.add(result.name)
                         if (
                             result.code != Outcome.OK
+                            and not result.skipped
                             and not result.ignore_outcome
                             and (options.parsed.fail_fast or result.fail_fast)
                         ):
-                            interrupt.set()
+                            # stop scheduling new work but let running environments finish: only a user interrupt
+                            # abandons them (cancel only stops futures the executor has not started yet)
+                            stop_scheduling = True
                             env_list = []
                             for pending_future in list(future_to_env.keys()):
                                 pending_future.cancel()
 
-                if not interrupt.is_set() and not env_list:
+                if not interrupt.is_set() and not stop_scheduling and not env_list:
                     env_list = next(envs_to_run_generator, [])
                 # if nothing running and nothing more to run we're done
                 final_run = not env_list and not future_to_env

--- a/src/tox/tox_env/python/virtual_env/package/pyproject.py
+++ b/src/tox/tox_env/python/virtual_env/package/pyproject.py
@@ -247,14 +247,17 @@ class Pep517VenvPackager(PythonPackageToxEnv, ABC):
             try:
                 if executor.is_alive:
                     self._frontend._send("_exit")  # try first on amicable shutdown  # ruff:ignore[private-member-access]
-            except (SystemExit, BrokenPipeError):  # pragma: no cover  # if interrupted or backend dead, ignore
+            except (SystemExit, BrokenPipeError, Fail):  # pragma: no cover  # if interrupted or backend dead, ignore
                 pass
             finally:
                 executor.close()
         for path in self._package_paths:
             if path.exists():
                 logging.debug("delete package %s", path)
-                path.unlink()
+                try:
+                    path.unlink()
+                except OSError as exception:  # e.g. still open on Windows; cleanup must reach the wheel build envs
+                    logging.warning("failed to delete package %s: %s", path, exception)
         super()._teardown()
 
     def perform_packaging(self, for_env: EnvConfigSet) -> list[Package]:

--- a/src/tox/tox_env/runner.py
+++ b/src/tox/tox_env/runner.py
@@ -11,6 +11,7 @@ from tox.config.types import Command, EnvList
 from tox.execute import Outcome
 
 from .api import ToxEnv, ToxEnvCreateArgs
+from .errors import Fail
 from .package import Package, PackageToxEnv, PathPackage
 from .util import add_change_dir_conf
 
@@ -151,7 +152,7 @@ class RunToxEnv(ToxEnv, ABC):
     def _call_pkg_envs(self, method_name: str, *args: Any) -> None:
         for package_env in self.package_envs:
             with package_env.display_context(suspend=self._has_display_suspended):
-                getattr(package_env, method_name)(*args)
+                _call_guarded(package_env, method_name, *args)
 
     def _clean(self, transitive: bool = False) -> None:  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
         if not self._run_state["clean"] and self.env_dir.exists():
@@ -275,3 +276,10 @@ class RunToxEnv(ToxEnv, ABC):
     def mark_active(self) -> None:
         for pkg_env in self.package_envs:
             pkg_env.mark_active_run_env(self)
+
+
+def _call_guarded(package_env: PackageToxEnv, method_name: str, *args: Any) -> None:
+    try:
+        getattr(package_env, method_name)(*args)
+    except (Fail, OSError):  # one package env failing must not leak the others' resources
+        logging.warning("failed to %s package environment %s", method_name, package_env.name, exc_info=True)

--- a/tests/session/cmd/test_parallel.py
+++ b/tests/session/cmd/test_parallel.py
@@ -4,6 +4,7 @@ import sys
 from argparse import ArgumentTypeError
 from signal import SIGINT
 from subprocess import PIPE, Popen
+from textwrap import dedent
 from time import sleep
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -286,3 +287,23 @@ def test_no_capture_short_flag_with_parallel_fails(tox_project: ToxProjectCreato
     ini = "[testenv]\npackage=skip\ncommands=python --version"
     result = tox_project({"tox.ini": ini}).run("p", "-e", "py", "-i")
     result.assert_failed()
+
+
+def test_parallel_fail_fast_lets_running_finish(tox_project: ToxProjectCreator) -> None:
+    """Documented contract: on fail fast, running environments finish; only pending ones are skipped."""
+    toml = dedent("""\
+        env_list = ["a", "b"]
+        [env_run_base]
+        package = "skip"
+        [env.a]
+        commands = [["python", "-c", "raise SystemExit(7)"]]
+        [env.b]
+        commands = [["python", "-c", "import time, pathlib; time.sleep(2); pathlib.Path('done.txt').write_text('x')"]]
+    """)
+    project = tox_project({"tox.toml": toml})
+
+    outcome = project.run("p", "-p", "2", "--fail-fast")
+
+    outcome.assert_failed(code=7)
+    assert (project.path / "done.txt").exists()
+    assert "b: OK" in outcome.out

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -8,6 +8,7 @@ import sys
 import sysconfig
 from pathlib import Path
 from subprocess import PIPE, Popen
+from textwrap import dedent
 from time import sleep
 from typing import TYPE_CHECKING, Any
 
@@ -17,9 +18,12 @@ from virtualenv.discovery.py_info import PythonInfo
 
 from tox import __version__
 from tox.tox_env.api import ToxEnv
+from tox.tox_env.errors import Fail
 from tox.tox_env.info import Info
 
 if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
     from tox.pytest import ToxProjectCreator
 
 
@@ -830,3 +834,52 @@ def test_second_interrupt_stops_post_commands(tox_project: ToxProjectCreator, tm
     assert marker_post_start.exists(), "commands_post should have started"
     assert not marker_post_end.exists(), "second SIGINT should have stopped commands_post"
     assert "second interrupt received" in out
+
+
+def test_fail_fast_exit_code_is_first_failure(tox_project: ToxProjectCreator) -> None:
+    """Documented contract: the overall exit code under fail fast is the first failed environment's code."""
+    toml = dedent("""\
+        env_list = ["a", "b"]
+        [env_run_base]
+        package = "skip"
+        [env.a]
+        commands = [["python", "-c", "raise SystemExit(7)"]]
+        [env.b]
+        commands = [["python", "-c", "print('ok')"]]
+    """)
+    project = tox_project({"tox.toml": toml})
+
+    outcome = project.run("r", "--fail-fast")
+
+    outcome.assert_failed(code=7)
+
+
+def test_teardown_continues_after_failure(tox_project: ToxProjectCreator, mocker: MockerFixture) -> None:
+    """One environment's teardown failure must not leave the remaining environments' resources alive."""
+    toml = dedent("""\
+        env_list = ["a", "b"]
+        [env_run_base]
+        package = "skip"
+        [env.a]
+        depends = ["b"]
+        [env.b]
+        depends = ["a"]
+    """)
+    project = tox_project({"tox.toml": toml})
+    torn_down: list[str] = []
+    original_teardown = ToxEnv.teardown
+
+    def recording_teardown(self: ToxEnv) -> None:
+        torn_down.append(self.conf.name)
+        if self.conf.name == "a":
+            msg = "teardown boom"
+            raise Fail(msg)
+        original_teardown(self)
+
+    mocker.patch.object(ToxEnv, "teardown", recording_teardown)
+
+    outcome = project.run("r", "--notest")
+
+    outcome.assert_failed()
+    assert "circular dependency detected" in outcome.out
+    assert torn_down == ["a", "b"]


### PR DESCRIPTION
The documentation promises that under `--fail-fast`, environments already running continue to completion and only pending ones are skipped, with the overall exit code being the first failed environment's code. Neither held. In parallel mode a failure interrupted every running environment about a second later, killed mid-command, and the report listed them as skipped with near-zero durations, hiding that they ran at all and inverting the promise, since a pending environment grabbed by a freeing worker could still run to completion. The overall exit code was always 1 for any multi-environment run.

Fail fast now stops scheduling new work while running environments drain and report their real outcomes; environments cancelled before starting report as skipped, and the exit code is the first failure's, so CI that matches on specific codes sees the same value as a single-environment run. Interrupting with Ctrl-C behaves as before.

Cleanup also survives its own failures now: one environment failing to tear down, a wedged build backend or a file still open on Windows, no longer prevents the remaining environments from releasing their processes, which could previously leave tox hanging at exit.
