### PR TITLE
fix(config): report a malformed ini as a handled error instead of a traceback

### DIFF
--- a/docs/changelog/4027.bugfix.rst
+++ b/docs/changelog/4027.bugfix.rst
@@ -1,0 +1,2 @@
+Report a malformed ``tox.ini`` or ``setup.cfg`` as a handled error during config discovery instead of raising an
+unhandled :class:`configparser.Error` traceback - by :user:`VXNCXNX`

--- a/src/tox/config/source/ini.py
+++ b/src/tox/config/source/ini.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from configparser import ConfigParser
+from configparser import Error as ConfigParserError
 from itertools import chain
 from typing import TYPE_CHECKING
 
@@ -34,7 +35,12 @@ class IniSource(Source):
             if not path.exists():
                 raise ValueError
             content = path.read_text(encoding="utf-8")
-        self._parser.read_string(content, str(path))
+        try:
+            self._parser.read_string(content, str(path))
+        except ConfigParserError as exc:
+            # configparser errors do not derive from ValueError, unlike tomllib ones, so translate them to let
+            # config discovery report them as a handled error instead of leaking a traceback
+            raise ValueError(exc) from exc
         self._section_mapping: defaultdict[str, list[str]] = defaultdict(list)
 
     def transform_section(self, section: Section) -> Section:  # ruff:ignore[no-self-use]

--- a/tests/config/source/test_discover.py
+++ b/tests/config/source/test_discover.py
@@ -67,6 +67,17 @@ def test_malformed_toml_in_dir_reports_error(tox_project: ToxProjectCreator) -> 
     assert "failed loading" in outcome.out
 
 
+def test_malformed_ini_in_dir_reports_error(tox_project: ToxProjectCreator) -> None:
+    """Config discovery in a directory should report ini parse errors instead of raising a traceback."""
+    project = tox_project({})
+    # Write a tox.ini with an unterminated section header
+    (project.path / "tox.ini").write_text("[tox\nenv_list = a\n", encoding="utf-8")
+    outcome = project.run("l", "-c", str(project.path))
+    outcome.assert_failed()
+    assert "failed loading" in outcome.out
+    assert "File contains no section headers" in outcome.out
+
+
 def test_toml_native_preferred_over_legacy_tox_ini(tox_project: ToxProjectCreator) -> None:
     """When pyproject.toml has both legacy_tox_ini and native TOML config, native TOML should win."""
     pyproject = """\


### PR DESCRIPTION
## What's broken

A malformed `tox.ini` prints a raw traceback instead of a handled error.

```
$ printf '[tox\nenv_list = a\n' > tox.ini
$ tox l
Traceback (most recent call last):
  File ".../bin/tox", line 10, in <module>
    sys.exit(run())
  ...
    raise MissingSectionHeaderError(fpname, lineno, line)
configparser.MissingSectionHeaderError: File contains no section headers.
file: '/tmp/toxbad/tox.ini', line: 1
```

The equivalent TOML mistake is already handled cleanly, which is what makes this look like an oversight rather than a decision:

```
$ tox l
ROOT: HandledError| TomlPyProject failed loading .../pyproject.toml due to Unescaped '\' in a string (at line 2, column 13)
```

It also takes down a run whose real config is fine: a broken `setup.cfg` sitting next to a valid `pyproject.toml` crashes discovery before the good file is ever reached.

## The fix

`discover.py` catches `ValueError` in three places. `tomllib.TOMLDecodeError` subclasses `ValueError`, so TOML is covered. `configparser.MissingSectionHeaderError` derives from `configparser.Error`, not `ValueError`, so the ini path walks straight past all three handlers.

The narrower of the two available fixes is to translate at the raising call, in `IniSource.__init__`, and leave `discover.py` alone. That covers `SetupCfg` too, since it subclasses `IniSource`, and it keeps the existing contract: `MissingRequiredConfigKeyError` in `config/types.py` is already a `ValueError` for exactly this reason.

After:

```
ROOT: HandledError| ToxIni failed loading /tmp/toxbad/tox.ini due to File contains no section headers.
file: '/tmp/toxbad/tox.ini', line: 1
'[tox\n'
```

and for the second case:

```
ROOT: HandledError| SetupCfg failed loading /tmp/toxbad2/setup.cfg due to File contains no section headers.
```

Discovery still stops at the bad `setup.cfg` rather than falling through to the good `pyproject.toml`. That is unchanged here, since altering the fall-through would be a behaviour change rather than a crash fix. Happy to look at it separately if you would like it to fall through.

## Verification

`test_malformed_ini_in_dir_reports_error`, directly beside `test_malformed_toml_in_dir_reports_error` and matching its assertion style. With the translation reverted it fails with the `MissingSectionHeaderError` above.

Full suite: 7988 passed, 30 skipped. The 13 errors are pre-existing missing optional dependencies, `docutils` for the manpage tests and `tombi` for the schema tests, and are the same with and without this change. ruff check and format both pass.
