### PR TITLE
fix(config): handle configuration file read errors

### DIFF
--- a/docs/changelog/4031.bugfix.rst
+++ b/docs/changelog/4031.bugfix.rst
@@ -1,0 +1,1 @@
+Report unreadable configuration files as handled errors instead of leaking an ``OSError`` traceback.

--- a/src/tox/config/source/discover.py
+++ b/src/tox/config/source/discover.py
@@ -50,7 +50,7 @@ def discover_source(config_file: Path | None, root_dir: Path | None) -> Source:
                 break
             except MissingRequiredConfigKeyError:
                 continue
-            except ValueError as exc:
+            except (OSError, ValueError) as exc:
                 msg = f"{src_type.__name__} failed loading {candidate.resolve()} due to {exc}"
                 raise HandledError(msg) from exc
         if src is None:
@@ -72,7 +72,7 @@ def _locate_source() -> Source | None:
                 except MissingRequiredConfigKeyError as exc:
                     msg = f"{src_type.__name__} skipped loading {candidate.resolve()} due to {exc}"
                     logging.info(msg)
-                except ValueError as exc:
+                except (OSError, ValueError) as exc:
                     msg = f"{src_type.__name__} failed loading {candidate.resolve()} due to {exc}"
                     raise HandledError(msg) from exc
     return None
@@ -89,7 +89,7 @@ def _load_exact_source(config_file: Path) -> Source:
             return src_type(config_file)
         except MissingRequiredConfigKeyError:  # ruff:ignore[try-except-in-loop]
             pass
-        except ValueError as exc:
+        except (OSError, ValueError) as exc:
             msg = f"{src_type.__name__} failed loading {config_file.resolve()} due to {exc}"
             raise HandledError(msg) from exc
     msg = f"could not recognize config file {config_file}"

--- a/tests/config/source/test_discover.py
+++ b/tests/config/source/test_discover.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pytest_mock import MockerFixture
 
     from tox.pytest import ToxProjectCreator
 
@@ -76,6 +80,29 @@ def test_malformed_ini_in_dir_reports_error(tox_project: ToxProjectCreator) -> N
     outcome.assert_failed()
     assert "failed loading" in outcome.out
     assert "File contains no section headers" in outcome.out
+
+
+@pytest.mark.parametrize("config_mode", ["auto", "directory", "file"])
+def test_unreadable_config_reports_error(
+    tox_project: ToxProjectCreator,
+    mocker: MockerFixture,
+    config_mode: str,
+) -> None:
+    project = tox_project({"tox.ini": "[tox]\n"})
+    config_file = project.path / "tox.ini"
+    error = PermissionError(13, "Permission denied", str(config_file))
+    mocker.patch("tox.config.source.tox_ini.ToxIni.__init__", side_effect=error)
+    args = {
+        "auto": (),
+        "directory": ("-c", str(project.path)),
+        "file": ("-c", str(config_file)),
+    }[config_mode]
+
+    outcome = project.run("l", *args)
+
+    outcome.assert_failed()
+    assert f"ToxIni failed loading {config_file} due to {error}" in outcome.out
+    assert "Traceback" not in outcome.out
 
 
 def test_toml_native_preferred_over_legacy_tox_ini(tox_project: ToxProjectCreator) -> None:


### PR DESCRIPTION
## Summary

- translate configuration-source `OSError` failures into `HandledError`
- apply the behavior consistently to automatic, directory, and exact-file discovery
- add regression coverage for all three discovery paths

## Root cause and impact

Configuration discovery only translated `ValueError` into tox's handled error path. Reading an existing configuration can also raise an `OSError` subclass, such as `PermissionError` or a race-time `FileNotFoundError`. Those exceptions escaped to `tox.run` and exposed a full Python traceback for a user configuration problem.

Unreadable configuration files now produce the same concise `failed loading` message as malformed files.

Fixes #4031.

## Validation

- `pytest -q tests/config/source` (`201 passed`)
- `ruff check src/tox/config/source/discover.py tests/config/source/test_discover.py`
- `ruff format --check src/tox/config/source/discover.py tests/config/source/test_discover.py`
- real CLI reproduction with an unreadable `tox.ini`
- `git diff --check`

## Checklist

- [x] ran the relevant linter and formatter checks
- [x] added tests validating the fix
- [x] added `docs/changelog/4031.bugfix.rst`
- [x] no documentation update is needed because this only changes error presentation
