### PR TITLE
🐛 fix(type): cast set value in _render_options

### DIFF
--- a/src/tox/tox_env/python/pip/req_file.py
+++ b/src/tox/tox_env/python/pip/req_file.py
@@ -299,7 +299,10 @@ ONE_ARG_ESCAPE = {
 def _render_options(options: dict[str, object]) -> list[str]:
     # set-valued options (e.g. no_binary) render sorted so the value is stable across hash seeds - the install
     # cache compares these strings and an order change would force a spurious recreate
-    return [f"{key}={','.join(sorted(value)) if isinstance(value, set) else value}" for key, value in options.items()]
+    return [
+        f"{key}={','.join(sorted(cast('set[str]', value))) if isinstance(value, set) else value}"
+        for key, value in options.items()
+    ]
 
 
 __all__ = (


### PR DESCRIPTION
The `type` and `type-min` jobs fail on `main`, so every scheduled `check` run goes red. ty reports `invalid-argument-type` at `src/tox/tox_env/python/pip/req_file.py:302`, where `sorted()` receives a value typed `object` that fails the `SupportsRichComparisonT` bound.

`_render_options` guards the `sorted()` call with `isinstance(value, set)`, but ty does not narrow the element type through that check, so `sorted` sees `object`. Casting the value to `set[str]` gives `sorted` a comparable element type. The same cast already appears twice in this module, at lines 148 and 257.

The cast vanishes at runtime, so rendering does not change and the fix needs no changelog fragment. Both `tox r -e type` and `tox r -e type-min` pass.
