### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
@@ -38,6 +39,7 @@ html_js_files = ["mermaid-reset.js"]
 html_logo, html_favicon = "_static/img/tox.svg", "_static/img/toxfavi.ico"
 
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.extlinks",
@@ -182,3 +184,6 @@ def setup(app: Sphinx) -> None:
     prev_check = ExternalLinksChecker.check_uri
     ExternalLinksChecker.check_uri = check_uri
     inject_into_ssl()
+
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ docs = [
   "sphinx-copybutton>=0.5.2",
   "sphinx-inline-tabs>=2025.12.21.14",
   "sphinx-issues>=5.0.1",
+  "sphinx-llm>=0.4.1",
   "sphinx-reredirects>=1.1",
   "sphinxcontrib-mermaid>=2.0.1",
   "sphinxcontrib-towncrier>=0.2.1a0",


### PR DESCRIPTION
The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt` ([llmstxt.org](https://llmstxt.org/)), `llms-full.txt`, and a markdown twin of each page during the HTML build; Read the Docs serves `llms.txt` from the docs domain root ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Plain markdown lets agents read the docs without rendering themed, JavaScript-dependent HTML. `markdown_http_base` keeps the sitemap links absolute so they resolve from the domain root.
