### PR TITLE
fix(config): preserve Windows UNC paths

### DIFF
--- a/docs/changelog/4060.bugfix.rst
+++ b/docs/changelog/4060.bugfix.rst
@@ -1,0 +1,2 @@
+A UNC or extended-length path in ``commands`` no longer loses one of its two leading backslashes, so
+``\\server\share\file.txt`` survives tokenization on Windows - by :user:`MohammedAlkindi`.

--- a/docs/changelog/4060.bugfix.rst
+++ b/docs/changelog/4060.bugfix.rst
@@ -1,2 +1,1 @@
-A UNC or extended-length path in ``commands`` no longer loses one of its two leading backslashes, so
-``\\server\share\file.txt`` survives tokenization on Windows - by :user:`MohammedAlkindi`.
+Preserve UNC and extended-length paths in Windows commands, including quoted paths - by :user:`MohammedAlkindi`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1392,6 +1392,17 @@ Run
         The backslash ``\`` character can be used to escape quotes, whitespace, itself, and
         other characters (except on Windows, where a backslash in a path will not be interpreted as an escape).
         Unescaped single quote will disable the backslash escape until closed by another unescaped single quote.
+        On Windows, UNC and extended-length prefixes retain both leading backslashes, including in quoted paths and
+        option values such as ``--source=\\server\share``. Quote paths containing spaces:
+
+        .. code-block:: ini
+
+            [testenv]
+            commands = xcopy "\\server\share\file name.txt" .
+
+        Inside an unquoted or double-quoted path, double backslashes escape one backslash. Single-quoted text is
+        literal; TOML argument arrays bypass command-line splitting.
+
         For more details, please see :doc:`shlex parsing rules <python:library/shlex>`.
 
     .. note::
@@ -3210,8 +3221,9 @@ In substitutions, the backslash character ``\`` will act as an escape when prece
           python -c 'print("host: \{}".format("{env:HOSTNAME:host\: not set}")'
 
 Note that any backslashes remaining after substitution may be processed by ``shlex`` during command parsing. On POSIX
