### PR TITLE
🐛 fix(schema): declare prefix in the labeled factor group's not clause

### DIFF
--- a/.github/workflows/update-schemastore.yaml
+++ b/.github/workflows/update-schemastore.yaml
@@ -2,10 +2,42 @@ name: Update SchemaStore
 on:
   push:
     tags: ["*"]
+  pull_request:
+    paths:
+      - "src/tox/tox.schema.json"
+      - ".github/workflows/update-schemastore.yaml"
 permissions:
   contents: read
 jobs:
+  validate:
+    name: schema passes SchemaStore's checks
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Clone SchemaStore
+        run: git clone --depth 1 https://github.com/SchemaStore/schemastore /tmp/schemastore
+      - name: Install SchemaStore's dependencies
+        run: npm ci
+        working-directory: /tmp/schemastore
+      - name: Stage tox's schema
+        run: |
+          python3 -c "
+          import json
+          with open('${{ github.workspace }}/src/tox/tox.schema.json') as f:
+              schema = json.load(f)
+          schema['\$id'] = 'https://json.schemastore.org/tox.json'
+          with open('/tmp/schemastore/src/schemas/json/tox.json', 'w') as f:
+              json.dump(schema, f, indent=2)
+              f.write('\n')
+          "
+      - name: Run SchemaStore's checks against it
+        run: node ./cli.js check --schema-name=tox.json
+        working-directory: /tmp/schemastore
   update-schemastore:
+    needs: validate
+    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     environment: schemastore
     env:

--- a/docs/changelog/4051.bugfix.rst
+++ b/docs/changelog/4051.bugfix.rst
@@ -1,0 +1,2 @@
+Declare ``prefix`` inside the labeled factor group's ``not`` clause of the generated JSON Schema, so the published
+schema compiles under the strict mode SchemaStore validates with - by :user:`gaborbernat`.

--- a/docs/changelog/4051.contrib.rst
+++ b/docs/changelog/4051.contrib.rst
@@ -1,0 +1,2 @@
+Check tox's JSON Schema against SchemaStore's own validator on every pull request that touches it, and before the
+release sync opens a pull request there - by :user:`gaborbernat`.

--- a/src/tox/session/cmd/schema.py
+++ b/src/tox/session/cmd/schema.py
@@ -223,7 +223,8 @@ def gen_schema(state: State) -> int:
                 "type": "object",
                 "minProperties": 1,
                 "maxProperties": 1,
-                "not": {"required": ["prefix"]},
+                # ``properties`` declares the key so ajv strict mode can see it; ``{}`` adds no constraint of its own
+                "not": {"properties": {"prefix": {}}, "required": ["prefix"]},
                 "additionalProperties": {
                     "oneOf": [
                         {"type": "array", "items": {"type": "string"}},

--- a/src/tox/tox.schema.json
+++ b/src/tox/tox.schema.json
@@ -804,6 +804,9 @@
       "minProperties": 1,
       "maxProperties": 1,
       "not": {
+        "properties": {
+          "prefix": {}
+        },
         "required": ["prefix"]
       },
       "additionalProperties": {

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -4,6 +4,7 @@ import json
 import re
 import shutil
 import subprocess
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Protocol
@@ -14,6 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from tox.pytest import MonkeyPatch, ToxProjectCreator
+    from tox.util.json_types import JsonValue
 
 
 class LintWorkspace(Protocol):
@@ -145,26 +147,27 @@ def test_schema_freshness(
     )
 
 
-def _subschemas(node: Any, pointer: str = "#") -> Iterator[tuple[str, dict[str, Any]]]:
-    if isinstance(node, dict):
+def _subschemas(node: JsonValue, pointer: str = "#") -> Iterator[tuple[str, Mapping[str, JsonValue]]]:
+    if isinstance(node, Mapping):
         yield pointer, node
         for key, value in node.items():
             yield from _subschemas(value, f"{pointer}/{key}")
-    elif isinstance(node, list):
+    elif isinstance(node, Sequence) and not isinstance(node, str):
         for index, value in enumerate(node):
             yield from _subschemas(value, f"{pointer}/{index}")
 
 
-def test_schema_required_properties_are_declared(committed_schema: dict[str, Any]) -> None:
+def test_schema_required_properties_are_declared(committed_schema: Mapping[str, JsonValue]) -> None:
     # SchemaStore compiles the published schema with ajv strict mode, which rejects a required property that the
     # schema never declares, so catch it here rather than in a release-time sync PR (see tox-dev/tox#4051)
-    undeclared = [
-        f"{pointer} requires {name!r}"
-        for pointer, schema in _subschemas(committed_schema)
-        if isinstance(schema.get("required"), list)
-        for name in schema["required"]
-        if name not in schema.get("properties", {})
-    ]
+    undeclared: list[str] = []
+    for pointer, schema in _subschemas(committed_schema):
+        required = schema.get("required")
+        if not isinstance(required, Sequence) or isinstance(required, str):
+            continue
+        properties = schema.get("properties")
+        declared = set(properties) if isinstance(properties, Mapping) else set()
+        undeclared += [f"{pointer} requires {name!r}" for name in required if name not in declared]
     assert undeclared == []
 
 

--- a/tests/session/cmd/test_schema.py
+++ b/tests/session/cmd/test_schema.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any, Protocol
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from tox.pytest import MonkeyPatch, ToxProjectCreator
 
 
@@ -141,6 +143,29 @@ def test_schema_freshness(
     assert generated == committed_schema, (
         "tox.schema.json is out of date — regenerate with: tox schema > src/tox/tox.schema.json"
     )
+
+
+def _subschemas(node: Any, pointer: str = "#") -> Iterator[tuple[str, dict[str, Any]]]:
+    if isinstance(node, dict):
+        yield pointer, node
+        for key, value in node.items():
+            yield from _subschemas(value, f"{pointer}/{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from _subschemas(value, f"{pointer}/{index}")
+
+
+def test_schema_required_properties_are_declared(committed_schema: dict[str, Any]) -> None:
+    # SchemaStore compiles the published schema with ajv strict mode, which rejects a required property that the
+    # schema never declares, so catch it here rather than in a release-time sync PR (see tox-dev/tox#4051)
+    undeclared = [
+        f"{pointer} requires {name!r}"
+        for pointer, schema in _subschemas(committed_schema)
+        if isinstance(schema.get("required"), list)
+        for name in schema["required"]
+        if name not in schema.get("properties", {})
+    ]
+    assert undeclared == []
 
 
 def test_schema_allows_deps_array(committed_schema: dict[str, Any]) -> None:


### PR DESCRIPTION
The JSON Schema tox publishes for editors stopped compiling under SchemaStore's validator, so the 4.61.0 sync failed and editors still get the schema from 4.56.0 ([SchemaStore/schemastore#6265](https://github.com/SchemaStore/schemastore/pull/6265)).

The rule that keeps a bare range from reading as a labeled factor group had a form their validator tolerated by luck. Giving labeled groups ranges and value tables in 4.61 tipped it over. The rule now takes a form they accept, and what the schema allows does not change: a labeled list, a labeled range, a labeled values table, a bare range dict and a two-key table each validate as before.

Nothing on the way to a release compiled the schema the way SchemaStore does, so this could only appear after the tag shipped. Every pull request that changes the schema now runs it through their validator, and the release sync runs it again before opening a pull request there, so a schema they would reject can no longer reach a release.
