### PR TITLE
Stop Windows pytest-timeout kills in CI

### DIFF
--- a/docs/changelog/4026.contrib.rst
+++ b/docs/changelog/4026.contrib.rst
@@ -1,0 +1,2 @@
+Pre-seed the setuptools wheel image alongside pip before the test session and give integration tests a 240s budget on
+Windows, so pytest-timeout no longer kills Windows CI workers - by :user:`gaborbernat`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,9 +153,20 @@ def pytest_configure(config: pytest.Config) -> None:
         config.add_cleanup(partial(rmtree, app_data, ignore_errors=True))
     seed_env = mkdtemp(prefix="virtualenv-seed-")
     config.add_cleanup(partial(rmtree, seed_env, ignore_errors=True))
-    # seeding builds the pip wheel image, a compileall over pip's tree that is slow on Windows CI; pay it here so it
-    # does not land inside the timeout of whichever test happens to create the first environment
-    cli_run([seed_env, "--activators", ""], setup_logging=False)
+    # seeding builds the pip and setuptools wheel images, a compileall over their trees that is slow on Windows CI; pay
+    # it here so it does not land inside the timeout of whichever test happens to create the first environment (the
+    # setuptools image is not built by default on 3.12+, but tox.pytest forces it via VIRTUALENV_SETUPTOOLS=embed)
+    cli_run([seed_env, "--activators", "", "--pip", "embed", "--setuptools", "embed"], setup_logging=False)
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    if sys.platform != "win32":
+        return  # pragma: win32 no cover
+    # integration tests install from PyPI or a local devpi, which on Windows CI regularly overruns even an explicit
+    # 120s budget; pytest-timeout kills the whole worker, so flaky reruns cannot rescue the job
+    for item in items:  # pragma: win32 cover
+        if item.get_closest_marker("integration") is not None:
+            item.add_marker(pytest.mark.timeout(240), append=False)
 
 
 @pytest.fixture(scope="session")

--- a/tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py
+++ b/tests/tox_env/python/virtual_env/package/test_package_cmd_builder.py
@@ -86,6 +86,7 @@ def test_install_pkg_via(tox_project: ToxProjectCreator, mode: str, pkg_with_ext
     assert calls == [("py", "install_package_deps"), ("py", "install_package")]
 
 
+@pytest.mark.integration
 @pytest.mark.usefixtures("enable_pip_pypi_access")
 def test_build_wheel_external_runs_once(
     tox_project: ToxProjectCreator, demo_pkg_inline: Path, monkeypatch: pytest.MonkeyPatch
@@ -112,6 +113,7 @@ def test_build_wheel_external_runs_once(
     assert result.out.count("greetings from demo_pkg_inline") == 2
 
 
+@pytest.mark.integration
 @pytest.mark.usefixtures("enable_pip_pypi_access")
 def test_build_wheel_external(
     tox_project: ToxProjectCreator, demo_pkg_inline: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Windows CI jobs keep dying from pytest-timeout (e.g. [3.14 win on 08-13](https://github.com/tox-dev/tox/actions/runs/31753049037), where `test_env_base_generated_envs_can_run` was killed inside virtualenv's `_build_wheel_image` and `test_build_wheel_external` while waiting on `pyproject-build` against real PyPI; `test_provision_requires_ok` hit its full 120s three times in the last week); with `method: thread` the kill takes the whole worker down, so `flaky` reruns cannot rescue the job. Two structural causes: the session pre-seed in `tests/conftest.py` only built pip's wheel image while `tox.pytest` sets `VIRTUALENV_SETUPTOOLS=embed` for every project run, so the setuptools image (not built by default on 3.12+) still landed inside the first env-creating test's 30s budget - it now seeds `--pip embed --setuptools embed`; and PyPI/devpi-backed integration tests overrun even an explicit 120s on Windows runners, so a `pytest_collection_modifyitems` hook gives `integration`-marked items a 240s budget on `win32`, and the two `test_build_wheel_external*` tests that download from real PyPI now carry the `integration` marker so they get it too.
