### PR TITLE
Report a bad ini core value as a handled error

### DIFF
--- a/docs/changelog/4028.bugfix.rst
+++ b/docs/changelog/4028.bugfix.rst
@@ -1,0 +1,2 @@
+Report an invalid value in the ini ``[tox]`` core section (such as ``min_version``, ``requires`` or ``env_list``) as a
+handled error instead of an unhandled traceback, matching the existing TOML loader behavior - by :user:`VXNCXNX`

--- a/src/tox/config/loader/ini/__init__.py
+++ b/src/tox/config/loader/ini/__init__.py
@@ -95,7 +95,19 @@ class IniLoader(StrConvert, Loader[str]):
             return replaced
 
         prepared = replacer(raw, args) if not delay_replace else raw
-        converted = self.to(prepared, of_type, factory)
+        if conf is None or args.env_name is not None:
+            # the CLI config file and tox environments have their own handling for a bad value
+            converted = self.to(prepared, of_type, factory)
+        else:
+            try:
+                converted = self.to(prepared, of_type, factory)
+            except (HandledError, Skip):
+                raise
+            except Exception as exception:
+                # core values are loaded before any guard is in place, so mirror the TOML loader and report a bad
+                # value as a handled error instead of leaking a traceback
+                msg = f"failed to load {self.core_section.key}.{key}: {exception}"
+                raise HandledError(msg) from exception
         if delay_replace:
             cast("SetEnv", converted).use_replacer(replacer, args)  # delay_replace means of_type is SetEnv
         return converted

--- a/tests/config/source/test_discover.py
+++ b/tests/config/source/test_discover.py
@@ -117,6 +117,29 @@ def test_malformed_ini_in_dir_reports_error(tox_project: ToxProjectCreator) -> N
     assert "File contains no section headers" in outcome.out
 
 
+@pytest.mark.parametrize(
+    ("core_value", "message"),
+    [
+        pytest.param("min_version = notaversion", "min_version: Invalid version", id="min_version"),
+        pytest.param("requires = ===bad!!!", "requires: Expected package name", id="requires"),
+        pytest.param("env_list = {py39,py310", "env_list: {py39", id="env_list"),
+    ],
+)
+def test_bad_ini_core_value_reports_error(tox_project: ToxProjectCreator, core_value: str, message: str) -> None:
+    """A bad value in the ini core section should be a handled error rather than an unhandled traceback."""
+    project = tox_project({"tox.ini": f"[tox]\n{core_value}\n"})
+    outcome, leaked = None, None
+    try:
+        outcome = project.run("l")
+    except Exception as exception:  # ruff:ignore[blind-except]  # a leaked traceback is the bug under test
+        leaked = exception
+    assert leaked is None, f"unhandled {type(leaked).__name__}: {leaked}"
+    assert outcome is not None
+    outcome.assert_failed()
+    assert "failed to load tox." in outcome.out
+    assert message in outcome.out
+
+
 def test_toml_native_preferred_over_legacy_tox_ini(tox_project: ToxProjectCreator) -> None:
     """When pyproject.toml has both legacy_tox_ini and native TOML config, native TOML should win."""
     pyproject = """\


### PR DESCRIPTION
A bad value in the ini `[tox]` core section exits with a raw traceback, while the same value in `pyproject.toml` is already reported properly.

```
$ printf '[tox]\nmin_version = notaversion\n' > tox.ini && tox l
  File ".../packaging/version.py", line 452, in __init__
    raise InvalidVersion(f"Invalid version: {version!r}")
packaging.version.InvalidVersion: Invalid version: 'notaversion'
```

The TOML path, same input, unchanged by this PR:

```
$ printf '[tool.tox]\nmin_version = "notaversion"\n' > pyproject.toml && tox l
ROOT: HandledError| failed to load core.min_version: Invalid version: 'notaversion'
```

After:

```
ROOT: HandledError| failed to load tox.min_version: Invalid version: 'notaversion'
```

`requires = ===bad!!!` and `env_list = {py39,py310` (unbalanced brace) were tracebacks too, and are now handled the same way.

## The fix

`IniLoader.build` called `self.to(...)` unguarded. `TomlLoader.build` already wraps the identical call and re-raises as `HandledError`, so this mirrors it, including letting `HandledError` and `Skip` through untouched.

## Why the guard is narrow

The wrap only applies to the core section. My first attempt covered every section and broke 6 existing tests, because two paths deliberately let raw exceptions through:

- testenv values, where `tox c` renders the exception inline as `# Exception: ...` (`test_config_bad_dict`, `test_config_bad_bool` and friends)
- the CLI config file, loaded with `conf is None`

Those are existing behaviour I did not want to change, so the condition is `conf is None or args.env_name is not None` to bypass. Core values are the case with no handling at all, because they are loaded before any guard is in place.

## Verification

`test_ini_core_bad_value_is_handled_error` in `tests/config/source/test_discover.py`, parametrised over `min_version`, `requires` and `env_list`. It asserts no unhandled exception leaks, so it fails on the actual symptom rather than on a message string.

Reverting only the guard condition to always bypass fails it as an assertion:

```
>       assert leaked is None, f"unhandled {type(leaked).__name__}: {leaked}"
E       AssertionError: unhandled InvalidVersion: Invalid version: 'notaversion'
E       AssertionError: unhandled InvalidRequirement: Expected package name at the start of dependency specifier
E       AssertionError: unhandled ValueError: {py39
```

`pytest tests/config/` is 6644 passed, 2 skipped. `tests/config/cli/test_argcomplete.py` is excluded because `argcomplete` is not installed here; it fails to collect identically on a clean checkout.

*Disclosure: written with AI assistance (Claude Code). I reproduced the traceback and the TOML contrast at the CLI, confirmed the narrow guard is required by removing it and watching 6 tests break, and ran the mutation check myself.*
