### PR TITLE
🐛 fix(config): stop splitting factor names that look like ranges

### DIFF
--- a/docs/changelog/4053.bugfix.rst
+++ b/docs/changelog/4053.bugfix.rst
@@ -1,0 +1,1 @@
+Only expand a generative digit range at a factor boundary, so a name like ``py313-django4-2`` is no longer split into separate environments.

--- a/docs/changelog/4053.bugfix.rst
+++ b/docs/changelog/4053.bugfix.rst
@@ -1,2 +1,2 @@
-Only expand a generative digit range at a factor boundary, so a name like ``py313-django4-2`` is no longer split into
-separate environments.
+A generative digit range now expands only where a factor starts, so an environment such as ``py313-django4-2`` keeps its
+name instead of splitting into ``py313-django4``, ``3`` and ``2`` - by :user:`MohammedAlkindi`.

--- a/docs/changelog/4053.bugfix.rst
+++ b/docs/changelog/4053.bugfix.rst
@@ -1,1 +1,2 @@
-Only expand a generative digit range at a factor boundary, so a name like ``py313-django4-2`` is no longer split into separate environments.
+Only expand a generative digit range at a factor boundary, so a name like ``py313-django4-2`` is no longer split into
+separate environments.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -2938,6 +2938,10 @@ will create the following envs:
 Negative ranges will also be expanded (``{3-1}`` -> ``{3,2,1}``). Non-numerical open ranges such as ``{a-}`` and
 ``{-b}`` will not be expanded.
 
+A range is recognized only where a factor starts, so digits carrying on a name stay part of it: ``py313-django4-2``
+names one environment rather than three, and ``3.10-2`` keeps its version. The same rule applies wherever tox reads
+factors, including ``-e`` on the command line.
+
 Open-ended numerical ranges use bounds derived from the `supported CPython versions
 <https://devguide.python.org/versions/>`_ at the time of the tox release:
 

--- a/src/tox/config/loader/ini/factor.py
+++ b/src/tox/config/loader/ini/factor.py
@@ -186,9 +186,9 @@ def expand_ranges(value: str) -> str:
     return re.sub(
         r"""
         (                       # outer capture group
-            ( \d+ ) - ( \d+ )   # closed range: start-end
+            (?<! [\w.] ) ( \d+ ) - ( \d+ )   # closed range: start-end
             |
-            ( \d+ ) -           # right-open range: start-
+            (?<! [\w.] ) ( \d+ ) -           # right-open range: start-
             |
             (?<= [{,] ) - ( \d+ )  # left-open range: -end (preceded by { or ,)
             |

--- a/src/tox/config/loader/ini/factor.py
+++ b/src/tox/config/loader/ini/factor.py
@@ -186,9 +186,12 @@ def expand_ranges(value: str) -> str:
     return re.sub(
         r"""
         (                       # outer capture group
-            (?<! [\w.] ) ( \d+ ) - ( \d+ )   # closed range: start-end
-            |
-            (?<! [\w.] ) ( \d+ ) -           # right-open range: start-
+            (?<! [\w.] )        # a range opens a factor, so digits carrying on a name are not one (py313-django4-2)
+            (?:
+                ( \d+ ) - ( \d+ ) # closed range: start-end
+                |
+                ( \d+ ) -         # right-open range: start-
+            )
             |
             (?<= [{,] ) - ( \d+ )  # left-open range: -end (preceded by { or ,)
             |

--- a/tests/config/loader/ini/test_factor.py
+++ b/tests/config/loader/ini/test_factor.py
@@ -199,6 +199,11 @@ def test_factor_config_no_env_list_creates_env(tox_ini_conf: ToxIniCreator) -> N
             "py313-django4-2,py313-django5-1",
             id="digit run continuing a factor name is not a range",
         ),
+        pytest.param(
+            "3.10-2,3.11-2",
+            "3.10-2,3.11-2",
+            id="digit run continuing a dotted version is not a range",
+        ),
     ],
 )
 def test_expand_ranges_targets_matched_range(value: str, expected: str) -> None:
@@ -289,6 +294,11 @@ def test_expand_ranges_targets_matched_range(value: str, expected: str) -> None:
             "py313-django4-2,py313-django5-1",
             ["py313-django4-2", "py313-django5-1"],
             id="Don't expand a digit run that continues a factor name",
+        ),
+        pytest.param(
+            "3.10-2,3.11-2",
+            ["3.10-2", "3.11-2"],
+            id="Don't expand a digit run that continues a dotted version",
         ),
         pytest.param(
             "py3{10-11, 13-14}",

--- a/tests/config/loader/ini/test_factor.py
+++ b/tests/config/loader/ini/test_factor.py
@@ -194,6 +194,11 @@ def test_factor_config_no_env_list_creates_env(tox_ini_conf: ToxIniCreator) -> N
         pytest.param("x2-4y-{2-4}", "x2-4y-{2,3,4}", id="literal range text before an identical braced range"),
         pytest.param("{2-4}", "{2,3,4}", id="braced range only"),
         pytest.param("a{1-2}-b{1-2}", "a{1,2}-b{1,2}", id="two identical braced ranges"),
+        pytest.param(
+            "py313-django4-2,py313-django5-1",
+            "py313-django4-2,py313-django5-1",
+            id="digit run continuing a factor name is not a range",
+        ),
     ],
 )
 def test_expand_ranges_targets_matched_range(value: str, expected: str) -> None:
@@ -280,6 +285,16 @@ def test_expand_ranges_targets_matched_range(value: str, expected: str) -> None:
         pytest.param("foo{a-11}", ["fooa-11"], id="Don't expand alpha-umerical range"),
         pytest.param("foo{13-a}", ["foo13-a"], id="Don't expand numerical-alpha range"),
         pytest.param("foo{a-b}", ["fooa-b"], id="Don't expand non-numerical range"),
+        pytest.param(
+            "py313-django4-2,py313-django5-1",
+            ["py313-django4-2", "py313-django5-1"],
+            id="Don't expand a digit run that continues a factor name",
+        ),
+        pytest.param(
+            "py3{10-11, 13-14}",
+            ["py310", "py311", "py313", "py314"],
+            id="Expand a range that follows a comma and whitespace",
+        ),
     ],
 )
 def test_env_list_expands_ranges(env_list: str, expected_envs: list[str], tox_ini_conf: ToxIniCreator) -> None:


### PR DESCRIPTION
tox pulled an environment name ending in a digit, a hyphen and another digit apart, as though the tail were a generative range. `py313-django4-2` never got created: tox made `py313-django4`, `3` and `2` instead, and said nothing. `py310-1,py310-2` turned into more than three hundred environments, counting down from 310.

A range now has to open a factor, so digits carrying on a name stay part of it. The documented range forms keep working, including one written after a comma and a space, and a version-shaped name such as `3.10-2` survives too.

The same expansion sits behind `-e` on the command line, behind generative section names and behind factor conditions, so those pick up the fix as well.

The left-open form `{-13}` keeps its narrower rule. Widening it to match would swallow the trailing `-2` in `py3{10-11}-2,x`.
