### PR TITLE
🔥 chore: remove the misc changelog category

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,8 +62,8 @@ repos:
       - id: changelogs-rst
         name: changelog filenames
         language: fail
-        entry: "changelog files must be named ####.(feature|bugfix|doc|removal|misc).rst"
-        exclude: ^docs/changelog/(\d+\.(feature|bugfix|doc|removal|misc).rst|template.jinja2)
+        entry: "changelog files must be named ####.(breaking|deprecation|feature|bugfix|doc|packaging|contrib).rst"
+        exclude: ^docs/changelog/(\d+\.(breaking|deprecation|feature|bugfix|doc|packaging|contrib).rst|template.jinja2)
         files: ^docs/changelog/
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.29.0

--- a/docs/changelog/4012.contrib.rst
+++ b/docs/changelog/4012.contrib.rst
@@ -1,0 +1,2 @@
+Remove the ``misc`` changelog category, and align the changelog filename check with the categories towncrier accepts -
+by :user:`gaborbernat`.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -25,7 +25,7 @@ section. This section contains only highlights; it's not a substitute for readin
   changes *must* be checked visually (see below).
 - All PRs that make changes visible to an end user require a changelog entry. This should reference an issue if it
   closes that issue, otherwise reference the PR. Create one or more (if there's more than one issue)
-  ``docs/changelog/####.{breaking,deprecation,feature,bugfix,doc,packaging,contrib,misc}.rst`` per the `changelog entry
+  ``docs/changelog/####.{breaking,deprecation,feature,bugfix,doc,packaging,contrib}.rst`` per the `changelog entry
   <#changelog-entries>`_ section below.
 - GitHub Actions will do a full set of `tests and checks <#automated-testing>`_ when the PR is submitted. For local
   testing you'll need to install your own "top-level" tox (using pipx_ or similar is fine) and use the following targets
@@ -205,8 +205,7 @@ directory named after that issue number with an extension of:
 - ``bugfix.rst`` - bug fixes,
 - ``doc.rst`` - documentation improvements,
 - ``packaging.rst`` - packaging updates and notes for downstreams,
-- ``contrib.rst`` - contributor-facing changes,
-- ``misc.rst`` - miscellaneous internal changes.
+- ``contrib.rst`` - contributor-facing changes.
 
 Thus if your issue or PR number is ``1234`` and this change is fixing a bug, then you would create a file
 ``docs/changelog/1234.bugfix.rst``. PRs can span multiple categories by creating multiple files (for instance, if you

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,5 +282,4 @@ type = [
   { directory = "doc", name = "Improved documentation", showcontent = true },
   { directory = "packaging", name = "Packaging updates and notes for downstreams", showcontent = true },
   { directory = "contrib", name = "Contributor-facing changes", showcontent = true },
-  { directory = "misc", name = "Miscellaneous internal changes", showcontent = true },
 ]


### PR DESCRIPTION
A changelog entry filed under `misc` tells the reader nothing. Anything real belongs under one of the seven remaining categories, so `misc` is gone from towncrier and from the contributing docs.

The filename pre-commit hook had drifted from the towncrier config as well: it allowed `removal`, which is not a category, and turned away `breaking`, `deprecation`, `packaging` and `contrib`. Both lists now match.