### PR TITLE
Handle unreadable configuration files

### DIFF
--- a/docs/changelog/4031.bugfix.rst
+++ b/docs/changelog/4031.bugfix.rst
@@ -1,0 +1,2 @@
+Report a handled configuration error instead of leaking a traceback when the
+selected configuration file exists but cannot be read - by :user:`SirHegel`.

--- a/docs/changelog/4031.bugfix.rst
+++ b/docs/changelog/4031.bugfix.rst
@@ -1,2 +1,2 @@
-Report a handled configuration error instead of leaking a traceback when the
-selected configuration file exists but cannot be read - by :user:`SirHegel`.
+Report a handled configuration error instead of leaking a traceback when the selected configuration file exists but
+cannot be read - by :user:`SirHegel`.

--- a/src/tox/config/source/discover.py
+++ b/src/tox/config/source/discover.py
@@ -50,7 +50,7 @@ def discover_source(config_file: Path | None, root_dir: Path | None) -> Source:
                 break
             except MissingRequiredConfigKeyError:
                 continue
-            except ValueError as exc:
+            except (ValueError, OSError) as exc:
                 msg = f"{src_type.__name__} failed loading {candidate.resolve()} due to {exc}"
                 raise HandledError(msg) from exc
         if src is None:
@@ -72,7 +72,7 @@ def _locate_source() -> Source | None:
                 except MissingRequiredConfigKeyError as exc:
                     msg = f"{src_type.__name__} skipped loading {candidate.resolve()} due to {exc}"
                     logging.info(msg)
-                except ValueError as exc:
+                except (ValueError, OSError) as exc:
                     msg = f"{src_type.__name__} failed loading {candidate.resolve()} due to {exc}"
                     raise HandledError(msg) from exc
     return None
@@ -89,7 +89,7 @@ def _load_exact_source(config_file: Path) -> Source:
             return src_type(config_file)
         except MissingRequiredConfigKeyError:  # ruff:ignore[try-except-in-loop]
             pass
-        except ValueError as exc:
+        except (ValueError, OSError) as exc:
             msg = f"{src_type.__name__} failed loading {config_file.resolve()} due to {exc}"
             raise HandledError(msg) from exc
     msg = f"could not recognize config file {config_file}"

--- a/tests/config/source/test_discover.py
+++ b/tests/config/source/test_discover.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
+import os
+import sys
 from typing import TYPE_CHECKING
+
+import pytest
+
+from tox.config.source.discover import discover_source
+from tox.report import HandledError
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from tox.pytest import ToxProjectCreator
+
+
+# Root ignores the permission bits, and Windows does not model them this way,
+# so the file stays readable and there is nothing to assert.
+unreadable_files_possible = pytest.mark.skipif(
+    sys.platform == "win32" or os.getuid() == 0,
+    reason="cannot make a file unreadable as root or on Windows",
+)
 
 
 def out_no_src(path: Path) -> str:
@@ -48,6 +63,29 @@ def test_bad_src_content(tox_project: ToxProjectCreator, tmp_path: Path) -> None
     outcome = project.run("l", "-c", str(tmp_path / "setup.cfg"))
     outcome.assert_failed()
     assert outcome.out == f"ROOT: HandledError| config file {tmp_path / 'setup.cfg'} does not exist\n"
+
+
+@unreadable_files_possible
+@pytest.mark.parametrize("named", [True, False], ids=["explicit-path", "discovery"])
+def test_unreadable_config_raises_handled_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, named: bool) -> None:
+    """Reading the file raises an OSError subclass, not ValueError.
+
+    Without handling it, discovery lets PermissionError escape and the CLI
+    prints a traceback instead of the one-line error used for malformed files.
+
+    This exercises discover_source directly: the tox_project fixture converts
+    exceptions on its own, so it cannot tell the two cases apart.
+    """
+    config = tmp_path / "tox.ini"
+    config.write_text("[tox]\nenv_list = py\n")
+    config.chmod(0o000)
+    monkeypatch.chdir(tmp_path)
+
+    try:
+        with pytest.raises(HandledError, match="failed loading"):
+            discover_source(config if named else None, None)
+    finally:
+        config.chmod(0o644)
 
 
 def test_malformed_config_does_not_prevent_help(tox_project: ToxProjectCreator) -> None:

--- a/tests/config/source/test_discover.py
+++ b/tests/config/source/test_discover.py
@@ -70,11 +70,12 @@ def test_bad_src_content(tox_project: ToxProjectCreator, tmp_path: Path) -> None
 def test_unreadable_config_raises_handled_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, named: bool) -> None:
     """Reading the file raises an OSError subclass, not ValueError.
 
-    Without handling it, discovery lets PermissionError escape and the CLI
-    prints a traceback instead of the one-line error used for malformed files.
+    Without handling it, discovery lets PermissionError escape and the CLI prints a traceback instead of the one-line
+    error used for malformed files.
 
-    This exercises discover_source directly: the tox_project fixture converts
-    exceptions on its own, so it cannot tell the two cases apart.
+    This exercises discover_source directly: the tox_project fixture converts exceptions on its own, so it cannot tell
+    the two cases apart.
+
     """
     config = tmp_path / "tox.ini"
     config.write_text("[tox]\nenv_list = py\n")


### PR DESCRIPTION
Fixes #4031.

## The problem

The three source-loading paths in `tox.config.source.discover` translate `ValueError` into `HandledError`, but reading a file can also raise an `OSError` subclass. So a config file that exists and cannot be read lets `PermissionError` escape:

```console
$ chmod 000 tox.ini
$ tox -c tox.ini list
Traceback (most recent call last):
  ...
PermissionError: [Errno 13] Permission denied: 'tox.ini'
```

After:

```console
$ tox -c tox.ini list
ROOT: HandledError| ToxIni failed loading /tmp/p/tox.ini due to [Errno 13] Permission denied: 'tox.ini'
```

## The change

`OSError` is caught alongside `ValueError` in all three paths — the directory branch of `discover_source`, `_locate_source`, and `_load_exact_source` — so the named file, automatic discovery, and `-c <directory>` all behave the same. Verified all three by hand.

## A note on the test

The regression test exercises `discover_source` directly rather than going through the `tox_project` fixture.

I wrote it through the fixture first, and it passed against unfixed code. The fixture converts exceptions on its own, so from the outside both versions produce the same `HandledError| ToxIni failed loading` line and the test cannot tell them apart. Testing the function where the bug lives does distinguish them: unfixed it raises `PermissionError`, fixed it raises `HandledError`.

The test is skipped on Windows and when running as root, since neither can make a file unreadable this way.

`tests/config/source/`: **200 passed**.