### PR TITLE
fix(config): register bare env_list factor labels

### DIFF
--- a/docs/changelog/4062.bugfix.rst
+++ b/docs/changelog/4062.bugfix.rst
@@ -1,0 +1,2 @@
+Register the ``{factor:label}`` name for a bare labeled dict in ``env_list``, as the configuration reference documents;
+previously only a labeled group nested inside a ``product`` dict registered one - by :user:`dylanpulver`.

--- a/docs/changelog/4062.bugfix.rst
+++ b/docs/changelog/4062.bugfix.rst
@@ -1,2 +1,1 @@
-Register the ``{factor:label}`` name for a bare labeled dict in ``env_list``, as the configuration reference documents;
-previously only a labeled group nested inside a ``product`` dict registered one - by :user:`dylanpulver`.
+Register factor labels and defaults for bare labeled dicts in ``env_list`` - by :user:`dylanpulver`.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -3099,8 +3099,18 @@ there is only one axis:
 .. code-block:: toml
 
     env_list = [
-        { ecosystem = ["oci", "python"] },
+        { ecosystem = { values = ["oci", "python"], default = "python" } },
     ]
+
+    [env_run_base]
+    description = "Sync {factor:ecosystem} artifacts"
+
+    [env.lint]
+
+The description is ``Sync oci artifacts`` in ``oci`` and ``Sync python artifacts`` in ``python``. The ``default`` also
+supplies ``python`` in environments outside the list, such as ``lint``. Omit ``default`` to use an empty string when no
+factor matches. Bare labeled dicts register their name; numeric labels such as ``{factor:0}`` refer to positions in a
+``product`` or ``env_base`` factor list.
 
 **Product dict** -- a Cartesian product of multiple factor groups, joined with ``-``. Each factor group inside
 ``product`` is itself an array of strings, a range dict, or a labeled dict:

--- a/src/tox/config/source/toml_pyproject.py
+++ b/src/tox/config/source/toml_pyproject.py
@@ -219,7 +219,9 @@ def _extract_env_list_labels(env_list_raw: TomlTypes) -> dict[str, FactorGroup]:
         return {}
     labels: dict[str, FactorGroup] = {}
     for item in env_list_raw:
-        if isinstance(item, dict) and "product" in item:
+        if not isinstance(item, dict):
+            continue
+        if "product" in item:
             raw_groups = item["product"]
             if not isinstance(raw_groups, list):
                 continue
@@ -229,6 +231,9 @@ def _extract_env_list_labels(env_list_raw: TomlTypes) -> dict[str, FactorGroup]:
                 labels[str(idx)] = group
                 if (label := extract_label(g)) is not None:
                     labels[label] = group
+        elif (label := extract_label(item)) is not None:  # a bare labeled dict is its own single factor group
+            values = expand_factor_group(item)
+            labels[label] = FactorGroup(values=values, default=extract_default(item, values))
     return labels
 
 

--- a/src/tox/config/source/toml_pyproject.py
+++ b/src/tox/config/source/toml_pyproject.py
@@ -231,7 +231,7 @@ def _extract_env_list_labels(env_list_raw: TomlTypes) -> dict[str, FactorGroup]:
                 labels[str(idx)] = group
                 if (label := extract_label(g)) is not None:
                     labels[label] = group
-        elif (label := extract_label(item)) is not None:  # a bare labeled dict is its own single factor group
+        elif (label := extract_label(item)) is not None:
             values = expand_factor_group(item)
             labels[label] = FactorGroup(values=values, default=extract_default(item, values))
     return labels

