### PR TITLE
chore: add license-files, remove licence classifier (PEP 639)

### DIFF
--- a/docs/changelog/4052.contrib.rst
+++ b/docs/changelog/4052.contrib.rst
@@ -1,0 +1,2 @@
+Improve license metadata (PEP 639), add ``license-files`` and remove license classifier in ``pyproject.toml`` - by
+:user:`mwtoews`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ keywords = [
   "virtual",
 ]
 license = "MIT"
+license-files = [ "LICENSE" ]
 maintainers = [
   { name = "Bernát Gábor", email = "gaborjbernat@gmail.com" },
   { name = "Jürgen Gmach", email = "juergen.gmach@googlemail.com" },
@@ -31,7 +32,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Framework :: tox",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX",


### PR DESCRIPTION
This addresses two items from [PEP 639](https://peps.python.org/pep-0639/) to improve the licence metadata:

1. Add `licence-files` to explicitly include the licence file
2. Remove deprecated licence classifier

---

- [X] ran the linter to address style issues (`tox -e fix`)
- [X] wrote descriptive pull request text
- [x] ensured there are test(s) validating the fix
- [x] added news fragment in `docs/changelog` folder
- [ ] updated/extended the documentation
