### PR TITLE
✅ test: seed the virtualenv wheel image up front

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,10 @@ import os
 import site
 import sys
 import sysconfig
+from functools import partial
 from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Protocol
 from unittest.mock import patch
 from uuid import uuid4
@@ -142,15 +145,17 @@ def patch_prev_py(mocker: MockerFixture) -> PatchPrevPy:
     return _func
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _do_not_share_virtualenv_for_parallel_runs(tmp_path_factory: pytest.TempPathFactory, worker_id: str) -> None:
-    # virtualenv uses locks to manage access to its cache, when running with xdist this may throw off test timings
-    if worker_id != "master":  # pragma: no branch
-        temp_app_data = str(tmp_path_factory.mktemp(f"virtualenv-app-{worker_id}"))  # pragma: no cover
-        os.environ["VIRTUALENV_APP_DATA"] = temp_app_data  # pragma: no cover
-        seed_env_folder = str(tmp_path_factory.mktemp(f"seed-cache-{worker_id}"))  # pragma: no cover
-        args = [seed_env_folder, "--without-pip", "--activators", ""]  # pragma: no cover
-        cli_run(args, setup_logging=False)  # pragma: no cover
+def pytest_configure(config: pytest.Config) -> None:
+    if (worker_id := os.environ.get("PYTEST_XDIST_WORKER")) is not None:  # pragma: no cover
+        # virtualenv locks its app data, so sharing one across xdist workers throws off test timings
+        app_data = mkdtemp(prefix=f"virtualenv-app-{worker_id}-")
+        os.environ["VIRTUALENV_APP_DATA"] = app_data
+        config.add_cleanup(partial(rmtree, app_data, ignore_errors=True))
+    seed_env = mkdtemp(prefix="virtualenv-seed-")
+    config.add_cleanup(partial(rmtree, seed_env, ignore_errors=True))
+    # seeding builds the pip wheel image, a compileall over pip's tree that is slow on Windows CI; pay it here so it
+    # does not land inside the timeout of whichever test happens to create the first environment
+    cli_run([seed_env, "--activators", ""], setup_logging=False)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Windows CI fails at random with a pytest-timeout stack dump, on a different test each time — `test_build_wheel_external_runs_once`, then `test_pylock_install_integration`, and most recently `test_env_base_generated_envs_can_run`. Every dump lands in the same place: virtualenv building its pip wheel image, which runs `compileall` over pip's tree.

That image is built once per app data directory, so the entire cost falls on whichever test happens to create the first environment. In the last passing Windows run `test_env_base_generated_envs_can_run` took 4.18s against roughly 0.1s for its neighbours in the same file — that is the build, and when the runner is loaded it outlasts the 30 second per-test timeout.

The warm-up that was supposed to absorb this did neither half of its job:

- it only ran under xdist, and CI sets `PYTEST_XDIST_AUTO_NUM_WORKERS: 0`, so on CI it never ran;
- it passed `--without-pip`, which skips the image entirely. A seed with pip leaves 569 entries in the app data; `--without-pip` leaves 4.

So the fix seeds a throwaway environment from `pytest_configure` — before any test starts, outside every per-test timeout — and keeps the per-worker app data isolation that xdist needs. The seed picks up `VIRTUALENV_SYMLINK_APP_DATA` from `tox.pytest`, so it builds the same `SymlinkPipInstall` image key the tests go on to use.

Raising the timeout was the obvious move here and it would have been wrong: it hides a one-off cost that lands on an arbitrary test rather than removing it.