--- a/tests/config/source/test_toml_tox.py
+++ b/tests/config/source/test_toml_tox.py
@@ -116,6 +116,46 @@ def test_config_in_toml_replace_from_section_absolute(tox_project: ToxProjectCre
     outcome.assert_out_err("[testenv:B]\ndescription = o\n", "")
 
 
+def test_config_in_toml_env_list_bare_labeled_factor_description(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                { ecosystem = ["oci", "python"] },
+            ]
+
+            [env_run_base]
+            package = "skip"
+            description = "Sync {factor:ecosystem} artifacts"
+            commands = [["python", "-c", "print('ok')"]]
+        """),
+    })
+    outcome = project.run("c", "-e", "oci", "-k", "description")
+    outcome.assert_success()
+    outcome.assert_out_err("[testenv:oci]\ndescription = Sync oci artifacts\n", "")
+    outcome = project.run("c", "-e", "python", "-k", "description")
+    outcome.assert_success()
+    outcome.assert_out_err("[testenv:python]\ndescription = Sync python artifacts\n", "")
+
+
+def test_config_in_toml_env_list_bare_labeled_factor_default(tox_project: ToxProjectCreator) -> None:
+    project = tox_project({
+        "tox.toml": textwrap.dedent("""\
+            env_list = [
+                { ecosystem = { values = ["oci", "python"], default = "oci" } },
+            ]
+
+            [env_run_base]
+            package = "skip"
+
+            [env.lint]
+            description = "Lint {factor:ecosystem} artifacts"
+        """),
+    })
+    outcome = project.run("c", "-e", "lint", "-k", "description")
+    outcome.assert_success()
+    outcome.assert_out_err("[testenv:lint]\ndescription = Lint oci artifacts\n", "")
+
+
 def test_config_in_toml_env_list_keyed_factor_description(tox_project: ToxProjectCreator) -> None:
     project = tox_project({
         "tox.toml": textwrap.dedent("""\

--- a/tests/config/source/test_toml_tox.py
+++ b/tests/config/source/test_toml_tox.py
@@ -4,8 +4,10 @@ import sys
 import textwrap
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
-    import pytest
+    from typing import Final
 
     from tox.pytest import ToxProjectCreator
 
@@ -116,44 +118,48 @@ def test_config_in_toml_replace_from_section_absolute(tox_project: ToxProjectCre
     outcome.assert_out_err("[testenv:B]\ndescription = o\n", "")
 
 
-def test_config_in_toml_env_list_bare_labeled_factor_description(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({
-        "tox.toml": textwrap.dedent("""\
-            env_list = [
-                { ecosystem = ["oci", "python"] },
-            ]
-
-            [env_run_base]
-            package = "skip"
-            description = "Sync {factor:ecosystem} artifacts"
-            commands = [["python", "-c", "print('ok')"]]
-        """),
+@pytest.mark.parametrize("filename", ["tox.toml", "pyproject.toml"])
+@pytest.mark.parametrize(
+    ("factor", "env_name", "expected"),
+    [
+        pytest.param('{ ecosystem = ["oci", "python"] }', "oci", "oci", id="first-value"),
+        pytest.param('{ ecosystem = ["oci", "python"] }', "python", "python", id="second-value"),
+        pytest.param('{ ecosystem = ["oci", "python"] }', "lint", "", id="no-match"),
+        pytest.param('{ ecosystem = { values = ["oci", "python"], default = "oci" } }', "lint", "oci", id="default"),
+        pytest.param(
+            '{ ecosystem = { values = ["oci", "python"], default = "oci" } }',
+            "python",
+            "python",
+            id="match-over-default",
+        ),
+        pytest.param(
+            '{ ecosystem = { prefix = "py", start = 312, stop = 313 } }', "py313", "py313", id="labeled-range"
+        ),
+        pytest.param(
+            '{ ecosystem = { prefix = "py", start = 312, stop = 313, default = "py312" } }',
+            "lint",
+            "py312",
+            id="range-default",
+        ),
+        pytest.param('{ prefix = "py", start = 312, stop = 313 }', "py313", "", id="unlabeled-range"),
+    ],
+)
+def test_config_in_toml_env_list_bare_factor(
+    tox_project: ToxProjectCreator, filename: str, factor: str, env_name: str, expected: str
+) -> None:
+    prefix: Final = "tool.tox." if filename == "pyproject.toml" else ""
+    project: Final = tox_project({
+        filename: f"""
+            {"[tool.tox]" if prefix else ""}
+            env_list = [{factor}]
+            [{prefix}env_run_base]
+            description = "{{factor:ecosystem}}"
+            [{prefix}env.lint]
+        """,
     })
-    outcome = project.run("c", "-e", "oci", "-k", "description")
+    outcome: Final = project.run("c", "-e", env_name, "-k", "description")
     outcome.assert_success()
-    outcome.assert_out_err("[testenv:oci]\ndescription = Sync oci artifacts\n", "")
-    outcome = project.run("c", "-e", "python", "-k", "description")
-    outcome.assert_success()
-    outcome.assert_out_err("[testenv:python]\ndescription = Sync python artifacts\n", "")
-
-
-def test_config_in_toml_env_list_bare_labeled_factor_default(tox_project: ToxProjectCreator) -> None:
-    project = tox_project({
-        "tox.toml": textwrap.dedent("""\
-            env_list = [
-                { ecosystem = { values = ["oci", "python"], default = "oci" } },
-            ]
-
-            [env_run_base]
-            package = "skip"
-
-            [env.lint]
-            description = "Lint {factor:ecosystem} artifacts"
-        """),
-    })
-    outcome = project.run("c", "-e", "lint", "-k", "description")
-    outcome.assert_success()
-    outcome.assert_out_err("[testenv:lint]\ndescription = Lint oci artifacts\n", "")
+    outcome.assert_out_err(f"[testenv:{env_name}]\ndescription = {expected}\n", "")
 
 
 def test_config_in_toml_env_list_keyed_factor_description(tox_project: ToxProjectCreator) -> None:


### PR DESCRIPTION
Bare labeled dicts in `env_list` now register their factor names, so `{ ecosystem = ["oci", "python"] }` makes `{factor:ecosystem}` resolve to the current environment's factor.

Use the existing factor expansion and default validation for bare labels, including labeled ranges. A declared default applies outside the group; a matching factor takes precedence. The reference docs include a runnable example.