-platforms, the backslash will escape any following character; on windows, the backslash will escape any following quote,
-whitespace, or backslash character (since it normally acts as a path delimiter).
+platforms, the backslash escapes the following character. On Windows, it escapes quotes and other backslashes;
+backslashes before whitespace remain path separators. UNC prefixes retain their leading pair. Single-quoted text is
+literal on both platforms.
 
 Special substitutions that accept additional colon-delimited ``:`` parameters cannot have a space after the ``:`` at the
 beginning of line (e.g. ``{posargs: magic}`` would be parsed as factorial ``{posargs``, having value magic).

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -60,17 +60,43 @@ class StrConvert(Convert[str]):
         This allows windows paths to be written without double backslash, while retaining the POSIX backslash escape
         semantics for quotes and escapes.
 
+        A backslash pair at the very start of a word, immediately followed by more path text, is the exception: a
+        UNC path (``\\\\server\\share``) or an extended-length path prefix requires exactly two literal leading
+        backslashes, so that leading pair must survive as-is rather than being collapsed the way an interior
+        ``\\\\`` (the POSIX-escaped form of a single literal backslash) is elsewhere in a path. A bare ``\\\\`` with
+        nothing (or only whitespace) after it is not a path prefix, and keeps the ordinary collapsing behavior.
+
         """
         result = []
-        for ix, char in enumerate(value):
+        ix = 0
+        at_word_start = True
+        n = len(value)
+        while ix < n:
+            char = value[ix]
+            if char.isspace():
+                result.append(char)
+                at_word_start = True
+                ix += 1
+                continue
+            starts_backslash_pair = at_word_start and char == escape and value[ix + 1 : ix + 2] == escape
+            if starts_backslash_pair:
+                after_run = value[ix + 2 : ix + 3]
+                if after_run and after_run != escape and not after_run.isspace():
+                    # exactly two leading backslashes starting a word, followed by more text: a UNC/extended-path
+                    # prefix - keep both backslashes literal instead of collapsing them
+                    result.extend((escape * 2, escape * 2))
+                    ix += 2
+                    at_word_start = False
+                    continue
             result.append(char)
+            at_word_start = False
             if char == escape:
                 last_char = value[ix - 1 : ix]
-                if last_char == escape:
-                    continue
-                next_char = value[ix + 1 : ix + 2]
-                if next_char not in {escape, *special_chars}:
-                    result.append(escape)  # escape escapes that are not themselves escaping a special character
+                if last_char != escape:
+                    next_char = value[ix + 1 : ix + 2]
+                    if next_char not in {escape, *special_chars}:
+                        result.append(escape)  # escape escapes that are not themselves escaping a special character
+            ix += 1
         return "".join(result)
 
     @staticmethod

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -55,7 +55,7 @@ class StrConvert(Convert[str]):
 
     @staticmethod
     def _win32_process_path_backslash(value: str, escape: str, special_chars: str) -> str:
-        """Escape backslash in value that is not followed by a special character.
+        r"""Escape backslash in value that is not followed by a special character.
 
         This allows windows paths to be written without double backslash, while retaining the POSIX backslash escape
         semantics for quotes and escapes.

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -60,11 +60,11 @@ class StrConvert(Convert[str]):
         This allows windows paths to be written without double backslash, while retaining the POSIX backslash escape
         semantics for quotes and escapes.
 
-        A backslash pair at the very start of a word, immediately followed by more path text, is the exception: a
-        UNC path (``\\\\server\\share``) or an extended-length path prefix requires exactly two literal leading
-        backslashes, so that leading pair must survive as-is rather than being collapsed the way an interior
-        ``\\\\`` (the POSIX-escaped form of a single literal backslash) is elsewhere in a path. A bare ``\\\\`` with
-        nothing (or only whitespace) after it is not a path prefix, and keeps the ordinary collapsing behavior.
+        A backslash pair at the very start of a word, immediately followed by more path text, is the exception: a UNC
+        path (``\\server\share``) or an extended-length path prefix requires exactly two literal leading backslashes, so
+        that leading pair must survive as-is rather than being collapsed the way an interior ``\\`` (the POSIX-escaped
+        form of a single literal backslash) is elsewhere in a path. A bare ``\\`` with nothing (or only whitespace)
+        after it is not a path prefix, and keeps the ordinary collapsing behavior.
 
         """
         result = []

--- a/src/tox/config/loader/str_convert.py
+++ b/src/tox/config/loader/str_convert.py
@@ -54,52 +54,6 @@ class StrConvert(Convert[str]):
                     raise TypeError(msg)
 
     @staticmethod
-    def _win32_process_path_backslash(value: str, escape: str, special_chars: str) -> str:
-        r"""Escape backslash in value that is not followed by a special character.
-
-        This allows windows paths to be written without double backslash, while retaining the POSIX backslash escape
-        semantics for quotes and escapes.
-
-        A backslash pair at the very start of a word, immediately followed by more path text, is the exception: a UNC
-        path (``\\server\share``) or an extended-length path prefix requires exactly two literal leading backslashes, so
-        that leading pair must survive as-is rather than being collapsed the way an interior ``\\`` (the POSIX-escaped
-        form of a single literal backslash) is elsewhere in a path. A bare ``\\`` with nothing (or only whitespace)
-        after it is not a path prefix, and keeps the ordinary collapsing behavior.
-
-        """
-        result = []
-        ix = 0
-        at_word_start = True
-        n = len(value)
-        while ix < n:
-            char = value[ix]
-            if char.isspace():
-                result.append(char)
-                at_word_start = True
-                ix += 1
-                continue
-            starts_backslash_pair = at_word_start and char == escape and value[ix + 1 : ix + 2] == escape
-            if starts_backslash_pair:
-                after_run = value[ix + 2 : ix + 3]
-                if after_run and after_run != escape and not after_run.isspace():
-                    # exactly two leading backslashes starting a word, followed by more text: a UNC/extended-path
-                    # prefix - keep both backslashes literal instead of collapsing them
-                    result.extend((escape * 2, escape * 2))
-                    ix += 2
-                    at_word_start = False
-                    continue
-            result.append(char)
-            at_word_start = False
-            if char == escape:
-                last_char = value[ix - 1 : ix]
-                if last_char != escape:
-                    next_char = value[ix + 1 : ix + 2]
-                    if next_char not in {escape, *special_chars}:
-                        result.append(escape)  # escape escapes that are not themselves escaping a special character
-            ix += 1
-        return "".join(result)
-
-    @staticmethod
     def to_command(value: str) -> Command:
         """At this point, ``value`` has already been substituted out, and all punctuation / escapes are final.
 
@@ -136,6 +90,47 @@ class StrConvert(Convert[str]):
             args[0] = args[0][1:]
             args = ["-", *args]
         return Command(args)
+
+    @staticmethod
+    def _win32_process_path_backslash(value: str, escape: str, special_chars: str) -> str:
+        """Allow Windows paths while retaining shlex quote and backslash escapes."""
+        result: Final[list[str]] = []
+        quote = ""
+        path_start = True
+        index = 0
+        while index < len(value):
+            char = value[index]
+            if quote == "'":
+                result.append(char)
+                if char == quote:
+                    quote = ""
+                path_start = False
+            elif char == escape:
+                following = value[index + 1 : index + 2]
+                if following == escape:
+                    after_pair = value[index + 2 : index + 3]
+                    # UNC prefixes need two literal backslashes; a bare pair still escapes one.
+                    is_prefix = path_start and bool(after_pair) and after_pair not in escape + special_chars + " \t\r\n"
+                    result.append(escape * (4 if is_prefix else 2))
+                    index += 1
+                elif following and following in special_chars:
+                    result.extend((escape, following))
+                    index += 1
+                else:
+                    result.append(escape if value[index - 1 : index] == escape else escape * 2)
+                path_start = False
+            else:
+                result.append(char)
+                if char in special_chars and not quote:
+                    quote = char
+                    path_start = True
+                elif char == quote:
+                    quote = ""
+                    path_start = False
+                else:
+                    path_start = (not quote and char in " \t\r\n") or char == "="
+            index += 1
+        return "".join(result)
 
     @staticmethod
     def to_env_list(value: str) -> EnvList:

--- a/tests/config/loader/test_str_convert.py
+++ b/tests/config/loader/test_str_convert.py
@@ -159,6 +159,11 @@ WINDOWS_PATH_ARGS = [
 WINDOWS_TRAILING_SEP_ARGS = [
     (r"command path\to\trailing\sep\ -b foo", ["command", "path\\to\\trailing\\sep\\", "-b", "foo"]),
 ]
+WINDOWS_UNC_PATH_ARGS = [
+    (r"xcopy \\server\share\file.txt .", ["xcopy", r"\\server\share\file.txt", "."]),
+    (r"\\server\share", [r"\\server\share"]),
+    (r"copy a \\srv\share\a b", ["copy", "a", r"\\srv\share\a", "b"]),
+]
 WACKY_SLASH_ARGS = [
     ("\\\\\\", ["\\\\\\"]),
     (" \\'\\'\\ '", [" \\'\\'\\ '"]),
@@ -224,6 +229,15 @@ def test_shlex_platform_specific(sys_platform: str, value: str, expected: list[s
 def test_shlex_win32_trailing_sep(sys_platform: str, value: str, expected: list[str]) -> None:
     if sys_platform != "win32":
         pytest.skip("trailing path separator only relevant on Windows")
+    result = StrConvert().to_command(value)
+    assert result is not None
+    assert result.args == expected
+
+
+@pytest.mark.parametrize(("value", "expected"), WINDOWS_UNC_PATH_ARGS)
+def test_shlex_win32_unc_path(sys_platform: str, value: str, expected: list[str]) -> None:
+    if sys_platform != "win32":
+        pytest.skip("UNC path prefix only relevant on Windows")
     result = StrConvert().to_command(value)
     assert result is not None
     assert result.args == expected

--- a/tests/config/loader/test_str_convert.py
+++ b/tests/config/loader/test_str_convert.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import importlib
 import sys
 from pathlib import Path
 from textwrap import dedent
-from types import ModuleType
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 
 import pytest
@@ -13,6 +11,10 @@ from tox.config.loader.str_convert import StrConvert
 from tox.config.types import Command, EnvList
 
 if TYPE_CHECKING:
+    from typing import Final
+
+    from pytest_mock import MockerFixture
+
     from tox.pytest import MonkeyPatch, SubRequest, ToxProjectCreator
 
 from typing import Literal
@@ -143,14 +145,16 @@ WINDOWS_PATH_ARGS = [
     ('cc --arg "C:\\\\Users\\\\"', ["cc", "--arg", "C:\\Users\\"]),
     ('cc --arg "C:\\\\Users\\\\ "', ["cc", "--arg", "C:\\Users\\ "]),
     (
-        r'cc --arg C:\\Users\\ --arg2 "SPECIAL:\Temp\f o o" --arg3="\\FOO\share\Path name" --arg4 SPECIAL:\Temp\ '[:-1],
+        r'cc --arg C:\\Users\\ --arg2 "SPECIAL:\Temp\f o o" --arg3="\\\\FOO\share\Path name" --arg4 SPECIAL:\Temp\ '[
+            :-1
+        ],
         [
             "cc",
             "--arg",
             "C:\\Users\\",
             "--arg2",
             "SPECIAL:\\Temp\\f o o",
-            "--arg3=\\FOO\\share\\Path name",
+            r"--arg3=\\FOO\share\Path name",
             "--arg4",
             "SPECIAL:\\Temp\\",
         ],
@@ -158,11 +162,6 @@ WINDOWS_PATH_ARGS = [
 ]
 WINDOWS_TRAILING_SEP_ARGS = [
     (r"command path\to\trailing\sep\ -b foo", ["command", "path\\to\\trailing\\sep\\", "-b", "foo"]),
-]
-WINDOWS_UNC_PATH_ARGS = [
-    (r"xcopy \\server\share\file.txt .", ["xcopy", r"\\server\share\file.txt", "."]),
-    (r"\\server\share", [r"\\server\share"]),
-    (r"copy a \\srv\share\a b", ["copy", "a", r"\\srv\share\a", "b"]),
 ]
 WACKY_SLASH_ARGS = [
     ("\\\\\\", ["\\\\\\"]),
@@ -183,25 +182,8 @@ WACKY_SLASH_ARGS_WIN32 = {
 
 
 @pytest.fixture(params=["win32", "linux2"])
-def sys_platform(request: SubRequest, monkeypatch: MonkeyPatch) -> str:
-    class _SelectiveSys(ModuleType):
-        """A sys-like proxy that only overrides `platform`."""
-
-        def __init__(self, patched_platform: str) -> None:
-            super().__init__("sys")
-            self.__dict__["_real"] = sys
-            self.__dict__["_patched_platform"] = patched_platform
-
-        def __getattr__(self, name: str) -> Any:
-            if name == "platform":
-                return self.__dict__["_patched_platform"]
-            return getattr(self.__dict__["_real"], name)
-
-    # Patches sys.platform only for the tox.config.loader.str_convert module.
-    # Everywhere else, sys.platform remains the real value.
-    mod = importlib.import_module("tox.config.loader.str_convert")
-    proxy = _SelectiveSys(str(request.param))
-    monkeypatch.setattr(mod, "sys", proxy, raising=True)
+def sys_platform(request: SubRequest, mocker: MockerFixture) -> str:
+    mocker.patch("tox.config.loader.str_convert.sys", mocker.create_autospec(sys, platform=request.param))
     return str(request.param)
 
 
@@ -234,13 +216,41 @@ def test_shlex_win32_trailing_sep(sys_platform: str, value: str, expected: list[
     assert result.args == expected
 
 
-@pytest.mark.parametrize(("value", "expected"), WINDOWS_UNC_PATH_ARGS)
-def test_shlex_win32_unc_path(sys_platform: str, value: str, expected: list[str]) -> None:
-    if sys_platform != "win32":
-        pytest.skip("UNC path prefix only relevant on Windows")
-    result = StrConvert().to_command(value)
-    assert result is not None
-    assert result.args == expected
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(r"xcopy \\server\share\file.txt .", ["xcopy", r"\\server\share\file.txt", "."], id="unc-argument"),
+        pytest.param(r"\\server\share", [r"\\server\share"], id="unc-command"),
+        pytest.param(
+            r'copy "\\server\share\file name" .', ["copy", r"\\server\share\file name", "."], id="double-quoted"
+        ),
+        pytest.param(
+            r"copy '\\server\share\file name' .", ["copy", r"\\server\share\file name", "."], id="single-quoted"
+        ),
+        pytest.param(r'copy --source="\\server\share"', ["copy", r"--source=\\server\share"], id="quoted-option"),
+        pytest.param(r"copy --source=\\server\share", ["copy", r"--source=\\server\share"], id="unquoted-option"),
+        pytest.param(r"copy \\?\C:\file .", ["copy", r"\\?\C:\file", "."], id="extended-drive"),
+        pytest.param(r"copy \\?\UNC\server\share .", ["copy", r"\\?\UNC\server\share", "."], id="extended-unc"),
+        pytest.param(r"copy \\.\pipe\name .", ["copy", r"\\.\pipe\name", "."], id="device"),
+        pytest.param(r"copy \\\\server\share .", ["copy", r"\\server\share", "."], id="escaped-prefix"),
+        pytest.param("copy\t\\\\server\\share", ["copy", r"\\server\share"], id="tab-separator"),
+        pytest.param(r'copy "\\" \\', ["copy", "\\", "\\"], id="bare-pairs"),
+        pytest.param(r'copy "text \\server"', ["copy", r"text \server"], id="quoted-interior"),
+        pytest.param(r"copy path\\part", ["copy", r"path\part"], id="interior-pair"),
+    ],
+)
+@pytest.mark.parametrize("sys_platform", ["win32"], indirect=True)
+@pytest.mark.usefixtures("sys_platform")
+@pytest.mark.parametrize("via_config", [False, True], ids=["direct", "ini"])
+def test_shlex_win32_unc_path(
+    tox_project: ToxProjectCreator, value: str, expected: list[str], via_config: bool
+) -> None:
+    if via_config:
+        outcome: Final = tox_project({"tox.ini": f"[testenv]\ncommands = {value}"}).run("c", "-k", "commands")
+        outcome.assert_success()
+        assert outcome.env_conf("py")["commands"] == [Command(args=expected)]
+    else:
+        assert StrConvert().to_command(value).args == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Windows commands now preserve the leading backslashes in UNC and extended-length paths, including quoted paths and `--source=\\server\share` option values.

Track quotes while preparing arguments for shlex. Preserve single-quoted text and keep existing escapes for interior or bare backslash pairs. The reference docs include a quoted UNC path example and explain the escaping rules.
