### PR TITLE
🐛 fix(config): read a set_env file as UTF-8

### DIFF
--- a/docs/changelog/4059.bugfix.rst
+++ b/docs/changelog/4059.bugfix.rst
@@ -1,0 +1,2 @@
+A ``set_env`` environment file (``file|.env``) is now read as UTF-8 instead of the platform's locale encoding, so
+non-ASCII values no longer arrive mangled on Windows - by :user:`MohammedAlkindi`.

--- a/src/tox/config/set_env.py
+++ b/src/tox/config/set_env.py
@@ -121,7 +121,7 @@ class SetEnv:
         if not env_file.exists():
             msg = f"{env_file} does not exist for set_env"
             raise Fail(msg)
-        for env_line in env_file.read_text().splitlines():
+        for env_line in env_file.read_text(encoding="utf-8").splitlines():
             env_line = env_line.strip()  # ruff:ignore[redefined-loop-name]
             if not env_line or env_line.startswith("#"):
                 continue

--- a/tests/config/test_set_env.py
+++ b/tests/config/test_set_env.py
@@ -201,6 +201,14 @@ def test_set_env_environment_file(
     }
 
 
+def test_set_env_environment_file_is_utf8(eval_set_env: EvalSetEnv) -> None:
+    set_env = eval_set_env(
+        "[testenv]\npackage=skip\nset_env=file|.env",
+        extra_files={".env": "GREETING=Grüße\n"},
+    )
+    assert set_env.load("GREETING") == "Grüße"
+
+
 @pytest.mark.parametrize(
     ("of_type", "config"),
     [


### PR DESCRIPTION
`_stream_env_file` reads the file named by `set_env = file|.env` with a bare `read_text()`, which decodes using the process locale encoding. The same file therefore yields different values per platform: on a Windows ANSI code page a UTF-8 value comes back mojibaked, and under a DBCS code page an undecodable byte raises `UnicodeDecodeError` out of a function whose only other error path is a clean `Fail`.

Measured here with `locale.getencoding()` = `cp1252`, on a file holding the bytes `GREETING=Gr\xc3\xbc\xc3\x9fe`:

```
read_text()                 -> 'GREETING=GrÃ¼ÃŸe\n'
read_text(encoding="utf-8") -> 'GREETING=Grüße\n'
```

Every other user-facing text file tox reads is already pinned: `tox.ini` at `config/source/ini.py:37`, `tox_env/python/api.py:221`, and PEP 723 metadata at `tox_env/python/pep723.py:124` with `utf-8-sig`. The env file was the one that was not.

The added test fails on the unpatched tree and passes with the change. Scoped run over `tests/config tests/util tests/execute tests/journal tests/plugin`: 6816 passed and 20 failed before, 6817 and 20 after, with byte-identical failing names. Those 20 are pre-existing `WinError 1314` virtualenv-seeding failures on this machine.

Left out deliberately: a BOM still leaves the first key prefixed with U+FEFF, and a legacy ANSI file will now raise rather than decode. Both are separate concerns; say the word if you want either folded in.
