### PR TITLE
fix: report an invalid --skip-env regex as a handled error

### DIFF
--- a/docs/changelog/4029.bugfix.rst
+++ b/docs/changelog/4029.bugfix.rst
@@ -1,0 +1,2 @@
+Report an invalid ``--skip-env``/``TOX_SKIP_ENV`` regular expression as a handled error instead of raising an
+unhandled :class:`re.error` traceback - by :user:`VXNCXNX`

--- a/docs/changelog/4029.bugfix.rst
+++ b/docs/changelog/4029.bugfix.rst
@@ -1,2 +1,2 @@
 Report an invalid ``--skip-env``/``TOX_SKIP_ENV`` regular expression as a handled error instead of raising an unhandled
-:class:`re.error` traceback - by :user:`VXNCXNX`
+``re.error`` traceback - by :user:`VXNCXNX`

--- a/docs/changelog/4029.bugfix.rst
+++ b/docs/changelog/4029.bugfix.rst
@@ -1,2 +1,2 @@
-Report an invalid ``--skip-env``/``TOX_SKIP_ENV`` regular expression as a handled error instead of raising an
-unhandled :class:`re.error` traceback - by :user:`VXNCXNX`
+Report an invalid ``--skip-env``/``TOX_SKIP_ENV`` regular expression as a handled error instead of raising an unhandled
+:class:`re.error` traceback - by :user:`VXNCXNX`

--- a/src/tox/session/env_select.py
+++ b/src/tox/session/env_select.py
@@ -247,7 +247,15 @@ class EnvSelector:
 
         self._state.conf.core.add_config("labels", dict[str, EnvList], {}, "core labels")
         tox_env_filter_regex = getattr(state.conf.options, "skip_env", "").strip()
-        self._filter_re = re.compile(tox_env_filter_regex) if tox_env_filter_regex else None
+        self._filter_re = self._compile_filter(tox_env_filter_regex) if tox_env_filter_regex else None
+
+    @staticmethod
+    def _compile_filter(pattern: str) -> re.Pattern[str]:
+        try:
+            return re.compile(pattern)
+        except re.error as exc:
+            msg = f"invalid environment skip filter {pattern!r}: {exc}"
+            raise HandledError(msg) from exc
 
     @property
     def _cli_envs(self) -> CliEnv | None:

--- a/tests/session/test_env_select.py
+++ b/tests/session/test_env_select.py
@@ -246,6 +246,22 @@ def test_tox_skip_env_logs(tox_project: ToxProjectCreator, monkeypatch: MonkeyPa
     outcome.assert_out_err("ROOT: skip environment mypy, matches filter 'm[y]py'\npy310\npy39\n", "")
 
 
+@pytest.mark.parametrize("bad_filter", ["[", "(", "*"])
+def test_tox_skip_env_invalid_regex(tox_project: ToxProjectCreator, monkeypatch: MonkeyPatch, bad_filter: str) -> None:
+    monkeypatch.delenv("TOX_SKIP_ENV", raising=False)
+    project = tox_project({"tox.ini": "[tox]\nenv_list = py3{10,9},mypy"})
+
+    leaked: BaseException | None = None
+    try:
+        outcome = project.run("l", "--no-desc", "--skip-env", bad_filter)
+    except Exception as exception:  # ruff:ignore[blind-except]
+        leaked = exception
+    assert leaked is None, f"unhandled {type(leaked).__name__}: {leaked}"
+
+    outcome.assert_failed()
+    assert f"HandledError| invalid environment skip filter {bad_filter!r}" in outcome.out
+
+
 def test_multiple_e_flags_are_additive(tox_project: ToxProjectCreator) -> None:
     proj = tox_project({"tox.ini": "[tox]\nenv_list=a,b,c"})
     outcome = proj.run("c", "-e", "a", "-e", "b", "-k", "env_name")


### PR DESCRIPTION
An invalid regex passed to `--skip-env` exits with a raw `re.error` traceback.

```
$ tox l --skip-env '['
Traceback (most recent call last):
  File ".../re/_parser.py", line 568, in _parse
    raise source.error("unterminated character set",
re.error: unterminated character set at position 0
```

`TOX_SKIP_ENV='('` does the same. Both are user input, so a traceback here is a
bug report waiting to happen rather than a tox failure.

## Cause

`EnvSelector.__init__` compiles the filter with no guard:

```python
self._filter_re = re.compile(tox_env_filter_regex) if tox_env_filter_regex else None
```

Everything else that parses user input in this path raises `HandledError`, which
the runner prints as a one-line message.

## The fix

Wrap the compile and re-raise as `HandledError`, keeping the original message
from `re`:

```
$ tox l --skip-env '['
ROOT: HandledError| invalid environment skip filter '[': unterminated character set at position 0
```

A valid filter is untouched:

```
$ tox l --skip-env 'py31[0-9]'
ROOT: skip environment py312, matches filter 'py31[0-9]'
```

## Verification

`test_tox_skip_env_invalid_regex`, parametrized over `[`, `(` and `*`. It
asserts that nothing escapes `tox_run`, rather than matching on message text, so
it stays valid if the wording changes.

Replacing the `except re.error` body with a bare `raise` fails all three:

```
>       assert leaked is None, f"unhandled {type(leaked).__name__}: {leaked}"
E       AssertionError: unhandled error: unterminated character set at position 0
E       AssertionError: unhandled error: missing ), unterminated subpattern at position 0
E       AssertionError: unhandled error: nothing to repeat at position 0
3 failed, 92 deselected
```

`tests/session/test_env_select.py` is 95 passed. Ruff 0.16.2 (the pinned
pre-commit version) `check` and `format --check` both pass on the two files.

On the full suite: 1 failed, 7862 passed, 28 skipped, 9 errors, which matches
the baseline on a clean checkout here (1 failed, 7859 passed, 28 skipped, 9
errors; the extra 3 are these tests). The failure and errors come from
`argcomplete` and `tombi` missing in this environment, not from the change.

- [x] ran the linter to address style issues (`tox -e fix`) (ruff 0.16.2 check and format, the pinned versions)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation (no doc change: `--skip-env` already documents itself as a regex, only the failure mode changes)

*Disclosure: written with AI assistance (Claude Code). I produced the before and after output above by running the real `tox` binary, and ran the mutation check and the suite baseline myself.*
