### PR TITLE
docs: fix typo 'set the the' -> 'set then the' in config reference

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -2452,7 +2452,7 @@ You can reference environment variables via the ``env`` replacement:
     [env.A]
     set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "ok" }
 
-If the environment variable is set the the ``COVERAGE_FILE`` will become that, otherwise will default to ``ok``.
+If the environment variable is set then the ``COVERAGE_FILE`` will become that, otherwise will default to ``ok``.
 
 References within set_env
 =========================


### PR DESCRIPTION
<!-- Thank you for your contribution!

Please, make sure you address all the checklists (for details on how see
[development documentation](https://tox.wiki/en/latest/development.html))! -->

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
- [ ] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
