### PR TITLE
Add {home} and {tox_root_name} substitutions

### DIFF
--- a/docs/changelog/4020.feature.rst
+++ b/docs/changelog/4020.feature.rst
@@ -1,0 +1,2 @@
+:ref:`work_dir` now expands the ``${home}`` and ``{tox_root_name}`` placeholders. Use this to keep environments outside
+of the project tree, e.g.: ``work_dir = "${home}/.local/state/tox/{tox_root_name}"`` in ``tox.toml``.

--- a/docs/changelog/4020.feature.rst
+++ b/docs/changelog/4020.feature.rst
@@ -1,2 +1,2 @@
-:ref:`work_dir` now expands the ``${home}`` and ``{tox_root_name}`` placeholders. Use this to keep environments outside
-of the project tree, e.g.: ``work_dir = "${home}/.local/state/tox/{tox_root_name}"`` in ``tox.toml``.
+Add ``{home}`` and ``{tox_root_name}`` substitutions; set :ref:`work_dir` to e.g.
+``"{home}/.local/state/tox/{tox_root_name}"`` to keep environments outside of the project tree - by :user:`WhyNotHugo`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -341,6 +341,27 @@ environments (template name + factor suffix) appear in ``tox list`` and can be r
 
 For the configuration reference, see :ref:`env-base-templates`. For practical recipes, see :ref:`howto_env_base_matrix`.
 
+.. _work-dir-placement:
+
+Work directory placement
+========================
+
+Everything tox generates lives under one directory, :ref:`work_dir`: the virtual environments, their logs, packaging
+artifacts, and the provisioned tox itself when :ref:`auto-provisioning` kicks in. The default is ``.tox`` next to the
+configuration file, which makes a project self-contained: deleting the checkout deletes its environments, and two
+checkouts of the same project never share state.
+
+Placing environments in the tree also has costs. Editor indexers and file watchers crawl the virtual environments unless
+told otherwise, and backup or cloud-sync tools pick up thousands of files tox can regenerate at will. A project on a
+network or otherwise slow filesystem drags each environment operation down with it too. In those situations move the
+environments to a per-project directory under your home folder, the way ``virtualenvwrapper`` centralizes its virtual
+environments; the ``{home}`` and ``{tox_root_name}`` substitutions in :ref:`work_dir` express this without hard-coding a
+path.
+
+The trade-off mirrors the benefit of the default: ``{tox_root_name}`` is only the name of the project directory, so two
+projects checked out under the same name resolve to the same work directory, and removing a checkout leaves its
+environments behind until you delete them yourself. For the recipe, see :ref:`howto_out_of_tree_envs`.
+
 ***************
  Main features
 ***************

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -191,6 +191,43 @@ location can be changed via the ``TOX_CONFIG_FILE`` environment variable.
     # Force editable install for a specific environment
     tox run -e 3.13 -x "testenv:3.13.package=editable"
 
