### PR TITLE
✅ test: raise timeout for missing-interpreter discovery tests

### DIFF
--- a/tests/session/cmd/test_sequential.py
+++ b/tests/session/cmd/test_sequential.py
@@ -296,6 +296,7 @@ def test_backend_not_found(tox_project: ToxProjectCreator) -> None:
 
 
 @pytest.mark.slow
+@pytest.mark.timeout(120)
 def test_missing_interpreter_skip_on(tox_project: ToxProjectCreator) -> None:
     ini = "[tox]\nskip_missing_interpreters=true\n[testenv]\npackage=skip\nbase_python=missing-interpreter"
     proj = tox_project({"tox.ini": ini})
@@ -306,6 +307,7 @@ def test_missing_interpreter_skip_on(tox_project: ToxProjectCreator) -> None:
 
 
 @pytest.mark.slow
+@pytest.mark.timeout(120)
 def test_missing_interpreter_skip_off(tox_project: ToxProjectCreator) -> None:
     ini = "[tox]\nskip_missing_interpreters=false\n[testenv]\npackage=skip\nbase_python=missing-interpreter"
     proj = tox_project({"tox.ini": ini})
@@ -317,6 +319,7 @@ def test_missing_interpreter_skip_off(tox_project: ToxProjectCreator) -> None:
 
 
 @pytest.mark.slow
+@pytest.mark.timeout(120)
 def test_missing_interpreter_skip_set_env_substitution_ini(tox_project: ToxProjectCreator) -> None:
     ini = """\
 [tox]
@@ -339,6 +342,7 @@ set_env =
 
 
 @pytest.mark.slow
+@pytest.mark.timeout(120)
 def test_missing_interpreter_skip_set_env_substitution_toml(tox_project: ToxProjectCreator) -> None:
     toml = """\
 env_list = ["ok", "bad"]


### PR DESCRIPTION
`test_missing_interpreter_skip_on` timed out at the global 30 second pytest limit on the [Windows 3.11 CI job](https://github.com/tox-dev/tox/actions/runs/31426074585/job/93578057314). The four missing-interpreter tests in `test_sequential.py` ask tox to resolve `base_python=missing-interpreter`, and on Windows that discovery walks the `py` launcher, the registry, and `PATH` before concluding that no interpreter matches, which can take longer than 30 seconds on a cold runner.

All four tests now carry `@pytest.mark.timeout(120)`, the allowance `test_machine_factor_unavailable` already uses for its unresolvable `base_python` spec, following the approach of #4011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
