### PR TITLE
Replace deprecated load_module in docs conf

### DIFF
--- a/docs/changelog/4043.contrib.rst
+++ b/docs/changelog/4043.contrib.rst
@@ -1,0 +1,2 @@
+Replace the deprecated ``load_module`` call in the documentation configuration, which Python 3.15 removes - by
+:user:`gaborbernat`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@ import os
 import re
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from types import ModuleType
 from typing import TYPE_CHECKING, Any
 
 from sphinx.domains.python import PythonDomain
@@ -173,7 +174,10 @@ def setup(app: Sphinx) -> None:
 
     app.connect("autodoc-process-signature", process_signature, priority=400)
     app.add_domain(PatchedPythonDomain, override=True)
-    tox_cfg = SourceFileLoader("tox_conf", str(here / "tox_conf.py")).load_module().ToxConfig
+    tox_conf_loader = SourceFileLoader("tox_conf", str(here / "tox_conf.py"))
+    tox_conf = ModuleType(tox_conf_loader.name)
+    tox_conf_loader.exec_module(tox_conf)
+    tox_cfg = tox_conf.ToxConfig
     app.add_directive(tox_cfg.name, tox_cfg)
 
     def check_uri(self: ExternalLinksChecker, refnode: reference) -> None:


### PR DESCRIPTION
`main` is red on `tox env type`:

```
docs/conf.py:176:71: warning[deprecated] The function `load_module` is deprecated:
  Deprecated since Python 3.10; removed in Python 3.15. Use `exec_module()` instead.
Found 1 diagnostic
```

Nothing in the tree changed. ty 0.0.75 landed a `deprecated` lint, `ty` is unpinned at `>=0.0.19`, and the type environment runs with `--error-on-warning`, so the new diagnostic became a failure.

The deprecation is worth acting on rather than silencing: `load_module` is gone in 3.15, and the test matrix already runs 3.15. `docs/conf.py` now builds the module and executes it through the loader instead.

Verified with `tox -e type` (ty 0.0.75, mypy, pyrefly all clean) and `tox -e docs`, which builds with `-W`. The `conf` directive still registers and renders - `reference/config.html` comes out at 389 KB with every setting in place.
