### PR TITLE
docs: repoint nine dead source links in the onboarding guide

### DIFF
--- a/docs/changelog/4024.doc.rst
+++ b/docs/changelog/4024.doc.rst
@@ -1,0 +1,2 @@
+Fix nine source-code links in the onboarding guide that pointed at paths which no longer exist, and correct the class
+names of the TOML configuration sources and loaders they refer to - by :user:`Yusuf-Gadelrab`.

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -448,8 +448,7 @@ Command flow
    <https://github.com/tox-dev/tox/blob/main/src/tox/execute/local_sub_process/__init__.py>`_ spawns a
    :class:`subprocess.Popen` subprocess and starts drain threads.
 4. `LocalSubprocessExecuteStatus.wait()
-   <https://github.com/tox-dev/tox/blob/main/src/tox/execute/local_sub_process/__init__.py>`_ blocks until
-   completion.
+   <https://github.com/tox-dev/tox/blob/main/src/tox/execute/local_sub_process/__init__.py>`_ blocks until completion.
 5. An `Outcome <https://github.com/tox-dev/tox/blob/main/src/tox/execute/request.py>`_ is constructed with exit code,
    captured output, and timing.
 

--- a/docs/onboarding.rst
+++ b/docs/onboarding.rst
@@ -301,11 +301,12 @@ Built-in subcommands
       - Run environments in parallel
     - - ``list``
       - ``l``
-      - `session/cmd/list_envs.py <https://github.com/tox-dev/tox/blob/main/src/tox/session/cmd/list_envs.py>`_
+      - `session/cmd/list_env.py <https://github.com/tox-dev/tox/blob/main/src/tox/session/cmd/list_env.py>`_
       - List available environments
     - - ``config``
       - ``c``
-      - `session/cmd/show_config.py <https://github.com/tox-dev/tox/blob/main/src/tox/session/cmd/show_config.py>`_
+      - `session/cmd/show_config/
+        <https://github.com/tox-dev/tox/blob/main/src/tox/session/cmd/show_config/__init__.py>`_
       - Show materialised configuration
     - - ``devenv``
       - ``d``
@@ -367,8 +368,8 @@ subcommand handler starts iterating environments.
 CliEnv
 ------
 
-`CliEnv <https://github.com/tox-dev/tox/blob/main/src/tox/config/cli/env.py>`_ captures the user's ``-e`` flag in three
-modes:
+`CliEnv <https://github.com/tox-dev/tox/blob/main/src/tox/session/env_select.py>`_ captures the user's ``-e`` flag in
+three modes:
 
 - **Specific list** (``-e py39,py310``) — run exactly these envs.
 - **ALL** (``-e ALL``) — run every defined env.
@@ -443,11 +444,11 @@ Command flow
    <https://github.com/tox-dev/tox/blob/main/src/tox/execute/request.py>`_.
 2. `Execute.call() <https://github.com/tox-dev/tox/blob/main/src/tox/execute/api.py>`_ — context manager — creates
    `SyncWrite <https://github.com/tox-dev/tox/blob/main/src/tox/execute/stream.py>`_ streams for stdout/stderr.
-3. `ExecuteInstance.start()
-   <https://github.com/tox-dev/tox/blob/main/src/tox/execute/local_sub_process/execute_instance.py>`_ spawns a
+3. `LocalSubProcessExecuteInstance.start()
+   <https://github.com/tox-dev/tox/blob/main/src/tox/execute/local_sub_process/__init__.py>`_ spawns a
    :class:`subprocess.Popen` subprocess and starts drain threads.
-4. `ExecuteStatus.wait()
-   <https://github.com/tox-dev/tox/blob/main/src/tox/execute/local_sub_process/execute_status.py>`_ blocks until
+4. `LocalSubprocessExecuteStatus.wait()
+   <https://github.com/tox-dev/tox/blob/main/src/tox/execute/local_sub_process/__init__.py>`_ blocks until
    completion.
 5. An `Outcome <https://github.com/tox-dev/tox/blob/main/src/tox/execute/request.py>`_ is constructed with exit code,
    captured output, and timing.
@@ -546,9 +547,9 @@ for configuration in this order:
 1. If ``--conf`` is specified, it uses that file directly.
 2. Otherwise, it walks up from CWD looking for:
 
-   - ``tox.toml`` which uses `TomlSource <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/toml_.py>`_.
-   - ``pyproject.toml`` (with ``[tool.tox]``) which uses `PyProjectTomlSource
-     <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/pyproject.py>`_.
+   - ``tox.toml`` which uses `TomlTox <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/toml_tox.py>`_.
+   - ``pyproject.toml`` (with ``[tool.tox]``) which uses `TomlPyProject
+     <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/toml_pyproject.py>`_.
    - ``tox.ini`` which uses `IniSource <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/ini.py>`_.
    - ``setup.cfg`` (with ``[tox:tox]``) which uses `SetupCfgSource
      <https://github.com/tox-dev/tox/blob/main/src/tox/config/source/setup_cfg.py>`_.
@@ -586,9 +587,9 @@ Loaders
 
     - - Loader
       - Reads from
-    - - `IniLoader <https://github.com/tox-dev/tox/blob/main/src/tox/config/loader/ini.py>`_
+    - - `IniLoader <https://github.com/tox-dev/tox/blob/main/src/tox/config/loader/ini/__init__.py>`_
       - INI ``[section]`` key=value pairs
