### PR TITLE
📝 docs(config): cover the keys that had no reference entry

### DIFF
--- a/docs/changelog/4056.doc.rst
+++ b/docs/changelog/4056.doc.rst
@@ -1,0 +1,3 @@
+Give a reference entry to the configuration keys that had none. ``interrupt_post_commands`` keeps ``commands_post``
+running through an interrupt, and ``config_file_path``, ``host_python``, ``home`` and ``tox_root_name`` are constants a
+configuration can substitute - by :user:`gaborbernat`.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -1238,6 +1238,35 @@ To invert the exit code (fail if the command returns 0, succeed otherwise), use 
              ! python -c 'import sys; sys.exit(1)'
              python --version
 
+*****************************
+ Clean up after an interrupt
+*****************************
+
+An interrupt with :kbd:`Ctrl-C` stops the environment where it stands, so a container left running or a fixture database
+left behind stays that way. Set :ref:`interrupt_post_commands` to give :ref:`commands_post` a chance to run first:
+
+.. tab:: TOML
+
+    .. code-block:: toml
+
+         [env.integration]
+         interrupt_post_commands = true
+         commands_pre = [["docker", "compose", "up", "--detach"]]
+         commands = [["pytest", "tests/integration"]]
+         commands_post = [["docker", "compose", "down"]]
+
+.. tab:: INI (deprecated)
+
+    .. code-block:: ini
+
+         [testenv:integration]
+         interrupt_post_commands = true
+         commands_pre = docker compose up --detach
+         commands = pytest tests/integration
+         commands_post = docker compose down
+
+Press :kbd:`Ctrl-C` a second time to give up on the teardown as well.
+
 **********************
  Retry flaky commands
 **********************

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -567,6 +567,25 @@ the top level of ``tox.toml``. Placing these options in an environment section (
     The root directory for the tox project (where the configuration file is found).
 
 .. conf::
+    :keys: config_file_path
+    :constant:
+
+    A constant holding the path of the configuration file tox loaded.
+
+.. conf::
+    :keys: tox_root_name
+    :constant:
+
+    A constant holding the name of the :ref:`tox_root` directory. Pairs with ``{home}`` to give each project its own
+    location outside the project tree, as shown under :ref:`work_dir`.
+
+.. conf::
+    :keys: home
+    :constant:
+
+    A constant holding the user's home directory.
+
+.. conf::
     :keys: work_dir, toxworkdir
     :default: {tox_root}/.tox
     :version_added: 1.0
@@ -645,6 +664,13 @@ the top level of ``tox.toml``. Placing these options in an environment section (
     :version_added: 4.17
 
     A constant holding the platform of the tox runtime environment.
+
+.. conf::
+    :keys: host_python
+    :constant:
+
+    A constant holding the path of the Python interpreter running tox itself, which is not the interpreter of any tox
+    environment.
 
 Python language core options
 ============================
@@ -1383,6 +1409,15 @@ Run
 
     Commands to run after running the :ref:`commands`. Execute regardless of the outcome of both :ref:`commands` and
     :ref:`commands_pre`. All evaluation and configuration logic applies from :ref:`commands`.
+
+.. conf::
+    :keys: interrupt_post_commands
+    :default: false
+
+    Run :ref:`commands_post` even when you interrupt the run with :kbd:`Ctrl-C`, so teardown such as stopping a
+    container or removing a fixture database still happens. A second :kbd:`Ctrl-C` gives up on those commands too.
+
+    By default an interrupt stops the environment where it is, and :ref:`commands_post` does not run.
 
 .. conf::
     :keys: change_dir, changedir


### PR DESCRIPTION
I diffed every configuration key tox registers against every key the reference documents, taking the keys from the generated schema and from a live `tox config` dump so that nothing rests on reading the source. Five keys had no entry.

Four are constants a configuration can substitute: `config_file_path`, `host_python`, `home` and `tox_root_name`. The last two already appear in the `work_dir` guidance, which tells people to write `{home}/.local/state/tox/{tox_root_name}` while neither name resolves to anything in the reference.

The fifth changes what tox does. `interrupt_post_commands` runs `commands_post` after you interrupt a run, so a container stops and a fixture database goes away instead of surviving the interrupt. That one earns a how-to next to the reference entry, since you reach for it from the task rather than from the key.

The same sweep over the other surfaces found them covered, which is worth recording so the next audit can skip them. The CLI reference generates itself from the parser, every substitution the replacer dispatches appears in the substitution table, and the only environment variables missing from the docs are a private test hook and a read of `SHELL`.
