### PR TITLE
📝 docs(config): document how factors work

### DIFF
--- a/docs/changelog/4055.doc.rst
+++ b/docs/changelog/4055.doc.rst
@@ -1,0 +1,3 @@
+Document how factors work in one place, covering what a factor is, which characters it may hold, the platform and
+architecture factors that reach conditions without appearing in a name, and how selecting by factor differs from
+selecting by name - by :user:`gaborbernat`.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -335,8 +335,8 @@ Platform-dependent commands
 ===========================
 
 The current platform (``sys.platform`` value like ``linux``, ``darwin``, ``win32``) is automatically available as an
-implicit factor in all environments. Use platform factors to run different commands or set different dependencies per
-platform without encoding the platform name in the environment:
+implicit factor in all environments, alongside the machine architecture (see :ref:`factors`). Use platform factors to
+run different commands or set different dependencies per platform without encoding the platform name in the environment:
 
 .. tab:: TOML
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -71,7 +71,7 @@ generative section names (see below).
 **Conditional factors** -- Both INI and TOML support filtering by factor name. A factor is any dash-separated segment in
 the environment name (e.g. ``py313-django50`` has factors ``py313`` and ``django50``). Additionally, the current
 platform (``sys.platform`` value like ``linux``, ``darwin``, ``win32``) is automatically available as an implicit
-factor.
+factor. See :ref:`factors` for the naming rules and for selecting environments by factor.
 
 .. tab:: TOML
 
@@ -2401,6 +2401,80 @@ separators:
 
 Multiple dots can be escaped in the same key: ``-x 'some\.dotted\.name.key=val'``. A backslash not followed by a dot
 passes through literally.
+
+.. _factors:
+
+*********
+ Factors
+*********
+
+An environment name is a list of factors joined by ``-``. ``py313-django50-cov`` carries the factors ``py313``,
+``django50`` and ``cov``. Factors are what let one environment section serve a whole matrix: combinations of them decide
+which environments exist, and each setting can pick a value per factor.
+
+Naming
+======
+
+A factor holds letters, digits, underscores and dots, so ``3.14`` and ``django_5`` are both names tox accepts. ``-``
+separates factors and ``,`` separates environment names, so a factor can contain neither:
+
+.. code-block:: ini
+
+    [tox]
+    env_list = 3.14-django50, 3.14-django42, lint
+
+tox compares factors as plain text, so ``*`` and ``?`` sit in a name without matching anything.
+
+Implicit factors
+================
+
+Two factors reach conditions without appearing in an environment name:
+
+- the platform, which :data:`sys.platform` reports as ``linux``, ``darwin`` or ``win32``
+- the machine architecture, such as ``arm64`` or ``x86_64``, unless the environment name already carries one
+
+.. code-block:: ini
+
+    [testenv]
+    deps =
+        pytest
+        linux: pytest-xvfb
+
+Both belong to the environment tox is configuring, not to its name, so neither can select an environment: ``tox run -f
+darwin`` matches nothing.
+
+Where factors apply
+===================
+
+Factors reach settings through conditions. INI writes a condition as a prefix, TOML as a ``replace = "if"`` table.
+:ref:`conditional-settings` and :ref:`conditional-value-reference` cover the syntax of each.
+
+Factors create environments through generation. INI expands braces in ``env_list`` and in section names, TOML composes
+structured dicts. :ref:`generative-environment-list` covers both.
+
+Selecting environments by factor
+================================
+
+``-f`` runs every environment whose name carries the factors you name. Given ``env_list = 3.14-django50, 3.14-django42,
+lint``:
+
+.. code-block:: console
+
+    $ tox run -f django50          # 3.14-django50
+    $ tox run -f 3.14 django50     # 3.14-django50, since both factors must be present
+    $ tox run -f django50 -f lint  # 3.14-django50 and lint, since either group will do
+
+Naming several factors after one ``-f`` requires all of them; repeating ``-f`` accepts any of the groups. Use ``-e`` to
+name environments outright instead.
+
+Pitfalls
+========
+
+A condition needs whitespace after its colon. ``django50: pytest`` is a condition. ``django50:pytest`` is an ordinary
+value holding a colon, and tox installs a dependency by that name.
+
+In INI, naming a factor in a condition also teaches tox that environment name. A ``[testenv]`` holding ``docs: sphinx``
+answers to ``tox run -e docs`` even when ``docs`` appears in no ``env_list``.
 
 ***********
  TOML only

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -158,6 +158,7 @@ Environment names and Python versions
 Environment names can consist of alphanumeric characters, dashes, and dots. Names are split on dashes into **factors**
 -- for example ``py311-django42`` splits into factors ``py311`` and ``django42``. Additionally, the current platform
 (like ``linux``, ``darwin``, ``win32``) is automatically available as an implicit factor for conditional configuration.
+See :ref:`factors` for the full rules.
 
 tox recognizes certain naming patterns and automatically sets the Python interpreter:
 


### PR DESCRIPTION
Most of tox configuration involves factors, and the documentation described them four times over, each from the angle of the feature it was explaining. The format comparison, conditional settings, generative environment lists and the platform how-to each covered a slice. None of them defined a factor, listed the characters tox accepts in one, or explained how selecting by factor differs from selecting by name.

A new reference section states the model and the rules, and the three places that introduce factors link to it.

Some of it was documented nowhere. tox adds the machine architecture alongside the platform as an implicit factor, so `arm64` matches on an Apple Silicon machine, and naming an architecture in the environment turns that off. Neither implicit factor can select an environment, so `tox run -f darwin` matches nothing. Several factors after one `-f` require all of them, while repeating `-f` accepts any group.

I also wrote down two behaviours that cost people time. A condition needs whitespace after its colon, so `django50:pytest` installs a dependency by that name rather than filtering. In ini, tox treats a factor named in a condition as an environment name, so a `[testenv]` with `docs: sphinx` answers to `tox run -e docs` with no `env_list` entry.

I checked every claim against a run rather than reading it off the source, and the docs test suite executes the examples.
