### PR TITLE
👷 ci: pin coverage to the ctrace core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,7 @@ ini_options.tmp_path_retention_policy = "failed"
 ini_options.timeout = 30
 
 [tool.coverage]
+run.core = "ctrace"  # sysmon (the 3.14+ default) cannot record the dynamic contexts pytest-cov sets
 run.parallel = true
 run.plugins = [
   "covdefaults",


### PR DESCRIPTION
The Python 3.14 and 3.15 jobs started failing on every platform after coverage 7.15.3 shipped: it now picks the sys.monitoring core by default on those versions, and that core cannot record the per-test dynamic contexts pytest-cov sets. The warning coverage raises at the first context switch is an error under our pytest settings, so all 16k tests errored out.

Pinning the coverage core to ctrace restores the test runs and keeps context data accurate — sysmon was also under-reporting coverage.

Unblocks #4008.