### PR TITLE
Provision before loading env_list

### DIFF
--- a/docs/changelog/4021.bugfix.rst
+++ b/docs/changelog/4021.bugfix.rst
@@ -1,0 +1,2 @@
+Provision the requested tox version before reading ``env_list``, allowing configuration syntax introduced by that
+version - by :user:`CAOShurong`

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -257,6 +257,9 @@ class EnvSelector:
         """:returns: sources of tox environments defined with name and if is marked as target to run"""
         if self._provision is not None:  # pragma: no branch
             yield (self._provision[1],), False
+            if self._provision[0]:
+                # The provisioned tox may support configuration that this version does not.
+                return
         env_list, everything_active = self._state.conf.core["env_list"], False
         if self._cli_envs is None or self._cli_envs.is_default_list:
             yield env_list, True

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -178,6 +178,21 @@ def test_provision_requires_checks_true_markers(tox_project: ToxProjectCreator) 
     assert "pkg-does-not-exist" in outcome.out
 
 
+def test_provision_before_loading_env_list(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.toml": """
+            requires = ["tox>=999"]
+            env_list = [1]
+        """,
+    })
+    project.patch_execute(lambda _: 0)
+
+    outcome = project.run("l")
+
+    outcome.assert_success()
+    assert "will run in automatically provisioned tox" in outcome.out
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures("_pypi_index_self")
 @pytest.mark.timeout(120)

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -178,19 +178,53 @@ def test_provision_requires_checks_true_markers(tox_project: ToxProjectCreator) 
     assert "pkg-does-not-exist" in outcome.out
 
 
-def test_provision_before_loading_env_list(tox_project: ToxProjectCreator) -> None:
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("subcommand", ["l", "c"])
+def test_provision_before_loading_env_list(
+    tox_project: ToxProjectCreator,
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    pkg_builder: Callable[[Path, Path, Sequence[DistributionType], bool], Path],
+    subcommand: str,
+) -> None:
+    future_tox = tmp_path / "future-tox"
+    (future_tox / "tox").mkdir(parents=True)
+    (future_tox / "pyproject.toml").write_text(
+        """
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+
+        [project]
+        name = "tox"
+        version = "999"
+        """,
+        encoding="utf-8",
+    )
+    (future_tox / "tox" / "__init__.py").write_text("", encoding="utf-8")
+    (future_tox / "tox" / "__main__.py").write_text(
+        "import sys\n\n"
+        'command = next(arg for arg in sys.argv[1:] if arg in {"l", "c"})\n'
+        'print(f"future tox ran {command}")\n',
+        encoding="utf-8",
+    )
+    wheel = pkg_builder(tmp_path / "dist", future_tox, ["wheel"], False)
+    monkeypatch.setenv("PIP_FIND_LINKS", str(wheel.parent))
+    monkeypatch.setenv("PIP_NO_INDEX", "1")
+
     project = tox_project({
         "tox.toml": """
             requires = ["tox>=999"]
             env_list = [1]
         """,
     })
-    project.patch_execute(lambda _: 0)
 
-    outcome = project.run("l")
+    outcome = project.run(subcommand)
 
     outcome.assert_success()
     assert "will run in automatically provisioned tox" in outcome.out
+    assert f"future tox ran {subcommand}" in outcome.out
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Fixes #4021.

When tox decides it must provision a newer version, `EnvSelector` still reads the current version's `env_list` while constructing the provision environment. If the requested tox introduced new `env_list` syntax, that read fails before the newer tox can be installed.

This change stops environment-name collection after selecting the provision environment when provisioning is active. The provisioned tox then parses the rest of the configuration itself. Normal runs and the no-provision path keep their existing behavior.

The regression test uses an intentionally unsupported `env_list` value with `tox>=999` and intercepts execution. Before the fix, the current tox raises while parsing `env_list`; after the fix, it reaches the provision execution path.

Validation:

- `python -m pytest tests/test_provision.py --run-integration -q` — 28 passed
- `python -m pytest -m "not integration and not slow" -n auto --no-cov -q` — 7973 passed, 26 skipped, 2 unrelated failures; both existing Windows tests hard-code the English WinError 2 text, while this Traditional Chinese Windows installation returns the localized equivalent
- pre-commit on all changed files — passed
- `ty check --python-platform all --output-format concise --error-on-warning .` — passed
- `mypy` — passed
- `pyrefly check` — passed with 0 errors
- wheel and sdist build, `twine check`, `check-wheel-contents`, and `towncrier build --draft` — passed
- real Windows workflow: patched tox 4.42 provisioned tox 4.59, listed product-generated environments 3.10 through 3.15, and ran the selected 3.13 environment successfully
- real failure path: an unavailable `tox>=999` requirement reached dependency installation and exited nonzero instead of failing on the old `env_list` parser

Checklist:

- [x] ran the linter to address style issues
- [x] wrote descriptive pull request text
- [x] ensured there are tests validating the fix
- [x] added a news fragment in `docs/changelog`
- [x] documentation update is not needed; this restores the documented provisioning boundary without changing user-facing configuration
