### PR TITLE
docs: drop the claim that tox -e py skips tests with missing dependencies

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -31,8 +31,7 @@ section. This section contains only highlights; it's not a substitute for readin
   testing you'll need to install your own "top-level" tox (using pipx_ or similar is fine) and use the following targets
   (tox environments):
 
-  - :samp:`tox -e py [-- {pytest-arg ...}]` to `test code changes <#running-tests>`_. This will skip tests for which you
-    are missing dependencies, but those tests will still be run by GitHub Actions.
+  - :samp:`tox -e py [-- {pytest-arg ...}]` to `test code changes <#running-tests>`_.
   - ``tox -e type`` to typecheck changes. (All new code should have complete type annotations.)
   - ``tox -e docs`` to build documentation changes and update the changelog, followed by viewing (with a browser) the
     generated HTML files under :file:`.tox/docs_out/html/`. The required changelog entry can be viewed at the "Release

--- a/tests/config/cli/test_argcomplete.py
+++ b/tests/config/cli/test_argcomplete.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import argcomplete
+import pytest
 
 from tox.config.cli.parse import get_options
+
+argcomplete = pytest.importorskip("argcomplete")
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture

--- a/tests/config/cli/test_argcomplete.py
+++ b/tests/config/cli/test_argcomplete.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
+import argcomplete
 
 from tox.config.cli.parse import get_options
-
-argcomplete = pytest.importorskip("argcomplete")
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture


### PR DESCRIPTION
`docs/development.rst` said `tox -e py` "will skip tests for which you are missing dependencies", which is not what happens. `tests/config/cli/test_argcomplete.py` imports the optional `argcomplete` extra at module level, so without it collection aborts and no tests run at all:

```
ImportError while importing test module 'tests/config/cli/test_argcomplete.py'
E   ModuleNotFoundError: No module named 'argcomplete'
!!!!! Interrupted: 1 error during collection !!!!!
1 skipped, 19 deselected, 1 error in 2.56s
```

This drops that clause, per review feedback that guarding the import risks the coverage requirements and the documentation is the thing to correct.

Anyone running `tox -e py` is unaffected either way: `tox.toml` sets `extras = ["completion"]` on `env_run_base`, so argcomplete is always installed there.

Drafted with AI assistance; I ran the collection failure above myself on Windows 11 / Python 3.14.7.