-    - - `TomlLoader <https://github.com/tox-dev/tox/blob/main/src/tox/config/loader/toml.py>`_
+    - - `TomlLoader <https://github.com/tox-dev/tox/blob/main/src/tox/config/loader/toml/__init__.py>`_
       - TOML ``[table]`` key-value pairs
     - - `MemoryLoader <https://github.com/tox-dev/tox/blob/main/src/tox/config/loader/memory.py>`_
       - In-memory dict (provisioning, plugins)


### PR DESCRIPTION
Closes #4024.

- [ ] ran the linter to address style issues (`tox -e fix`)
      — **not run**: I could not install a working `tox` in this environment. Instead I checked
      the rules `tox -e fix` would enforce on an RST-only diff by hand: no line introduced by
      this change exceeds 120 characters (verified by script — the only lines over 120 in the
      file are the four that were already over on `main`), and the RST parses under `docutils`.
      Please re-run `tox -e fix` on my branch; I'll amend if it objects.
- [x] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix
      — not applicable: the change contains no code. The equivalent check is the link
      resolution described above (67 links in `docs/`, 0 unresolved), which I ran before and
      after. If you would find a repo-level guard against this class of regression useful, I'd
      be glad to contribute one as a separate PR rather than smuggle it in here.
- [x] added news fragment in `docs/changelog` folder — `docs/changelog/4024.doc.rst`
- [x] updated/extended the documentation — this PR is the documentation change

---

## Problem

Nine `blob/main` source links in `docs/onboarding.rst` point at paths that do not exist in
`main`, so they render as GitHub 404s. Six of them additionally label the link with a class or
module name that no longer exists, so the prose is misleading independently of the dead link.

This matters more than it would in most files because `onboarding.rst` is what a new
contributor reads to learn where things live — these are exactly the links someone with no
prior knowledge of the layout will click.

## How it was reproduced

I resolved every `https://github.com/tox-dev/tox/blob/main/<path>` link in `docs/` against the
working tree at `main`, rather than checking them over HTTP (GitHub rate-limits that hard enough
to produce false positives in both directions):

```
links resolving to an existing file: 58
links pointing at a NON-EXISTENT path: 9
```

All nine were in `onboarding.rst`; the other 58 were already correct and are untouched.

## What the fix does

Each link was resolved by locating the definition it refers to, not by guessing at a
similar-looking filename:

| Line | Was | Now |
|---|---|---|
| 304 | `session/cmd/list_envs.py` | `session/cmd/list_env.py` (singular; it registers the `list` command) |
| 308 | `session/cmd/show_config.py` | `session/cmd/show_config/` — became a package in #3857 |
| 370 | `config/cli/env.py` | `session/env_select.py`, where `CliEnv` is defined |
| 447 | `local_sub_process/execute_instance.py` | `local_sub_process/__init__.py`, label → `LocalSubProcessExecuteInstance.start()` |
| 450 | `local_sub_process/execute_status.py` | `local_sub_process/__init__.py`, label → `LocalSubprocessExecuteStatus.wait()` |
| 549 | `config/source/toml_.py`, labelled `TomlSource` | `config/source/toml_tox.py`, labelled `TomlTox` |
| 551 | `config/source/pyproject.py`, labelled `PyProjectTomlSource` | `config/source/toml_pyproject.py`, labelled `TomlPyProject` |
| 589 | `config/loader/ini.py` | `config/loader/ini/__init__.py` |
| 591 | `config/loader/toml.py` | `config/loader/toml/__init__.py` |

The `tox.toml` → `TomlTox` and `pyproject.toml` → `TomlPyProject` split was confirmed against
the import order in `src/tox/config/source/discover.py` so the two are not transposed.

Documentation only — no source changes, and no links outside the nine broken ones were touched.

## How it was verified

- Re-ran the same tree resolution after the change: **67 blob links in `docs/`, 0 broken.**
- Confirmed each of the nine new targets parses into a real `reference` node via `docutils`
  (80 reference nodes in the file), so none of them silently became plain text — relevant
  because two of the fixed links wrap across lines.
- Checked the 120-character rule from `docs/development.rst`. Two of my edits initially pushed
  their lines to 122 and 123, so I reflowed them: the `show_config` cell now wraps using the
  same 8-space continuation style already used by the `sequential.py` cell in that same
  `list-table`. Lines over 120 in the file are now exactly the four that were already over on
  `main` (5, 72, 410, 680) — the change adds none.
- Verified the class and module names by grepping for their definitions
  (`LocalSubProcessExecuteInstance` at `local_sub_process/__init__.py:162`,
  `LocalSubprocessExecuteStatus` at `:62`, `IniLoader` at `loader/ini/__init__.py:35`,
  `TomlLoader` at `loader/toml/__init__.py:31`, `CliEnv` at `session/env_select.py:41`).

I could not run `tox -e docs` in this environment, so the RST was validated with `docutils`
rather than a full Sphinx build. The change is confined to link targets and link labels inside
existing constructs, so I would not expect a Sphinx-specific failure, but please flag it if the
docs build disagrees.

Changelog entry added as `docs/changelog/4024.doc.rst`. If you would rather keep the abstract
`ExecuteInstance` / `ExecuteStatus` names in the prose at lines 447/450 and only repoint the
URLs, say so and I'll amend.


*Disclosure: this change was prepared with AI assistance. The link resolution, the `docutils`
reference-node check and the line-length comparison described above were actually run, and I
have reviewed every one of the nine mappings against the class definitions in the tree.
Flagging it so reviewers can weigh it as they see fit.*
