### PR TITLE
fix: a semicolon truncates a value read from a set_env file

### DIFF
--- a/docs/changelog/4030.bugfix.rst
+++ b/docs/changelog/4030.bugfix.rst
@@ -1,0 +1,3 @@
+Keep ``;`` inside values read from a ``set_env`` environment file (``file|.env``). Environment file lines are plain
+``KEY=VALUE`` pairs and were incorrectly parsed with the PEP-508 marker splitter, which truncated values such as
+``DATABASE_URL=postgresql://host/db?opt=1;sslmode=require`` at the first semicolon - by :user:`VXNCXNX`

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -941,7 +941,8 @@ Base options
         - blank lines are ignored,
         - lines starting with the ``#`` character are ignored,
         - each line is in KEY=VALUE format; both the key and the value are stripped,
-        - there is no special handling of quotation marks, they are part of the key or value.
+        - there is no special handling of quotation marks, they are part of the key or value,
+        - PEP-508 markers are not supported in environment files, so a ``;`` is a plain value character.
 
     **Conditional environment variables**
 

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -125,8 +125,16 @@ class SetEnv:
             env_line = env_line.strip()  # ruff:ignore[redefined-loop-name]
             if not env_line or env_line.startswith("#"):
                 continue
-            key, value, _ = self._extract_key_value_marker(env_line)
-            yield key, value
+            yield self._extract_key_value(env_line)
+
+    @staticmethod
+    def _extract_key_value(line: str) -> tuple[str, str]:
+        """Split an environment file line; markers do not apply here, so ``;`` is a plain value character."""
+        key, sep, value = line.partition("=")
+        if not sep:
+            msg = f"invalid line {line!r} in set_env"
+            raise ValueError(msg)
+        return key.strip(), value.strip()
 
     @staticmethod
     def _extract_key_value_marker(line: str) -> tuple[str, str, str]:

--- a/tests/config/test_set_env.py
+++ b/tests/config/test_set_env.py
@@ -237,6 +237,23 @@ def test_set_env_environment_file_combined_with_normal_setting(
     }
 
 
+def test_set_env_file_keeps_semicolon_in_value(tox_project: ToxProjectCreator) -> None:
+    ini = """\
+    [testenv]
+    skip_install = true
+    set_env =
+        file|.env
+    """
+    env_file = "DATABASE_URL=postgresql://host/db?opt=1;sslmode=require\nFLAGS=a;b\n"
+    project = tox_project({"tox.ini": ini, ".env": env_file})
+    result = project.run("c", "-e", "py", "-k", "set_env")
+    result.assert_success()
+    set_env = result.env_conf("py")["set_env"]
+    content = {k: set_env.load(k) for k in set_env}
+    assert content["DATABASE_URL"] == "postgresql://host/db?opt=1;sslmode=require"
+    assert content["FLAGS"] == "a;b"
+
+
 def test_set_env_file_does_not_override_later_values(tox_project: ToxProjectCreator) -> None:
     ini = """\
     [testenv]


### PR DESCRIPTION
A value read from a `set_env` environment file is silently truncated at the first
semicolon.

`.env` containing `DATABASE_URL=postgresql://host/db?opt=1;sslmode=require`, with
`set_env = file|.env`:

```
$ tox c -e py -k set_env
before:
[testenv:py]
set_env =
  DATABASE_URL=postgresql://host/db?opt=1

after:
  DATABASE_URL=postgresql://host/db?opt=1;sslmode=require
```

And in a real run:

```
py: commands[0]> python -c '...'
URL=postgresql://host/db?opt=1;sslmode=require
  py: OK
```

No error, no warning, just a shorter value. A database URL with `sslmode` is the
obvious way to hit it.

## Cause

`_stream_env_file` parses each line with the PEP-508 marker splitter:

```python
key, value, _ = self._extract_key_value_marker(env_line)
```

Markers are an inline `set_env` feature, where `KEY=VALUE; python_version < "3.9"`
is meaningful. Environment files have no such syntax: the docs describe their
lines as `KEY=VALUE` with the key and value merely stripped. So the splitter
treats the first `;` in a perfectly ordinary value as the start of a marker and
discards the rest.

## The fix

Give env files their own splitter, `_extract_key_value`, that partitions on `=`
and leaves the value alone, including the same "invalid line" error for a line
with no `=`. Inline `set_env` markers are untouched.

I also added a line to the env-file rules in `docs/reference/config.rst` saying
markers do not apply there, since the existing list describes exactly this kind
of detail.

## Verification

`test_set_env_file_keeps_semicolon_in_value` writes the `.env` above and checks
the resolved value.

Reverting `_stream_env_file` to the marker splitter fails it:

```
>       assert content["DATABASE_URL"] == "postgresql://host/db?opt=1;sslmode=require"
E       AssertionError: assert 'postgresql://host/db?opt=1' == 'postgresql://host/db?opt=1;sslmode=require'
```

`tests/config/test_set_env.py` is 40 passed. Ruff 0.16.2, the pinned pre-commit
version, passes `check` and `format --check` on both files.

Full suite: 1 failed, 7864 passed, 28 skipped, 17 errors, against a stashed
baseline of 1 failed, 7863 passed, 28 skipped, 17 errors. Same single failure
and same 17 errors either way, all from optional deps missing in this venv
(argcomplete, sphinx, tombi).

- [x] ran the linter to address style issues (ruff 0.16.2 check and format, the pinned versions)
- [x] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [x] updated/extended the documentation

## One thing worth your call

An escaped `\;` in an env file no longer collapses to `;`. That was never
documented for env files, and it only worked as a side effect of the marker
splitter, but if you would rather keep it, it is a one-line `.replace("\;", ";")`
in the new function. Inline `set_env` escaping is unchanged.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by running `tox c` and a real `tox r` against the env file shown, and ran the mutation check and the suite baseline myself.*
