### PR TITLE
📝 docs: mark the INI configuration format as deprecated

### DIFF
--- a/docs/changelog/4017.doc.rst
+++ b/docs/changelog/4017.doc.rst
@@ -1,0 +1,6 @@
+Mark the INI configuration format as deprecated throughout the documentation - by :user:`gaborbernat`.
+
+- The tutorial, the configuration reference, and the migration how-to state that INI keeps working for existing projects
+  but is frozen and receives no new features.
+- Every INI example tab, the configuration discovery diagram, and the man page carry a deprecation marker.
+- The tutorial no longer suggests generating a ``tox.ini`` via ``tox quickstart``.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -148,7 +148,7 @@ virtualenv resolution:
        [env_run_base]
        set_env.PATH = "{env_bin_dir}{:}/usr/local/bin{:}{env:PATH}"
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -444,7 +444,7 @@ the wheel is built once and reused for all tox environments:
          package = "wheel"
          wheel_build_env = ".pkg"
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -466,7 +466,7 @@ conflicting with packaging settings.
        [env_pkg_base]
        pass_env = ["PKG_CONFIG", "PKG_CONFIG_PATH"]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -514,7 +514,7 @@ For example given:
 
          requires = ["tox>=4", "tox-uv>=1"]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -614,7 +614,7 @@ You can also enable it per-environment via the ``fail_fast`` configuration:
        fail_fast = true
        commands = [["pytest", "tests/critical"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -652,7 +652,7 @@ it falls back to the base section (:ref:`base` configuration). For ``tox.toml`` 
          [env.test]
          description = "run the test suite with pytest"
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -780,7 +780,7 @@ To detect misplaced keys:
 
 For example, putting ``ignore_base_python_conflict`` in ``[testenv]`` instead of ``[tox]``:
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: text
 

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -61,7 +61,7 @@ A typical pytest configuration:
          deps = ["pytest>=8"]
          commands = [["pytest", { replace = "posargs", default = ["tests"], extend = true }]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -82,7 +82,7 @@ directory:
          [env_run_base]
          commands = [["pytest", "--basetemp={env_tmp_dir}", { replace = "posargs", default = ["tests"], extend = true }]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -115,7 +115,7 @@ ensure coverage runs after all test environments:
              ["coverage", "report", "--fail-under=80"],
          ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -218,7 +218,7 @@ Labels let you assign tags to environments and run them as a group with ``tox ru
          deps = ["mypy"]
          commands = [["mypy", "src"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -265,7 +265,7 @@ For example, given:
          deps = ["pytest"]
          commands = [["pytest"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -314,7 +314,7 @@ platform without encoding the platform name in the environment:
              ["python", "-m", "pytest"],
          ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -370,7 +370,7 @@ factors ``py313``, ``django50``, and the current platform:
             ["pytest"],
         ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -399,7 +399,7 @@ Negation also works with platform factors:
             { replace = "if", condition = "not factor.darwin", then = ["pyinotify"], extend = true },
         ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -425,7 +425,7 @@ There are two ways to handle platform differences:
             { replace = "if", condition = "factor.darwin or factor.win32", then = [["pytest"]], extend = true },
         ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -445,7 +445,7 @@ Settings without a platform factor apply to all platforms. This is ideal for mos
         [env_run_base]
         platform = "linux"
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -489,7 +489,7 @@ and normalized by :pypi:`virtualenv` (``amd64`` → ``x86_64``, ``aarch64`` → 
         base_python = ["cpython3.12-64-x86_64"]
         commands = [["pytest"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -645,7 +645,7 @@ You can run it through tox without duplicating the dependency list:
         runner = "virtualenv-pep-723"
         script = "tools/fetch.py"
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -666,7 +666,7 @@ To override the default command (which runs the script), set ``commands`` as usu
         script = "tools/fetch.py"
         commands = [["python", "-m", "pytest", "tests/"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -702,7 +702,7 @@ environment variables:
          [env_run_base]
          set_env = { PIP_INDEX_URL = { replace = "env", name = "PIP_INDEX_URL", default = "https://my.pypi.example/simple" } }
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -732,7 +732,7 @@ When not all dependencies are found on a single index, use ``PIP_EXTRA_INDEX_URL
          set_env.PIP_INDEX_URL = { replace = "env", name = "PIP_INDEX_URL", default = "https://primary.example/simple" }
          set_env.PIP_EXTRA_INDEX_URL = { replace = "env", name = "PIP_EXTRA_INDEX_URL", default = "https://secondary.example/simple" }
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -807,7 +807,7 @@ environments via the :ref:`extras` configuration:
          extras = ["docs"]
          commands = [["sphinx-build", "-W", "docs", "docs/_build/html"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -849,7 +849,7 @@ coverage combining, documentation builds, or linting environments that share the
          extras = ["docs"]
          commands = [["sphinx-build", "-W", "docs", "docs/_build/html"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -879,7 +879,7 @@ lock file changes.
          [env_run_base]
          pylock = "pylock.toml"
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -904,7 +904,7 @@ matching the selected extras/groups (and the target Python's platform markers) a
          pylock = "pylock.toml"
          dependency_groups = ["dev"]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -937,7 +937,7 @@ variables:
          set_env.VIRTUALENV_PIP = "22.1"
          set_env.VIRTUALENV_SYSTEM_SITE_PACKAGES = "true"
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -968,7 +968,7 @@ commands inside the old environment before it is removed:
          recreate_commands = [["{env_python}", "-Im", "pre_commit", "clean"]]
          commands = [["pre-commit", "run", "--all-files"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -998,7 +998,7 @@ virtualenv can no longer create transparently bootstraps a compatible older virt
          deps = ["pytest"]
          commands = [["pytest"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1032,7 +1032,7 @@ expressed as an explicit structured item. For a single axis use the bare range d
              { prefix = "3.", start = 12, stop = 14 },
          ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1063,7 +1063,7 @@ Combinations are joined with ``-``:
          ]
          commands = [["pytest"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1146,7 +1146,7 @@ When multiple commands are defined in :ref:`commands`, tox runs them sequentiall
              ["python", "--version"],
          ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1167,7 +1167,7 @@ To invert the exit code (fail if the command returns 0, succeed otherwise), use 
              ["python", "--version"],
          ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1194,7 +1194,7 @@ command is attempted up to 3 times total. Retries apply to :ref:`commands_pre`, 
          commands_retry = 2
          commands = [["pytest", "tests/integration"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1358,7 +1358,7 @@ Orchestrate Sphinx documentation builds with tox to integrate them into CI:
              ["python", "-c", "print(f'documentation available under file://{work_dir}/docs_out/index.html')"],
          ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1402,7 +1402,7 @@ Define separate environments for developing and deploying mkdocs documentation:
          ]
          commands = [["mkdocs", "gh-deploy", "--clean"]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1482,7 +1482,7 @@ When an environment fails, use these techniques to investigate:
 
    Given a ``tox.ini`` with ``deps = pytest`` and ``commands = pytest {posargs}``, the output looks like:
 
-   .. tab:: INI
+   .. tab:: INI (deprecated)
 
        .. code-block:: ini
 
@@ -1658,7 +1658,7 @@ Set :ref:`default_base_python` to pin a fallback interpreter for all environment
         [env_run_base]
         default_base_python = ["3.14", "3.13"]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1686,7 +1686,7 @@ Instead of updating ``env_list`` every time a new Python version is released, us
             "lint",
         ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1708,7 +1708,7 @@ To start from the oldest supported version:
             "lint",
         ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1727,7 +1727,7 @@ This expands down from the oldest supported CPython version. Both forms can be m
             "lint",
         ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1763,7 +1763,7 @@ virtualenv, so a single ``tox.toml`` can mix end-of-life and current interpreter
 
          env_list = ["py38", "py313"]  # py38 transparently bootstraps an older virtualenv, py313 does not
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1830,7 +1830,7 @@ and installed.
         deps = ["twine"]
         commands = [["twine", "check", { replace = "env", name = "TOX_PACKAGE" }]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1847,11 +1847,13 @@ example both an sdist and a wheel), the paths are joined with ``os.pathsep``.
     If you need a glob-based approach instead (e.g. matching files produced outside of tox), use the ``{glob:PATTERN}``
     substitution — see :ref:`substitution-reference`.
 
+.. _migrate-ini-to-toml:
+
 **********************************
  Migrate from tox.ini to tox.toml
 **********************************
 
-TOML is the recommended configuration format for new projects. Here is how common INI patterns translate to TOML:
+The INI format is deprecated -- migrate existing projects to TOML. Here is how common INI patterns translate to TOML:
 
 **Basic structure**:
 
@@ -1874,7 +1876,7 @@ TOML is the recommended configuration format for new projects. Here is how commo
          deps = ["ruff"]
          commands = [["ruff", "check", "."]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1925,7 +1927,7 @@ opinionated formatters for both TOML and INI configurations, available as pre-co
 
     Also available as a standalone command via ``pipx install tox-toml-fmt``.
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     Use :pypi:`tox-ini-fmt` for ``tox.ini`` files. It normalizes boolean fields, orders sections consistently, and
     formats multi-line values with uniform indentation:

--- a/docs/man/tox.1.rst
+++ b/docs/man/tox.1.rst
@@ -119,7 +119,7 @@ FILES
     Primary configuration file in TOML format (recommended).
 
 **tox.ini**
-    Configuration file in INI format.
+    Configuration file in INI format (deprecated).
 
 **pyproject.toml**
     Alternative configuration location under the ``[tool.tox]`` section.

--- a/docs/plugin/index.rst
+++ b/docs/plugin/index.rst
@@ -28,7 +28,7 @@ For example:
 
          requires = ["tox>=4", "tox-uv>=1"]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -26,8 +26,8 @@ on a best effort approach.
 
 With regards to the configuration format, at the moment we support the following formats:
 
-- `INI <https://en.wikipedia.org/wiki/INI_file>`_.
 - `TOML <https://toml.io/en/v1.0.0>`_.
+- `INI <https://en.wikipedia.org/wiki/INI_file>`_ (deprecated).
 
 Out of box tox supports five configuration locations prioritized in the following order:
 
@@ -35,9 +35,9 @@ Out of box tox supports five configuration locations prioritized in the followin
 
     flowchart TD
         search[tox searches current directory] --> tox_ini
-        tox_ini[tox.ini — INI] -- not found --> setup_cfg[setup.cfg — INI]
+        tox_ini[tox.ini — INI, deprecated] -- not found --> setup_cfg[setup.cfg — INI, deprecated]
         setup_cfg -- not found --> pyproject_native[pyproject.toml — tool.tox]
-        pyproject_native -- not found --> pyproject_legacy[pyproject.toml — legacy_tox_ini]
+        pyproject_native -- not found --> pyproject_legacy[pyproject.toml — legacy_tox_ini, deprecated]
         pyproject_legacy -- not found --> tox_toml[tox.toml — TOML]
 
         classDef ini fill:#dbeafe,stroke:#3b82f6,stroke-width:2px,color:#1e3a5f
@@ -48,15 +48,17 @@ Out of box tox supports five configuration locations prioritized in the followin
         class pyproject_native,tox_toml toml
         class search start
 
-1. ``tox.ini`` (INI),
-2. ``setup.cfg`` (INI),
+1. ``tox.ini`` (INI, deprecated),
+2. ``setup.cfg`` (INI, deprecated),
 3. Native ``pyproject.toml`` under the ``tool.tox`` table (TOML),
-4. ``pyproject.toml`` with the ``tool.tox`` table, having ``legacy_tox_ini`` key (containing INI),
+4. ``pyproject.toml`` with the ``tool.tox`` table, having ``legacy_tox_ini`` key (containing INI, deprecated),
 5. ``tox.toml`` (TOML).
 
-Historically, the INI format was created first, and TOML was added in 2024. **TOML is the recommended format for new
-projects** -- it is more robust, has proper type support, and avoids ambiguities inherent in INI parsing (e.g.
-multi-line values, comment escaping). INI remains supported and is more concise for some patterns.
+Historically, the INI format was created first, and TOML was added in 2024. **The INI format is deprecated** -- it keeps
+working for existing projects, but it is frozen: no new features will be added to it, and it may be removed in a future
+major release. Use TOML instead -- it is more robust, has proper type support, and avoids ambiguities inherent in INI
+parsing (e.g. multi-line values, comment escaping). For existing INI configurations, see :ref:`how to migrate to TOML
+<migrate-ini-to-toml>`.
 
 .. _toml-feature-gaps:
 
@@ -91,7 +93,7 @@ factor.
     Use ``replace = "if"`` with ``factor.NAME`` conditions. Supports boolean operations (``and``, ``or``, ``not``) and
     can combine with environment variable checks (``env.VAR``).
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -130,7 +132,7 @@ Platform factors work in any environment without requiring the platform name in 
     A ``product`` dict also accepts an ``exclude`` key to skip specific combinations. TOML never interprets curly
     braces inside string items — composition is always via these dicts.
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -441,7 +443,7 @@ the top level of ``tox.toml``. Placing these options in an environment section (
              "virtualenv>20.2",
            ]
 
-     .. tab:: INI
+     .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -561,7 +563,7 @@ the top level of ``tox.toml``. Placing these options in an environment section (
            [tool.tox]
            labels = { test = ["3.14t", "3.14", "3.13", "3.12"], static = ["ruff", "mypy"] }
 
-     .. tab:: INI
+     .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -868,7 +870,7 @@ Base options
           pass_env = ["FOO_*"]
           disallow_pass_env = ["FOO_SECRET"]
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
        .. code-block:: ini
 
@@ -893,7 +895,7 @@ Base options
            [tool.tox.env_run_base]
            set_env = { file = "conf{/}local.env", TEST_TIMEOUT = "30" }
 
-     .. tab:: INI
+     .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -912,7 +914,7 @@ Base options
            [tool.tox.env_run_base]
            set_env = { file = "{env:variable}" }
 
-     .. tab:: INI
+     .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -954,7 +956,7 @@ Base options
            # Can also be combined with replace directives
            set_env.CONDITIONAL = { replace = "env", name = "MY_VAR", default = "fallback", marker = "sys_platform == 'linux'" }
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -1062,7 +1064,7 @@ always set regardless of the ``pass_env`` or ``set_env`` configuration and canno
            [tool.tox.env.flake8]
            labels = ["mypy"]
 
-     .. tab:: INI
+     .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -1136,7 +1138,7 @@ Run
             runner = "virtualenv-pep-723"
             script = "tools/check.py"
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -1172,7 +1174,7 @@ Run
           [env.coverage]
           depends = ["3.*"]
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
        .. code-block:: ini
 
@@ -1218,7 +1220,7 @@ Run
             ["pre-commit", "run", "--all-files"],
           ]
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
        .. code-block:: ini
 
@@ -1248,7 +1250,7 @@ Run
           deps = ["pre-commit"]
           recreate_commands = [["{env_python}", "-Im", "pre_commit", "clean"]]
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
        .. code-block:: ini
 
@@ -1358,7 +1360,7 @@ Run
           commands_retry = 2
           commands = [["pytest", "tests"]]
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
        .. code-block:: ini
 
@@ -1429,7 +1431,7 @@ environments when needed.
        [env.".pkg-cpython311"]
        pass_env = ["PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_SYSROOT_DIR", "IS_311"]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -1534,7 +1536,7 @@ Python options
             [env_run_base]
             default_base_python = ["3.14", "3.13"]
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -1561,7 +1563,7 @@ Python options
           [env.mypy]
           base_python_file = [".python-version", ".python-version-default"]
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
        .. code-block:: ini
 
@@ -1658,7 +1660,7 @@ Python run
              "test",
            ]
 
-     .. tab:: INI
+     .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -1694,7 +1696,7 @@ Python run
            [tool.tox.env_run_base]
            pylock = "pylock.toml"
 
-     .. tab:: INI
+     .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -1731,7 +1733,7 @@ Python run
              "-c constraints.txt",
            ]
 
-     .. tab:: INI
+     .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -1945,7 +1947,7 @@ Python virtual environment
             base_python = ["python3.15"]
             commands = [["python", "-c", "import sys; print(sys.version)"]]
 
-    .. tab:: INI
+    .. tab:: INI (deprecated)
 
         .. code-block:: ini
 
@@ -2167,7 +2169,7 @@ You can override options in the configuration file, from the command line. For e
        set_env = { foo = "bar" }
        commands = [[ "pytest", "tests" ]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -2185,7 +2187,7 @@ You could enable ``ignore_errors`` by running:
 
        tox --override env_run_base.ignore_errors=True
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: bash
 
@@ -2199,7 +2201,7 @@ You could add additional dependencies by running:
 
        tox --override env_run_base.deps+=pytest-xdist
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: bash
 
@@ -2213,7 +2215,7 @@ You could set additional environment variables by running:
 
        tox --override env_run_base.set_env+=baz=quux
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: bash
 
@@ -2228,7 +2230,7 @@ You can specify overrides multiple times on the command line to append multiple 
        tox -x env_run_base.set_env+=foo=bar -x env_run_base.set_env+=baz=quux
        tox -x testenv_run_baseenv.deps+=pytest-xdist -x env_run_base.deps+=pytest-covt
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: bash
 
@@ -2243,7 +2245,7 @@ Or reset override and append to that (note the first override is ``=`` and not `
 
        tox -x env_run_base.deps=pytest-xdist -x env_run_base.deps+=pytest-cov
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: bash
 
@@ -2277,7 +2279,7 @@ extends:
 
        tox c -e test -k extras -x tool.tox.env_run_base.extras=blue
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -2308,7 +2310,7 @@ separators:
 
        tox -x 'env.3\.14.deps=pytest-xdist'
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: bash
 
@@ -2787,7 +2789,7 @@ and conditional settings to express that in a concise form:
             { replace = "if", condition = "(factor.py311 or factor.py310) and factor.sqlite", then = ["mock"], extend = true },
         ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -2944,7 +2946,7 @@ Generative section names
 Suppose you have some binary packages, and need to run tests both in 32 and 64 bits. You also want an environment to
 create your virtual env for the developers. This also supports ranges in the same way as generative environment lists.
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -3004,7 +3006,7 @@ In substitutions, the backslash character ``\`` will act as an escape when prece
           ["python", "-c", 'print("host: \{}".format("{env:HOSTNAME:host\: not set}")'],
         ]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -3147,7 +3149,7 @@ Relative patterns are resolved against ``tox_root``. Use ``**`` for recursive ma
         [env.A]
         commands = [["twine", "upload", { replace = "glob", pattern = "dist/*.whl", extend = true }]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -28,10 +28,11 @@ Verify tox is available:
 ***********************************
 
 tox needs a configuration file where you define what tools to run and how to set up environments for them. tox supports
-two configuration formats: TOML and INI. **TOML is the recommended format for new projects** -- it is more robust, has
-proper type support, and avoids ambiguities inherent in INI parsing. INI remains supported for existing projects.
+two configuration formats: TOML and INI. **Use TOML** -- it is more robust, has proper type support, and avoids
+ambiguities inherent in INI parsing. The INI format is deprecated: it keeps working for existing projects, but it is
+frozen and receives no new features.
 
-Create a ``tox.toml`` (or ``tox.ini``) at the root of your project:
+Create a ``tox.toml`` at the root of your project:
 
 .. tab:: TOML
 
@@ -52,7 +53,7 @@ Create a ``tox.toml`` (or ``tox.ini``) at the root of your project:
          deps = ["ruff"]
          commands = [["ruff", "check", { replace = "posargs", default = ["."], extend = true }]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -73,10 +74,6 @@ Create a ``tox.toml`` (or ``tox.ini``) at the root of your project:
              ruff
          commands = ruff check {posargs:.}
 
-.. tip::
-
-    You can also generate a ``tox.ini`` file automatically by running ``tox quickstart`` and answering a few questions.
-
 *********************************
  Understanding the configuration
 *********************************
@@ -95,7 +92,7 @@ Core settings affect all environments or configure how tox itself behaves. They 
 
        env_list = ["3.13", "3.12", "lint"]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 
@@ -130,7 +127,7 @@ Each tox environment has its own configuration. Settings defined at the base lev
          deps = ["ruff"]
          commands = [["ruff", "check", "."]]
 
-.. tab:: INI
+.. tab:: INI (deprecated)
 
     .. code-block:: ini
 


### PR DESCRIPTION
The configuration reference described INI as a supported alternative to TOML ("INI remains supported and is more concise for some patterns"), and users quote that line back when asking for new INI features, as in [tox-ini-fmt#359](https://github.com/tox-dev/tox-ini-fmt/issues/359). That wording contradicts the project position that INI is frozen. 📝

The tutorial, the configuration reference, and the migration how-to now state that INI is deprecated: it keeps working for existing projects, but it receives no new features and may be removed in a future major release. Every INI example tab is relabeled `INI (deprecated)`; `sphinx-inline-tabs` syncs tabs by label, so the consistent rename keeps tab groups switching together. The configuration discovery list, its mermaid diagram, and the man page carry the same marker, and the reference links to the migration how-to.

The tutorial now creates a `tox.toml` from the start and no longer suggests generating a `tox.ini` via `tox quickstart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