+.. _howto_out_of_tree_envs:
+
+********************************************
+ Keep environments outside the project tree
+********************************************
+
+By default tox creates its environments in a ``.tox`` directory next to the configuration file. To keep them out of the
+project tree, point :ref:`work_dir` at a location built from the ``{home}`` and ``{tox_root_name}`` substitutions:
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+        work_dir = "{home}/.local/state/tox/{tox_root_name}"
+
+.. tab:: INI (deprecated)
+
+    .. code-block:: ini
+
+        [tox]
+        work_dir = {home}/.local/state/tox/{tox_root_name}
+
+With this configuration a project checked out at ``~/src/magic`` keeps its environments in ``~/.local/state/tox/magic``.
+Verify the resolved location with:
+
+.. code-block:: bash
+
+    $ tox config --core -k work_dir
+    [tox]
+    work_dir = /home/user/.local/state/tox/magic
+
+Substitutions resolve in the project configuration file only: the ``--workdir`` CLI flag and the user-level
+configuration file take literal paths, so this setting belongs in ``tox.toml``. Since ``{tox_root_name}`` is the name of
+the project directory, two projects checked out under the same directory name share a work directory; give one of them
+an explicit path if that happens. See :ref:`work-dir-placement` for the trade-offs of moving environments out of the
+tree.
+
 **********************************
  Use labels to group environments
 **********************************

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -526,6 +526,10 @@ the top level of ``tox.toml``. Placing these options in an environment section (
 
         work_dir = "{home}/.local/state/tox/{tox_root_name}"
 
+    The ``--workdir`` CLI flag and the user-level configuration file take the value as a literal path, without
+    substitution. See :ref:`howto_out_of_tree_envs` for a walk-through and :ref:`work-dir-placement` for the
+    trade-offs.
+
 .. conf::
     :keys: temp_dir
     :default: {work_dir}/.tmp

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -519,12 +519,12 @@ the top level of ``tox.toml``. Placing these options in an environment section (
 
     Directory for tox to generate its environments into, will be created if it does not exist.
 
-    The value may contain the literal placeholders ``${home}``  and ``{tox_root_name}``. This allows keeping tox environments outside of the project tree in a
+    Use the ``{home}`` and ``{tox_root_name}`` substitutions to keep tox environments outside of the project tree, in a
     location unique per project, similar to ``virtualenvwrapper``:
 
     .. code-block:: toml
 
-        work_dir = "${home}/.local/state/tox/{tox_root_name}"
+        work_dir = "{home}/.local/state/tox/{tox_root_name}"
 
 .. conf::
     :keys: temp_dir
@@ -3189,6 +3189,10 @@ or via ``{name}`` in INI.
       - Description
     - - ``{tox_root}`` / ``{toxinidir}``
       - The directory where the configuration file is located (project root).
+    - - ``{tox_root_name}``
+      - Name of the project root directory (the last path component of ``{tox_root}``).
+    - - ``{home}``
+      - The current user's home directory.
     - - ``{work_dir}`` / ``{toxworkdir}``
       - The tox working directory (default: ``{tox_root}/.tox``).
     - - ``{temp_dir}``

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -515,8 +515,16 @@ the top level of ``tox.toml``. Placing these options in an environment section (
     :keys: work_dir, toxworkdir
     :default: {tox_root}/.tox
     :version_added: 1.0
+    :version_changed: 4.60
 
     Directory for tox to generate its environments into, will be created if it does not exist.
+
+    The value may contain the literal placeholders ``${home}``  and ``{tox_root_name}``. This allows keeping tox environments outside of the project tree in a
+    location unique per project, similar to ``virtualenvwrapper``:
+
+    .. code-block:: toml
+
+        work_dir = "${home}/.local/state/tox/{tox_root_name}"
 
 .. conf::
     :keys: temp_dir

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -250,8 +250,9 @@ pass after ``--``.
  Understanding the output
 **************************
 
-On the first run, tox creates virtual environments and installs dependencies. Subsequent runs reuse existing
-environments unless dependencies change:
+On the first run, tox creates virtual environments and installs dependencies. The environments land in a ``.tox``
+directory next to your configuration file; add it to your version control ignore file, or relocate it entirely as shown
+in :ref:`howto_out_of_tree_envs`. Subsequent runs reuse existing environments unless dependencies change:
 
 .. code-block:: bash
 

--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -289,7 +289,10 @@ class CoreConfigSet(ConfigSet):
         return self.get("work_dir", Path) / ".tmp"
 
     def _work_dir_post_process(self, folder: Path) -> Path:
-        return self._conf.work_dir if self._conf.options.work_dir else folder
+        if self._conf.options.work_dir:
+            return self._conf.work_dir
+        raw = str(folder).replace("{tox_root_name}", self._root.name).replace("${home}", str(Path.home()))
+        return Path(raw)
 
     def register_config(self) -> None:
         self.add_constant(keys=["config_file_path"], desc="path to the configuration file", value=self._src_path)

--- a/src/tox/config/sets.py
+++ b/src/tox/config/sets.py
@@ -289,10 +289,7 @@ class CoreConfigSet(ConfigSet):
         return self.get("work_dir", Path) / ".tmp"
 
     def _work_dir_post_process(self, folder: Path) -> Path:
-        if self._conf.options.work_dir:
-            return self._conf.work_dir
-        raw = str(folder).replace("{tox_root_name}", self._root.name).replace("${home}", str(Path.home()))
-        return Path(raw)
+        return self._conf.work_dir if self._conf.options.work_dir else folder
 
     def register_config(self) -> None:
         self.add_constant(keys=["config_file_path"], desc="path to the configuration file", value=self._src_path)
@@ -302,6 +299,8 @@ class CoreConfigSet(ConfigSet):
             default=self._root,
             desc="the root directory (where the configuration file is found)",
         )
+        self.add_constant("tox_root_name", "name of the root directory", self._root.name)
+        self.add_constant("home", "the user's home directory", Path.home)
 
         self.add_config(
             keys=["work_dir", "toxworkdir"],

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -193,3 +193,18 @@ def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: str) -> None:
     result = project.run("c", *(["--workdir", str(project.path / work_dir)] if work_dir else []))
     expected = project.path / work_dir if work_dir else Path("b")
     assert expected == result.state.conf.core["work_dir"]
+
+
+def test_config_work_dir_placeholders(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+    project = tox_project({"tox.toml": 'work_dir = "${home}/.local/state/tox/{tox_root_name}"'})
+    home = project.path.parent / "home"
+    monkeypatch.setenv("HOME", str(home))  # used by Path.home() on POSIX
+    monkeypatch.setenv("USERPROFILE", str(home))  # used by Path.home() on Windows
+    result = project.run("c")
+    assert result.state.conf.core["work_dir"] == home / ".local" / "state" / "tox" / project.path.name
+
+
+def test_config_work_dir_placeholders_cli_override(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.toml": 'work_dir = "${home}/.local/state/tox/{tox_root_name}"'})
+    result = project.run("c", "--workdir", str(project.path / "wd"))
+    assert result.state.conf.core["work_dir"] == project.path / "wd"

--- a/tests/config/test_sets.py
+++ b/tests/config/test_sets.py
@@ -195,16 +195,16 @@ def test_config_work_dir(tox_project: ToxProjectCreator, work_dir: str) -> None:
     assert expected == result.state.conf.core["work_dir"]
 
 
-def test_config_work_dir_placeholders(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
-    project = tox_project({"tox.toml": 'work_dir = "${home}/.local/state/tox/{tox_root_name}"'})
+def test_config_work_dir_substitutions(tox_project: ToxProjectCreator, monkeypatch: pytest.MonkeyPatch) -> None:
+    project = tox_project({"tox.toml": 'work_dir = "{home}/.local/state/tox/{tox_root_name}"'})
     home = project.path.parent / "home"
-    monkeypatch.setenv("HOME", str(home))  # used by Path.home() on POSIX
-    monkeypatch.setenv("USERPROFILE", str(home))  # used by Path.home() on Windows
+    for var in ("HOME", "USERPROFILE"):  # Path.home() reads HOME on POSIX, USERPROFILE on Windows
+        monkeypatch.setenv(var, str(home))
     result = project.run("c")
     assert result.state.conf.core["work_dir"] == home / ".local" / "state" / "tox" / project.path.name
 
 
-def test_config_work_dir_placeholders_cli_override(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({"tox.toml": 'work_dir = "${home}/.local/state/tox/{tox_root_name}"'})
+def test_config_work_dir_substitutions_cli_override(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({"tox.toml": 'work_dir = "{home}/.local/state/tox/{tox_root_name}"'})
     result = project.run("c", "--workdir", str(project.path / "wd"))
     assert result.state.conf.core["work_dir"] == project.path / "wd"


### PR DESCRIPTION
Basically, I want to configure:

```dosini
[tox]
work_dir = ~/.local/state/tox/{tox_root_name}
```

These two patches enable this to work.

- [x] wrote descriptive pull request text
- [x] ran the linter to address style issues (`tox -e fix`)
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

`docs/changelog` looks empty; there's no fragments there (and nothing to use as reference).

