### PR TITLE
🐛 fix(ux): four run-edge polish fixes

### DIFF
--- a/docs/changelog/4000.bugfix.rst
+++ b/docs/changelog/4000.bugfix.rst
@@ -1,0 +1,6 @@
+Polish four behaviors around the edges of a run:
+
+- an empty ``[tool.tox]`` stub in ``pyproject.toml`` no longer hides a ``tox.toml`` next to it;
+- setting ``CI=false`` (or empty) is respected as opting out of CI behavior;
+- spinner animation frames stay out of redirected output, which now holds plain text only;
+- the JSON report marks skipped environments with ``"skipped": true`` so they are distinguishable from passes.

--- a/src/tox/config/source/toml_pyproject.py
+++ b/src/tox/config/source/toml_pyproject.py
@@ -100,7 +100,7 @@ class TomlPyProject(Source):
             self._our_content = our_content
         except KeyError as exc:
             raise MissingRequiredConfigKeyError(path) from exc
-        if set(self._our_content.keys()) == {"legacy_tox_ini"}:
+        if set(self._our_content.keys()) <= {"legacy_tox_ini"}:  # an empty stub or a legacy pointer holds no config
             raise MissingRequiredConfigKeyError(path)
         self._env_base_generated, self._factor_labels = _build_env_base_map(
             dict(self._our_content.get(self._Section.ENV_BASE, {})),

--- a/src/tox/session/cmd/run/common.py
+++ b/src/tox/session/cmd/run/common.py
@@ -313,10 +313,12 @@ def _order_results(state: State, results: list[ToxEnvRunResult], to_run_list: li
 
 class ToxSpinner(Spinner):
     def __init__(self, enabled: bool, state: State, total: int) -> None:  # ruff:ignore[boolean-type-hint-positional-argument]
+        stream = state._options.log_handler.stdout  # ruff:ignore[private-member-access]
         super().__init__(
-            enabled=enabled,
+            # animation frames and erase sequences belong to an interactive terminal, never to redirected output
+            enabled=enabled and stream.isatty(),
             colored=state.conf.options.is_colored,
-            stream=state._options.log_handler.stdout,  # ruff:ignore[private-member-access]
+            stream=stream,
             total=total,
         )
 
@@ -483,6 +485,7 @@ def _handle_one_run_done(
             "success": success,
             "exit_code": result.code,
             "duration": result.duration,
+            "skipped": result.skipped,
         }
     if live is False and state.conf.options.parallel_live is False:  # teardown background run
         out_err = tox_env.close_and_read_out_err()  # sync writes from buffer to stdout/stderr

--- a/src/tox/util/ci.py
+++ b/src/tox/util/ci.py
@@ -19,11 +19,18 @@ _ENV_VARS = {  # per https://adamj.eu/tech/2020/03/09/detect-if-your-tests-are-r
 }
 
 
+_OPTED_OUT = frozenset({"", "0", "false"})
+
+
 def is_ci() -> bool:
     """:returns: a flag indicating if running inside a CI env or not"""
     for env_key, value in _ENV_VARS.items():
         if env_key in os.environ if value is None else os.environ.get(env_key) == value:
             if env_key == "TEAMCITY_VERSION" and os.environ.get(env_key) == "LOCAL":
+                continue
+            # the generic flag is the one users toggle: CI=false (or empty) is an explicit opt-out, the
+            # vendor-specific variables keep their pure presence semantics
+            if env_key == "CI" and os.environ[env_key].lower() in _OPTED_OUT:
                 continue
             return True
     return False

--- a/tests/config/source/test_toml_pyproject.py
+++ b/tests/config/source/test_toml_pyproject.py
@@ -1248,3 +1248,16 @@ def test_toml_machine_isa_implicit_when_no_env_isa(tox_project: ToxProjectCreato
     outcome = project.run("c", "-e", "py39", "-k", "description")
     outcome.assert_success()
     assert "matched" in outcome.out
+
+
+def test_empty_tool_tox_table_defers_to_tox_toml(tox_project: ToxProjectCreator) -> None:
+    """A leftover empty [tool.tox] stub has no usable configuration and must not shadow tox.toml."""
+    project = tox_project({
+        "pyproject.toml": "[project]\nname='demo'\nversion='1.0'\n[tool.tox]\n",
+        "tox.toml": 'env_list = ["special"]\n',
+    })
+
+    outcome = project.run("l", "--no-desc", "-q")
+
+    outcome.assert_success()
+    outcome.assert_out_err("special\n", "")

--- a/tests/session/cmd/test_parallel.py
+++ b/tests/session/cmd/test_parallel.py
@@ -307,3 +307,19 @@ def test_parallel_fail_fast_lets_running_finish(tox_project: ToxProjectCreator) 
     outcome.assert_failed(code=7)
     assert (project.path / "done.txt").exists()
     assert "b: OK" in outcome.out
+
+
+def test_parallel_spinner_stays_out_of_non_tty_output(tox_project: ToxProjectCreator) -> None:
+    """Redirected output must hold plain text, not spinner control sequences."""
+    toml = dedent("""\
+        env_list = ["a"]
+        [env_run_base]
+        package = "skip"
+        commands = [["python", "-c", "print('hi')"]]
+    """)
+    project = tox_project({"tox.toml": toml})
+
+    outcome = project.run("p")
+
+    outcome.assert_success()
+    assert "\x1b[" not in outcome.out

--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -145,7 +145,7 @@ def test_result_json_sequential(
 
     result_py = log_report["testenvs"]["py"].pop("result")
     assert result_py.pop("duration") > 0
-    assert result_py == {"success": True, "exit_code": 0}
+    assert result_py == {"success": True, "exit_code": 0, "skipped": False}
 
     py_setup = get_cmd_exit_run_id(log_report, "py", "setup")
     assert py_setup == [(0, "install_package_deps"), (0, "install_package"), (0, "freeze")]
@@ -883,3 +883,21 @@ def test_teardown_continues_after_failure(tox_project: ToxProjectCreator, mocker
     outcome.assert_failed()
     assert "circular dependency detected" in outcome.out
     assert torn_down == ["a", "b"]
+
+
+def test_result_json_marks_skipped(tox_project: ToxProjectCreator) -> None:
+    """A consumer of the JSON report can tell a skipped environment from a passing one."""
+    toml = dedent("""\
+        env_list = ["a", "b"]
+        [env_run_base]
+        package = "skip"
+        [env.a]
+        platform = "nonexistent"
+    """)
+    project = tox_project({"tox.toml": toml})
+
+    outcome = project.run("r", "--result-json", "out.json")
+
+    outcome.assert_success()
+    result = json.loads((project.path / "out.json").read_text())["testenvs"]["a"]["result"]
+    assert result == {"success": True, "exit_code": 0, "duration": result["duration"], "skipped": True}

--- a/tests/util/test_ci.py
+++ b/tests/util/test_ci.py
@@ -10,7 +10,7 @@ from tox.util.ci import _ENV_VARS, is_ci  # ruff:ignore[import-private-name]
 @pytest.mark.parametrize(
     "env_var",
     {
-        "CI": None,  # generic flag
+        "CI": "true",  # generic flag
         "TF_BUILD": "true",  # Azure Pipelines
         "bamboo.buildKey": None,  # Bamboo
         "BUILDKITE": "true",  # Buildkite
@@ -65,3 +65,12 @@ def test_is_ci_not_teamcity_local(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setenv("TEAMCITY_VERSION", "LOCAL")
     assert not is_ci()
+
+
+@pytest.mark.parametrize("value", ["false", "0", ""])
+def test_is_ci_generic_flag_opted_out(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("CI", value)
+
+    assert is_ci() is False


### PR DESCRIPTION
Four rough edges, each small but each a real surprise in daily use. A `pyproject.toml` holding a leftover empty `[tool.tox]` table claimed the configuration source, so a `tox.toml` sitting right next to it was silently ignored; an empty stub carries no configuration, so discovery now moves past it, the same way it already does for a `legacy_tox_ini` pointer. Setting `CI=false` or `CI=` counted as running in CI, flipping CI-only defaults such as dependency listing; the generic flag now honors the widespread opt-out convention, while vendor-set variables keep their plain presence semantics. Parallel runs with output redirected to a file wrote spinner frames and cursor-erase sequences into it; animation now only reaches an interactive terminal. And the machine-readable `--result-json` report recorded a skipped environment as a plain success, indistinguishable from a pass; entries now carry `"skipped": true`, an additive field, so existing consumers keep working.

Reviewed and left alone: the default `tox c` format prints a `set_env` value containing newlines across lines that its own parser would reject on paste-back. INI syntax has no representation for embedded newlines, so the round-trip is impossible in that format by construction; the json and toml formats reproduce such values faithfully and remain the formats to use for machine consumption.
